### PR TITLE
chore: update node versioning requirements

### DIFF
--- a/frontend/src/mobile/package.json
+++ b/frontend/src/mobile/package.json
@@ -23,9 +23,9 @@
         "@capacitor/core": "^2.2.1",
         "@capacitor/ios": "2.2.1",
         "shared-modules": "link:../shared"
-    },
-    "engineStrict": true,
-    "engines": {
-        "node": "12.x"
+    },	
+    "engineStrict": true,	
+    "engines": {	
+        "node": ">=11.15.0"	
     }
 }


### PR DESCRIPTION
# Description of change

Update node versioning. Many developers will have different node versions and enforcing a rigid versioning will mean a need to use a node version manager. It's better to allow developers to pick a version above the allowed minimum.

svelte-i18n@3.0.4 requires >= node v11.15.0

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Yarn runs, app builds.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
