### PR TITLE
chore: Fix PR template formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,9 +25,9 @@ Make sure to provide instructions for the maintainer as well as any relevant con
 
 Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.
 
-- [] I have followed the contribution guidelines for this project
-- [] I have performed a self-review of my own code
-- [] I have commented my code, particularly in hard-to-understand areas
-- [] I have made corresponding changes to the documentation
-- [] I have added tests that prove my fix is effective or that my feature works
-- [] New and existing unit tests pass locally with my changes
+- [ ] I have followed the contribution guidelines for this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
# Description of change

Fixes PR template formatting so that `[ ]` appears as a checkbox


## Type of change

- Documentation Fix

## How the change has been tested

N/A

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
