### PR TITLE
fix(frontend/desktop): Fix Rollup config

### DIFF
--- a/frontend/src/desktop/rollup.config.js
+++ b/frontend/src/desktop/rollup.config.js
@@ -86,7 +86,7 @@ if (isDev) {
         livereload({ watch: './public' })
     )
 } else {
-    plugins.push(terser({ sourcemap: isDev }))
+    plugins.push(terser())
 }
 
 module.exports = {


### PR DESCRIPTION
# Description of change

Fixes this error when running `yarn build`:

```
Error: sourcemap option is removed. Now it is inferred from rollup options.
    at Object.terser (/home/runner/work/firefly/firefly/frontend/src/desktop/node_modules/rollup-plugin-terser/rollup-plugin-terser.js:12:11)
```

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code