### PR TITLE
fix(backend/binding/node): Avoid using electron-build-env for pretest

### DIFF
--- a/packages/backend/bindings/node/package.json
+++ b/packages/backend/bindings/node/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "postinstall": "yarn build",
-    "pretest": "yarn build",
+    "pretest": "yarn build:api && yarn neon build --release",
     "build": "npm-run-all -p build:api build:binding",
     "build:binding": "electron-build-env -- yarn neon build --release",
     "build:api": "rimraf ./index.js && rollup -c --silent && yarn generate-declaration",


### PR DESCRIPTION
# Description of change

Using `electron-build-env` could result in building the bindings for a different Node version (the one used by Electron) than the one that will be used to run the unit tests

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
