### PR TITLE
Fix shared package build

### DIFF
--- a/packages/shared/lib/typings/wallet.ts
+++ b/packages/shared/lib/typings/wallet.ts
@@ -5,6 +5,7 @@ import type { Transfer } from './message'
 export interface LoggerOutput {
   name?: string
   level_filter: 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
+  target_filters?: string[]
 }
 
 export interface LoggerConfig {


### PR DESCRIPTION
# Description of change

The `shared` package build fails with `An interface property cannot have an initializer.`. This PR fixes the issue.

## Links to any relevant issues

N/A

## Type of change


- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
