### PR TITLE
fix(shared): Use ICU message syntax for plural interpolation

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -222,8 +222,8 @@
             }
         },
         "login": {
-            "please_wait": "Please wait {time} seconds",
-            "incorrect_attempts": "{attempts} incorrect attempts"
+            "please_wait": "Please wait {time, plural, one {1 second} other {# seconds}}",
+            "incorrect_attempts": "{attempts, plural, one {1 incorrect attempt} other {# incorrect attempts}}"
         }
     },
     "actions": {


### PR DESCRIPTION
# Description of change

To ensure plurals can be localized properly, this PR changes `views.login.incorrect_attempts` and `views.login.please_wait` so that they use [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format). This allows translators to add the appropriate plural categories for their language. For example, English uses two plural categories (`one` and `other`, singular vs. plural), while Polish uses four (`one`, `few`, `many`, and `other`).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested manually

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code