### PR TITLE
refactor(desktop): Disable and remove usage of remote module

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -94,7 +94,7 @@ ipcMain.handle('get-path', (_e, path) => {
         'userData',
     ]
     if (allowedPaths.indexOf(path) === -1) {
-        return null
+        throw Error(`Path ${path} is not allowed`)
     }
     return app.getPath(path)
 })

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -39,9 +39,9 @@ window.Electron = {
      *
      * @method getUserDataPath
      *
-     * @returns {string}
+     * @returns {Promise}
      */
-    getUserDataPath: () => ipcRenderer.invoke('get-path', 'userData').then((path) => (path)),
+    getUserDataPath: () => ipcRenderer.invoke('get-path', 'userData'),
     /**
      * Add native window wallet event listener
      * @param {string} event - Target event name

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -64,7 +64,7 @@
             PincodeManager.verify(profile.id, pinCode.toString())
                 .then((verified) => {
                     if (verified === true) {
-                        window['Electron'].getUserDataPath().then((path) => {
+                        return window['Electron'].getUserDataPath().then((path) => {
                             initialise(profile.id, getStoragePath(path, profile.name))
                             api.setStoragePassword(pinCode.toString(), {
                                 onSuccess() {

--- a/packages/shared/routes/setup/Setup.svelte
+++ b/packages/shared/routes/setup/Setup.svelte
@@ -29,7 +29,7 @@
                 profile = createProfile(profileName)
                 setActiveProfile(profile.id)
 
-                window['Electron'].getUserDataPath().then((path) => {
+                return window['Electron'].getUserDataPath().then((path) => {
                     initialise(profile.id, getStoragePath(path, profile.name))
 
                     network.set(mainnet ? Network.Mainnet : Network.Devnet)


### PR DESCRIPTION
# Description of change

This PR disables and removes usage of the `remote` module, which is deprecated and [not recommended](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31) for security reasons. Instead, any main process APIs that need to be called from the renderer process should be routed through IPC ([`ipcMain`](https://www.electronjs.org/docs/api/ipc-main) and [`ipcRenderer`](https://www.electronjs.org/docs/api/ipc-renderer)) as shown in this PR.

## Links to any relevant issues

N/A

## Type of change

- Refactor

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas