### PR TITLE
fix: Network indicator relocated resource strings

### DIFF
--- a/packages/shared/components/NetworkIndicator.svelte
+++ b/packages/shared/components/NetworkIndicator.svelte
@@ -63,15 +63,15 @@
 {#if isActive}
     <network-indicator-shield on:click={() => (isActive = false)} />
     <network-indicator-content class="flex flex-col bg-white dark:bg-gray-900" transition:fade={{}}>
-        <Text type="h3" classes="px-7 pt-5">{locale('views.network.status')}</Text>
-        <div class={`px-7 pb-5 text-13 health-status health-${healthStatus}`}>{locale(`views.network.${healthStatusText}`)}</div>
+        <Text type="h3" classes="px-7 pt-5">{locale('views.dashboard.network.status')}</Text>
+        <div class={`px-7 pb-5 text-13 health-status health-${healthStatus}`}>{locale(`views.dashboard.network.${healthStatusText}`)}</div>
         <hr />
         <div class="flex flex-row justify-between px-7 pt-5 pb-2">
-            <span class="text-12 text-gray-800 dark:text-white">{locale('views.network.messages_per_second')}</span>
+            <span class="text-12 text-gray-800 dark:text-white mr-2">{locale('views.dashboard.network.messages_per_second')}</span>
             <span class="text-12 text-gray-500">{`${Math.round(messagesPerSecond)}`}</span>
         </div>
         <div class="flex flex-row justify-between px-7 pb-5">
-            <span class="text-12 text-gray-800 dark:text-white">{locale('views.network.confirmation_rate')}</span>
+            <span class="text-12 text-gray-800 dark:text-white mr-2">{locale('views.dashboard.network.confirmation_rate')}</span>
             <span class="text-12 text-gray-500">{`${Math.round(confirmationRate)}%`}</span>
         </div>
     </network-indicator-content>


### PR DESCRIPTION
# Description of change

The resources string for the network indicator had been relocated, this adjust the UI to use the new resource location.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
