### PR TITLE
fix(shared): event message validation shouldn't include `action` check

### DIFF
--- a/packages/shared/lib/validator.ts
+++ b/packages/shared/lib/validator.ts
@@ -364,7 +364,6 @@ export default class ValidatorService {
             [ResponseTypes.Balance]: this.createBaseValidator().getFirst(),
             [ResponseTypes.BackupRestored]: this.createBaseValidator().getFirst(),
             [ResponseTypes.BackupSuccessful]: this.createBaseValidator().getFirst(),
-            [ResponseTypes.BackupSuccessful]: this.createBaseValidator().getFirst(),
             [ResponseTypes.GeneratedMnemonic]: this.createBaseValidator().getFirst(),
             [ResponseTypes.StoredMnemonic]: this.createBaseValidator().getFirst(),
             [ResponseTypes.VerifiedMnemonic]: this.createBaseValidator().getFirst(),
@@ -373,7 +372,7 @@ export default class ValidatorService {
             [ResponseTypes.StoragePasswordSet]: this.createBaseValidator().getFirst(),
             [ResponseTypes.StrongholdStatus]: this.createBaseValidator().getFirst(),
             [ResponseTypes.GeneratedAddress]: this.createBaseValidator().add(new PayloadTypeValidator('object')).getFirst(),
-            [ResponseTypes.StrongholdStatusChange]: this.createBaseValidator().getFirst(),
+            [ResponseTypes.StrongholdStatusChange]: this.createBaseEventValidator().getFirst(),
             [ResponseTypes.LatestAddress]: this.createBaseValidator().getFirst(),
             [ResponseTypes.SyncedAccount]: this.createBaseValidator().getFirst(),
             [ResponseTypes.UnusedAddress]: this.createBaseValidator().getFirst(),
@@ -393,6 +392,17 @@ export default class ValidatorService {
      */
     private createBaseValidator(): ValidatorChainBuilder {
         return new ValidatorChainBuilder().add(new TypeValidator()).add(new IdValidator(this.ids)).add(new ActionValidator())
+    }
+
+    /**
+     * Creates a base event validator
+     *
+     * @method createBaseEventValidator
+     *
+     * @returns {ValidatorChainBuilder}
+     */
+    private createBaseEventValidator(): ValidatorChainBuilder {
+        return new ValidatorChainBuilder().add(new TypeValidator()).add(new IdValidator(this.ids))
     }
 
     /**


### PR DESCRIPTION
# Description of change

The event message doesn't include the `action` field, so the frontend shouldn't validate it. This causes the event response to trigger the `onError` callback instead of `onSuccess`.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

By opening the Firefly app and checking if the response is actually calling `onSuccess`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
