### PR TITLE
feat: show (stronghold) password popup on send if stronghold is locked

### DIFF
--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -283,21 +283,58 @@
     }
 
     function onSend(senderAccountId, receiveAddress, amount) {
-        api.send(
-            senderAccountId,
-            {
-                amount,
-                address: receiveAddress,
-                remainder_value_strategy: {
-                    strategy: 'ChangeAddress',
+        const _send = () => {
+            api.send(
+                senderAccountId,
+                {
+                    amount,
+                    address: receiveAddress,
+                    remainder_value_strategy: {
+                        strategy: 'ChangeAddress',
+                    },
+                    indexation: { index: 'firefly', data: new Array() },
                 },
-                indexation: { index: 'firefly', data: new Array() },
+                {
+                    onSuccess(response) {
+                        accounts.update((_accounts) => {
+                            return _accounts.map((_account) => {
+                                if (_account.id === senderAccountId) {
+                                    return Object.assign({}, _account, {
+                                        messages: [response.payload, ..._account.messages],
+                                    })
+                                }
+
+                                return _account
+                            })
+                        })
+                        _next(WalletState.Init)
+                    },
+                    onError(error) {
+                        console.error(error)
+                    },
+                }
+            )
+        }
+
+        api.getStrongholdStatus({
+            onSuccess(strongholdStatusResponse) {
+                if (strongholdStatusResponse.payload.snapshot.status === 'Locked') {
+                    popupState.set({ active: true, type: 'password', props: { onSuccess: _send } })
+                }
             },
-            {
+            onError(error) {
+                console.error(error)
+            },
+        })
+    }
+
+    function onInternalTransfer(senderAccountId, receiverAccountId, amount) {
+        const _internalTransfer = () => {
+            api.internalTransfer(senderAccountId, receiverAccountId, amount, {
                 onSuccess(response) {
                     accounts.update((_accounts) => {
                         return _accounts.map((_account) => {
-                            if (_account.id === senderAccountId) {
+                            if (_account.id === senderAccountId || _account.id === receiverAccountId) {
                                 return Object.assign({}, _account, {
                                     messages: [response.payload, ..._account.messages],
                                 })
@@ -308,31 +345,20 @@
                     })
                     _next(WalletState.Init)
                 },
-                onError(error) {
-                    console.error(error)
+                onError(response) {
+                    console.error(response)
                 },
-            }
-        )
-    }
+            })
+        }
 
-    function onInternalTransfer(senderAccountId, receiverAccountId, amount) {
-        api.internalTransfer(senderAccountId, receiverAccountId, amount, {
-            onSuccess(response) {
-                accounts.update((_accounts) => {
-                    return _accounts.map((_account) => {
-                        if (_account.id === senderAccountId || _account.id === receiverAccountId) {
-                            return Object.assign({}, _account, {
-                                messages: [response.payload, ..._account.messages],
-                            })
-                        }
-
-                        return _account
-                    })
-                })
-                _next(WalletState.Init)
+        api.getStrongholdStatus({
+            onSuccess(strongholdStatusResponse) {
+                if (strongholdStatusResponse.payload.snapshot.status === 'Locked') {
+                    popupState.set({ active: true, type: 'password', props: { onSuccess: _internalTransfer } })
+                }
             },
-            onError(response) {
-                console.error(response)
+            onError(error) {
+                console.error(error)
             },
         })
     }


### PR DESCRIPTION
# Description of change

With this PR, we will display the stronghold password popup if it is locked at the time of send (or internal transfer). 

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
