### PR TITLE
chore(shared): Update market data endpoints

### DIFF
--- a/packages/shared/lib/marketData.ts
+++ b/packages/shared/lib/marketData.ts
@@ -6,8 +6,6 @@ import { currencies, Currencies, exchangeRates, ExchangeRates, CurrencyTypes } f
  */
 export const MARKETDATA_ENDPOINTS = [
     'https://nodes.iota.works/api/market',
-    'https://iota-node-api.now.sh/api/market',
-    'https://iota.dance/api/market',
 ]
 
 /**
@@ -226,4 +224,3 @@ export async function fetchMarketData(): Promise<void> {
         }
     }
 }
-


### PR DESCRIPTION
# Description of change

Updates market data endpoints to domains that we own (we no longer own `iota.dance` and nothing is deployed at `iota-node-api.now.sh`)

## Links to any relevant issues

N/A

## Type of change

- Chore

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code