### PR TITLE
fix(backend/bindings/node): Use paho fork for OpenSSL linking

### DIFF
--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
  "blake2",
  "digest 0.9.0",
  "flume",
- "futures",
+ "futures 0.3.12",
  "hex",
  "log",
  "thiserror",
@@ -335,7 +335,7 @@ dependencies = [
  "async-trait",
  "bee-runtime",
  "dashmap 4.0.2",
- "futures",
+ "futures 0.3.12",
  "lazy_static",
  "libp2p",
  "log",
@@ -375,7 +375,7 @@ dependencies = [
  "bee-tangle",
  "bee-ternary",
  "blake2",
- "futures",
+ "futures 0.3.12",
  "futures-util",
  "fxhash",
  "hex",
@@ -410,7 +410,7 @@ dependencies = [
  "bee-tangle",
  "blake2",
  "digest 0.9.0",
- "futures",
+ "futures 0.3.12",
  "hex",
  "log",
  "num_cpus",
@@ -428,7 +428,7 @@ dependencies = [
  "async-trait",
  "bee-storage",
  "dashmap 4.0.2",
- "futures",
+ "futures 0.3.12",
  "log",
 ]
 
@@ -475,7 +475,7 @@ dependencies = [
  "bee-storage",
  "chrono",
  "flume",
- "futures",
+ "futures 0.3.12",
  "log",
  "reqwest",
  "serde 1.0.123",
@@ -489,7 +489,7 @@ version = "0.2.0-alpha"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#8cdfe505e3e5a699655d2c43c4305fb109ec8c87"
 dependencies = [
  "async-trait",
- "futures",
+ "futures 0.3.12",
  "serde 1.0.123",
 ]
 
@@ -506,7 +506,7 @@ dependencies = [
  "bee-storage",
  "bitflags",
  "dashmap 4.0.2",
- "futures",
+ "futures 0.3.12",
  "log",
  "lru",
  "rand 0.8.3",
@@ -1210,6 +1210,12 @@ dependencies = [
 
 [[package]]
 name = "futures"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+
+[[package]]
+name = "futures"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
@@ -1234,10 +1240,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
+dependencies = [
+ "futures-core-preview",
+ "futures-sink-preview",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+
+[[package]]
+name = "futures-core-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 
 [[package]]
 name = "futures-executor"
@@ -1252,10 +1274,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-executor-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
+dependencies = [
+ "futures-core-preview",
+ "futures-util-preview",
+ "num_cpus",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+
+[[package]]
+name = "futures-io-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
 
 [[package]]
 name = "futures-lite"
@@ -1285,10 +1324,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
+dependencies = [
+ "futures-channel-preview",
+ "futures-core-preview",
+ "futures-executor-preview",
+ "futures-io-preview",
+ "futures-sink-preview",
+ "futures-util-preview",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+
+[[package]]
+name = "futures-sink-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 
 [[package]]
 name = "futures-task"
@@ -1297,6 +1356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "futures-timer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9eb554aa23143abc64ec4d0016f038caf53bb7cbc3d91490835c54edc96550"
+dependencies = [
+ "futures-preview",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1311,6 +1380,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
+ "futures 0.1.30",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1322,6 +1392,21 @@ dependencies = [
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
+name = "futures-util-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
+dependencies = [
+ "futures-channel-preview",
+ "futures-core-preview",
+ "futures-io-preview",
+ "futures-sink-preview",
+ "memchr",
+ "pin-utils",
  "slab",
 ]
 
@@ -1672,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b8538953a3f0d0d3868f0a706eb4273535e10d72acb5c82c1c23ae48835c85"
 dependencies = [
  "async-io",
- "futures",
+ "futures 0.3.12",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -1791,7 +1876,7 @@ dependencies = [
  "anyhow",
  "bee-signing-ext",
  "bincode",
- "futures",
+ "futures 0.3.12",
  "iota-crypto 0.1.0",
  "riker",
  "serde 1.0.123",
@@ -1812,7 +1897,7 @@ dependencies = [
  "bee-rest-api",
  "blake2",
  "chrono",
- "futures",
+ "futures 0.3.12",
  "getset",
  "hex",
  "iota-core",
@@ -1921,7 +2006,7 @@ checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
  "bytes",
- "futures",
+ "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
@@ -1949,8 +2034,8 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures",
- "futures-timer",
+ "futures 0.3.12",
+ "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -1988,7 +2073,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
- "futures",
+ "futures 0.3.12",
  "libp2p-core",
  "log",
 ]
@@ -2001,7 +2086,7 @@ checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures",
+ "futures 0.3.12",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -2019,7 +2104,7 @@ checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
  "bytes",
  "curve25519-dalek",
- "futures",
+ "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -2040,7 +2125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4f89ebb4d8953bda12623e9871959fe728dea3bf6eae0421dc9c42dc821e488"
 dependencies = [
  "either",
- "futures",
+ "futures 0.3.12",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -2056,8 +2141,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
  "async-io",
- "futures",
- "futures-timer",
+ "futures 0.3.12",
+ "futures-timer 3.0.2",
  "if-addrs",
  "if-watch",
  "ipnet",
@@ -2074,7 +2159,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
- "futures",
+ "futures 0.3.12",
  "libp2p-core",
  "parking_lot",
  "thiserror",
@@ -2280,7 +2365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
  "bytes",
- "futures",
+ "futures 0.3.12",
  "log",
  "pin-project 1.0.4",
  "smallvec",
@@ -2374,7 +2459,7 @@ dependencies = [
 name = "node-neon"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.3.12",
  "neon",
  "neon-build",
  "once_cell",
@@ -2551,11 +2636,10 @@ dependencies = [
 [[package]]
 name = "paho-mqtt"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82fea0990fe54e75d575bbd9bc2ee5919fd10cc0b4a95f1967528083129fc4b"
+source = "git+https://github.com/rajivshah3/paho.mqtt.rust?branch=feature/openssl-static-link-master-0.9#66b58ff517404546875f45fe1a69c9375d5d1b2a"
 dependencies = [
- "futures",
- "futures-timer",
+ "futures 0.3.12",
+ "futures-timer 0.3.0",
  "libc",
  "log",
  "paho-mqtt-sys",
@@ -2565,11 +2649,9 @@ dependencies = [
 [[package]]
 name = "paho-mqtt-sys"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9ac6a77a7e7c70cd51262b94ab666c9e4c38fb0f4201dba8d7f8589aa8ce4"
+source = "git+https://github.com/rajivshah3/paho.mqtt.rust?branch=feature/openssl-static-link-master-0.9#66b58ff517404546875f45fe1a69c9375d5d1b2a"
 dependencies = [
  "cmake",
- "openssl-sys",
 ]
 
 [[package]]
@@ -3098,7 +3180,7 @@ dependencies = [
  "chrono",
  "config",
  "dashmap 3.11.10",
- "futures",
+ "futures 0.3.12",
  "num_cpus",
  "pin-utils",
  "rand 0.7.3",
@@ -3197,7 +3279,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures",
+ "futures 0.3.12",
  "pin-project 0.4.27",
  "static_assertions",
 ]
@@ -4159,7 +4241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
 dependencies = [
  "bytes",
- "futures",
+ "futures 0.3.12",
  "headers",
  "http",
  "hyper",
@@ -4268,7 +4350,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures",
+ "futures 0.3.12",
  "js-sys",
  "parking_lot",
  "pin-utils",
@@ -4400,7 +4482,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
- "futures",
+ "futures 0.3.12",
  "log",
  "nohash-hasher",
  "parking_lot",

--- a/packages/backend/bindings/node/native/Cargo.toml
+++ b/packages/backend/bindings/node/native/Cargo.toml
@@ -21,3 +21,6 @@ tokio = "1.1"
 once_cell = "1.5"
 futures = "0.3"
 serde_json = "1.0"
+
+[patch.crates-io]
+paho-mqtt = { git = "https://github.com/rajivshah3/paho.mqtt.rust", branch = "feature/openssl-static-link-master-0.9"}


### PR DESCRIPTION
# Description of change

Paho still doesn't let us statically link OpenSSL 😑 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code