### PR TITLE
hotfix: assign depositAddress to each account object

### DIFF
--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -64,6 +64,7 @@
         return Object.assign({}, account, {
             id,
             index,
+            depositAddress,
             name: alias,
             rawIotaBalance: balance,
             balance: formatUnit(balance, 0),


### PR DESCRIPTION
# Description of change

This PR ensures `depositAddress` is assigned to each account object. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
