### PR TITLE
feat: keep track of profile setup completion

### DIFF
--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -1,4 +1,4 @@
-import { get, derived } from 'svelte/store'
+import { get, derived, writable } from 'svelte/store'
 import { persistent } from 'shared/lib/helpers'
 import { generateRandomId } from 'shared/lib/utils'
 import { AvailableExchangeRates } from 'shared/lib/currency'
@@ -49,6 +49,8 @@ interface Profile extends BaseProfile, ExtendedProfile { }
 
 export const profiles = persistent<Profile[]>('profiles', []);
 
+export const newProfile = writable<Profile | null>(null);
+
 /**
  * Profile interface
  */
@@ -57,9 +59,8 @@ interface Profile extends BaseProfile, ExtendedProfile { }
 /**
  * Currently active profile
  */
-export const activeProfile = derived(
-    profiles,
-	$profiles => $profiles.find((_profile) => {
+export const activeProfile = derived([profiles, newProfile], ([$profiles, $newProfile]) =>
+    $newProfile || $profiles.find((_profile) => {
         return _profile.active === true
     })
 )
@@ -93,6 +94,21 @@ export const createProfile = (profileName): Profile => {
         }
     };
 
+    newProfile.set(profile)
+
+    return profile;
+};
+
+/**
+ * Saves profile in persistent storage
+ * 
+ * @method saveProfile
+ * 
+ * @param {Profile} profile 
+ * 
+ * @returns {Profile}
+ */
+export const saveProfile = (profile: Profile): Profile => {
     profiles.update((_profiles) => {
         return [
             ..._profiles,
@@ -101,7 +117,7 @@ export const createProfile = (profileName): Profile => {
     })
 
     return profile;
-};
+}
 
 /**
  * Sets profile with provided id as active
@@ -140,20 +156,32 @@ export const removeProfile = (id: string): void => {
  * 
  * @returns {void} 
  */
-export const updateProfile = (path: string, value: string | boolean | Date | AvailableExchangeRates) => { 
-    profiles.update((_profiles) => {
-        return _profiles.map((_profile) => {
-            if (_profile.id === get(activeProfile).id) {
-                const pathList = path.split('.')
-                pathList.reduce((a, b: keyof ExtendedProfile | keyof UserSettings, level: number) => {
-                    if (level === pathList.length - 1){
-                        a[b] = value;
-                        return value;
-                    } 
-                    return a[b];
-                }, _profile)
+export const updateProfile = (path: string, value: string | boolean | Date | AvailableExchangeRates) => {
+    const _update = (_profile) => {
+        const pathList = path.split('.')
+
+        pathList.reduce((a, b: keyof ExtendedProfile | keyof UserSettings, level: number) => {
+            if (level === pathList.length - 1) {
+                a[b] = value;
+                return value;
             }
-            return _profile
+            return a[b];
+        }, _profile)
+
+        return _profile
+    };
+
+    if (get(newProfile)) {
+        newProfile.update((_profile) => _update(_profile))
+    } else {
+        profiles.update((_profiles) => {
+            return _profiles.map((_profile) => {
+                if (_profile.id === get(activeProfile).id) {
+                    return _update(_profile);
+                }
+
+                return _profile
+            })
         })
-    })
+    }
 }

--- a/packages/shared/routes/setup/backup/Backup.svelte
+++ b/packages/shared/routes/setup/backup/Backup.svelte
@@ -4,7 +4,7 @@
     import { Backup, RecoveryPhrase, VerifyRecoveryPhrase, BackupToFile, Success } from './views/'
     import { Transition } from 'shared/components'
     import { mnemonic } from 'shared/lib/app'
-    import { updateProfile } from 'shared/lib/profile'
+    import { newProfile, saveProfile, updateProfile } from 'shared/lib/profile'
     import { strongholdPassword } from 'shared/lib/app'
     import { api } from 'shared/lib/wallet'
     import { DEFAULT_NODES as nodes, network } from 'shared/lib/network'
@@ -92,11 +92,15 @@
                                     },
                                     {
                                         onSuccess() {
+                                            saveProfile($newProfile)
+
+                                            newProfile.set(null)
+                                            
                                             dispatch('next')
                                         },
                                         onError() {
                                             // TODO: handle error
-                                            alert('create account error')
+                                            console.error('create account error')
                                         }
                                     }
                                 )


### PR DESCRIPTION
# Description of change

This PR ensures that profile is not persisted in the local storage if a user does not complete the profile setup. It was also done in https://github.com/iotaledger/firefly/pull/126 in a different way. 

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
