### PR TITLE
feature(desktop): Use DefinePlugin to set devMode at compile time

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -42,7 +42,11 @@
 
         await fetchMarketData()
         await pollNetworkStatus()
-        await refreshVersionDetails();
+        
+        // @ts-ignore: This value is replaced by Webpack DefinePlugin
+        if (!devMode) {
+            await refreshVersionDetails()
+        }
     })
 </script>
 

--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -40,8 +40,6 @@ const windows = {
 const devMode = process.env.NODE_ENV === 'development'
 
 
-// TODO(rajivshah3): Use @rollup/plugin-replace here
-
 let paths = {
     preload: "",
     html: "",

--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -1,5 +1,6 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const { DefinePlugin } = require('webpack')
 const path = require('path');
 const sveltePreprocess = require('svelte-preprocess');
 
@@ -98,7 +99,11 @@ const rendererRules = [
 
 /// ------------------------ Plugins ------------------------
 
-const mainPlugins = []
+const mainPlugins = [
+  new DefinePlugin({
+    devMode: JSON.stringify(mode === 'development')
+  })
+]
 
 const rendererPlugins = [
   new CopyPlugin({
@@ -121,6 +126,9 @@ const rendererPlugins = [
   }),
   new MiniCssExtractPlugin({
     filename: '[name].css'
+  }),
+  new DefinePlugin({
+    devMode: JSON.stringify(mode === 'development')
   })
 ]
 


### PR DESCRIPTION
# Description of change

Uses Webpack's `DefinePlugin` to hardcode the value of `devMode` at compile time. This allows us to determine whether we're running in prod without using `process.env` (which might not be available in the renderer process)

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested in dev and prod

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas