### PR TITLE
fix(desktop): Init auto updater before loading HTML

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -101,6 +101,10 @@ function createWindow() {
         },
     })
 
+    if (!devMode) {
+        initAutoUpdate(windows.main);
+    }
+
     if (devMode) {
         // Enable dev tools only in developer mode
         windows.main.webContents.openDevTools()
@@ -127,10 +131,6 @@ function createWindow() {
      */
     windows.main.webContents.on('will-navigate', _handleNavigation)
     windows.main.webContents.on('new-window', _handleNavigation)
-
-    if (!devMode) {
-        initAutoUpdate(windows.main);
-    }
 
     /**
      * Handle permissions requests


### PR DESCRIPTION
# Description of change

This avoids a potential scenario where the HTML could be loaded before the handler for `update-get-version-details` is created. Invoking `update-get-version-details` (which happens when the app loads) before the handler is created will cause an error (`No handler registered for 'update-get-version-details'`)

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code