### PR TITLE
fix(desktop): Fix issues with main process in dev mode

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -45,15 +45,10 @@ let paths = {
     html: "",
 }
 
-if (devMode) {
-    // __dirname is desktop/electron
-    paths.preload = path.join(__dirname, 'preload.js')
-    paths.html = path.join(__dirname, '../public/index.html')
-} else if (app.isPackaged) {
+if (app.isPackaged) {
     paths.preload = path.join(app.getAppPath(), '/public/build/preload.js')
     paths.html = path.join(app.getAppPath(), '/public/index.html')
 } else {
-    // Probably production mode, but not packaged (i.e. run with yarn start:electron-prod)
     // __dirname is desktop/public/build
     paths.preload =  path.join(__dirname, 'preload.js')
     paths.html =  path.join(__dirname, '../index.html')

--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -99,11 +99,7 @@ const rendererRules = [
 
 /// ------------------------ Plugins ------------------------
 
-const mainPlugins = [
-  new DefinePlugin({
-    devMode: JSON.stringify(mode === 'development')
-  })
-]
+const mainPlugins = []
 
 const rendererPlugins = [
   new CopyPlugin({
@@ -164,6 +160,9 @@ module.exports = [
     },
     mode,
     plugins: mainPlugins,
-    devtool: prod ? false : 'cheap-module-source-map'
+    devtool: prod ? false : 'cheap-module-source-map',
+    optimization: {
+      nodeEnv: false
+    }
   }
 ]


### PR DESCRIPTION
# Description of change

This PR resolves issues with running the main process (`electron/main.js`) with `NODE_ENV=development`. The issues stem from the fact that [Webpack's optimizer uses `DefinePlugin` to replace the value of `process.env.NODE_ENV`](https://webpack.js.org/configuration/optimization/#optimizationnodeenv). Because `yarn build` sets `NODE_ENV=production`, `'production'` is hardcoded in `public/build/main.js` (since `electron/main.js` is now built ahead of time). This means that when `yarn start` is run, setting `NODE_ENV=development` has no effect on the main process. Basically, `process.env.NODE_ENV` was being evaluated at compile-time instead of at runtime.

In particular, this was the cause of the errors about `dev-app-update.yml` — `NODE_ENV=development` (set by `yarn start`) had no effect, because the optimizer output the following code when `yarn build` was run:

```js
const devMode = "production" === 'development'

...

if (!devMode) {
    initAutoUpdate(windows.main);
}
```

It turns out that as a result of this feature, the usage of `DefinePlugin` for the main process (added by #157) is redundant and can also cause problems in dev mode. As a result, that is removed in this PR as well (it's still relevant for the renderer process, however).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Tested in dev and prod

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code