### PR TITLE
chore: use testnet as default network for profiles

### DIFF
--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -23,7 +23,7 @@ export const DEFAULT_NODES: Node[] = [
 /**
  * Selected network during profile creation
  */
-export const network = writable<Network>(Network.Mainnet)
+export const network = writable<Network>(Network.Testnet)
 
 /**
  * Check if new node candidate is valid


### PR DESCRIPTION
# Description of change

This PR makes `testnet` the default network for new profiles. 

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
