### PR TITLE
fix(desktop): Avoid removing app data on uninstall on Windows

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -86,7 +86,7 @@
             ]
         },
         "nsis": {
-            "deleteAppDataOnUninstall": true
+            "deleteAppDataOnUninstall": false
         },
         "win": {
             "icon": "./public/assets/icons/win/icon.ico",


### PR DESCRIPTION
# Description of change

Sets `nsis.deleteAppDataOnUninstall` to false, which causes app data to be retained after uninstalling the app

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
