### PR TITLE
fix(backend): Replace npm-run-all with Node.js script

### DIFF
--- a/packages/backend/bindings/node/package.json
+++ b/packages/backend/bindings/node/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "postinstall": "yarn build",
     "pretest": "yarn build:api && yarn neon build --release",
-    "build": "npm-run-all -p build:api build:binding",
+    "build": "node ./scripts/build.js",
     "build:binding": "electron-build-env -- yarn neon build --release && move-file native/index.node ./index.node",
     "build:api": "rimraf ./index.js && rollup -c --silent && yarn generate-declaration",
     "generate-declaration": "tsc index.ts --declaration --emitDeclarationOnly --outDir dist && move-file dist/backend/bindings/node/index.d.ts dist/index.d.ts && replace --silent '\\.\\.\\/\\.\\.' '.' dist/index.d.ts",
@@ -29,7 +29,6 @@
     "mocha": "^8.0.1",
     "move-file-cli": "^2.0.0",
     "replace": "^1.2.0",
-    "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "rollup": "2.28.1",
     "rollup-plugin-terser": "7.0.2",

--- a/packages/backend/bindings/node/scripts/build.js
+++ b/packages/backend/bindings/node/scripts/build.js
@@ -1,0 +1,5 @@
+const { resolve } = require('path')
+const { spawnSync } = require('child_process')
+
+spawnSync(process.platform === 'win32' ? 'yarn.cmd' : 'yarn', ['build:api'], { stdio: 'inherit', cwd: resolve(__dirname, '../') })
+spawnSync(process.platform === 'win32' ? 'yarn.cmd' : 'yarn', ['build:binding'], { stdio: 'inherit', cwd: resolve(__dirname, '../') })


### PR DESCRIPTION
# Description of change

`npm-run-all` is causing problems on Windows, so we're replacing it with a simple Node.js script

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Script succeeds

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code