### PR TITLE
fix(shared): `getInitials` helper function throwing errors

### DIFF
--- a/packages/shared/components/Profile.svelte
+++ b/packages/shared/components/Profile.svelte
@@ -1,5 +1,6 @@
 <script>
     import { Text } from 'shared/components'
+    import { getInitials as _getInitials } from 'shared/lib/helpers'
 
     export let classes = undefined
     export let locale
@@ -13,15 +14,13 @@
     let slots = $$props.$$slots
 
     function getInitials() {
-        const names = name.split(' ')
-
-        let initials = names[0].substring(0, 1).toUpperCase()
-
-        if (names.length > 1) {
-            initials += names[names.length - 1].substring(0, 1).toUpperCase()
+        const initials = _getInitials(name)
+        if (initials.length === 1) {
+            return initials
+        } else {
+            const letters = initials.split('')
+            return letters[0] + letters[letters.length - 1]
         }
-
-        return initials
     }
 </script>
 

--- a/packages/shared/lib/helpers.ts
+++ b/packages/shared/lib/helpers.ts
@@ -40,12 +40,11 @@ export const shuffleArray = (array) => array.slice().sort(() => Math.random() - 
  * Extract initials from string
  */
 export const getInitials = (string: string, maxChars: number) => {
-    let initialsArray: string[] = string.replace(/[^a-zA-Z- ]/g, '').match(/\b\w/g)
+    let initialsArray = string.split(' ').map(n => n[0].toUpperCase())
     if (maxChars) {
         initialsArray = initialsArray.slice(0, maxChars)
     }
-    let initials = initialsArray.join('').toUpperCase()
-    return initials
+    return initialsArray.join('')
 }
 
 /**


### PR DESCRIPTION
# Description of change

The current `getInitials` implementation throws an exception if the profile name doesn't have any letters for instance. Rajiv also raised that this approach isn't so good for people using different languages.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested a bunch of cases with Rajiv.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
