### PR TITLE
refactor(ui): use forms where appropriate for better keyboard support

### DIFF
--- a/packages/shared/components/Button.svelte
+++ b/packages/shared/components/Button.svelte
@@ -12,6 +12,8 @@
     export let xl = false
     export let small = false
     export let classes = ''
+    export let type = 'button'
+    export let form = ''
 </script>
 
 <style type="text/scss">
@@ -155,6 +157,8 @@
 
 {#if xl}
     <button
+        {type}
+        {form}
         class={`xl cursor-pointer text-center rounded-2xl pt-8 pb-4 px-4 flex flex-col items-center ${classes}`}
         use:bindEvents={events}
         on:click={onClick}
@@ -169,6 +173,8 @@
     </button>
 {:else}
     <button
+        {type}
+        {form}
         class={`cursor-pointer text-center rounded-2xl px-3 py-4 ${classes}`}
         use:bindEvents={events}
         on:click={onClick}

--- a/packages/shared/components/inputs/Password.svelte
+++ b/packages/shared/components/inputs/Password.svelte
@@ -25,7 +25,8 @@
     }
 
     function onKeyPress(event) {
-        if (numeric && (event.which < 48 || event.which > 57)) {
+        // if the input is numeric, we accept only numbers and enter press
+        if (numeric && event.keyCode !== 13 && (event.which < 48 || event.which > 57)) {
             event.preventDefault()
         }
     }
@@ -95,7 +96,7 @@
                  bg-white border border-solid border-gray-300 hover:border-gray-500 focus:border-gray-500 rounded-xl text-gray
                  " />
         {#if showRevealToggle === true}
-            <button on:click={(e) => revealToggle(e)} tabindex="-1" class="absolute">
+            <button type="button" on:click={(e) => revealToggle(e)} tabindex="-1" class="absolute">
                 <Icon icon={revealed ? 'view' : 'hide'} classes="text-blue-500" />
             </button>
         {/if}

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -1,5 +1,8 @@
 <script>
     import { onMount } from 'svelte'
+    import { createEventDispatcher } from 'svelte'
+
+    const dispatch = createEventDispatcher()
 
     export let value = undefined
     export let size = 6
@@ -10,6 +13,7 @@
 
     const KEYBOARD = {
         BACKSPACE: 8,
+        ENTER: 13,
     }
 
     onMount(async () => {
@@ -26,6 +30,8 @@
             if (prevInput) {
                 prevInput.focus()
             }
+        } else if (e.keyCode == KEYBOARD.ENTER) {
+            dispatch('submit')
         } else {
             if (!nextInput && inputs[i] && inputs[i] !== '') {
                 return

--- a/packages/shared/components/popups/Password.svelte
+++ b/packages/shared/components/popups/Password.svelte
@@ -37,10 +37,10 @@
     <Text type="h4">{locale('popups.password.title')}</Text>
     <Text type="p" secondary>{locale('popups.password.subtitle')}</Text>
 </div>
-<div class="flex justify-center w-full flex-row flex-wrap">
+<form class="flex justify-center w-full flex-row flex-wrap" on:submit={handleSubmit}>
     <Password classes="w-full mb-8" bind:value={password} showRevealToggle {locale} placeholder={locale('general.password')} />
     <div class="flex flex-row justify-between w-full space-x-4 px-8">
-        <Button secondary classes="w-1/2" onClick={() => handleCancelClick()}>{locale('actions.cancel')}</Button>
-        <Button classes="w-1/2" onClick={() => handleSubmit()}>{locale('actions.unlock')}</Button>
+        <Button secondary classes="w-1/2" onClick={handleCancelClick}>{locale('actions.cancel')}</Button>
+        <Button classes="w-1/2" type="submit">{locale('actions.unlock')}</Button>
     </div>
-</div>
+</form>

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -33,7 +33,8 @@
         },
         "setup": {
             "title": "Set up your wallet",
-            "body": "You can create a new wallet or import an existing one."
+            "body": "You can create a new wallet or import an existing one.",
+            "profile_name": "Profile Name"
         },
         "password": {
             "title": "Create a password",

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -197,61 +197,65 @@
     </section>
     <hr class="border-t border-gray-100 w-full border-solid pb-5 mt-5 justify-center" />
     <section id="changePassword" class="w-3/4">
-        <Text type="h4" classes="mb-3">{locale('views.settings.changePassword.title')}</Text>
-        <Text type="p" secondary classes="mb-5">{locale('views.settings.changePassword.description')}</Text>
-        <Password
-            classes="mb-8"
-            bind:value={currentPassword}
-            showRevealToggle
-            {locale}
-            placeholder={locale('general.currentPassword')} />
-        <Password
-            classes="mb-4"
-            bind:value={newPassword}
-            showRevealToggle
-            strengthLevels={4}
-            showStrengthLevel
-            {strength}
-            {locale}
-            placeholder={locale('general.newPassword')} />
-        <Password
-            classes="mb-5"
-            bind:value={confirmedPassword}
-            showRevealToggle
-            {locale}
-            placeholder={locale('general.confirmNewPassword')} />
-        <Checkbox classes="mb-5" label={locale('actions.exportNewStronghold')} bind:checked={exportStrongholdChecked} />
-        <Button classes="w-1/4" onClick={changePassword}>{locale('views.settings.changePassword.title')}</Button>
+        <form on:submit={changePassword}>
+            <Text type="h4" classes="mb-3">{locale('views.settings.changePassword.title')}</Text>
+            <Text type="p" secondary classes="mb-5">{locale('views.settings.changePassword.description')}</Text>
+            <Password
+                classes="mb-8"
+                bind:value={currentPassword}
+                showRevealToggle
+                {locale}
+                placeholder={locale('general.currentPassword')} />
+            <Password
+                classes="mb-4"
+                bind:value={newPassword}
+                showRevealToggle
+                strengthLevels={4}
+                showStrengthLevel
+                {strength}
+                {locale}
+                placeholder={locale('general.newPassword')} />
+            <Password
+                classes="mb-5"
+                bind:value={confirmedPassword}
+                showRevealToggle
+                {locale}
+                placeholder={locale('general.confirmNewPassword')} />
+            <Checkbox classes="mb-5" label={locale('actions.exportNewStronghold')} bind:checked={exportStrongholdChecked} />
+            <Button type="submit" classes="w-1/4">{locale('views.settings.changePassword.title')}</Button>
+        </form>
     </section>
     <hr class="border-t border-gray-100 w-full border-solid pb-5 mt-5 justify-center" />
     <section id="changePincode" class="w-3/4">
-        <Text type="h4" classes="mb-3">{locale('views.settings.changePincode.title')}</Text>
-        <Text type="p" secondary classes="mb-5">{locale('views.settings.changePincode.description')}</Text>
-        <Password
-            classes="mb-4"
-            bind:value={currentPincode}
-            showRevealToggle
-            {locale}
-            maxlength="6"
-            numeric
-            placeholder={locale('views.settings.changePincode.currentPincode')} />
-        <Password
-            classes="mb-4"
-            bind:value={newPincode}
-            showRevealToggle
-            {locale}
-            maxlength="6"
-            numeric
-            placeholder={locale('views.settings.changePincode.newPincode')} />
-        <Password
-            classes="mb-5"
-            bind:value={confirmedPincode}
-            showRevealToggle
-            {locale}
-            maxlength="6"
-            numeric
-            placeholder={locale('views.settings.changePincode.confirmNewPincode')} />
-        <Button classes="w-1/4" onClick={changePincode}>{locale('views.settings.changePincode.action')}</Button>
+        <form on:submit={changePincode} id="pincode-change-form">
+            <Text type="h4" classes="mb-3">{locale('views.settings.changePincode.title')}</Text>
+            <Text type="p" secondary classes="mb-5">{locale('views.settings.changePincode.description')}</Text>
+            <Password
+                classes="mb-4"
+                bind:value={currentPincode}
+                showRevealToggle
+                {locale}
+                maxlength="6"
+                numeric
+                placeholder={locale('views.settings.changePincode.currentPincode')} />
+            <Password
+                classes="mb-4"
+                bind:value={newPincode}
+                showRevealToggle
+                {locale}
+                maxlength="6"
+                numeric
+                placeholder={locale('views.settings.changePincode.newPincode')} />
+            <Password
+                classes="mb-5"
+                bind:value={confirmedPincode}
+                showRevealToggle
+                {locale}
+                maxlength="6"
+                numeric
+                placeholder={locale('views.settings.changePincode.confirmNewPincode')} />
+            <Button type="submit" form="pincode-change-form" classes="w-1/4">{locale('views.settings.changePincode.action')}</Button>
+        </form>
     </section>
     <hr class="border-t border-gray-100 w-full border-solid pb-5 mt-5 justify-center" />
     <section id="resetWallet" class="w-3/4">

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -51,7 +51,7 @@
         }
     }
 
-    function handleContinueClick() {
+    function onSubmit() {
         if (!validatePinFormat(pinCode)) {
             attempts++
             if (attempts >= MAX_PINCODE_INCORRECT_ATTEMPTS) {
@@ -107,14 +107,14 @@
         <div class="pt-40 pb-16 flex w-full h-full flex-col items-center justify-between">
             <div class="w-96 flex flex-row flex-wrap justify-center mb-20">
                 <Profile name={$activeProfile.name} bgColor="blue" />
-                <Pin bind:value={pinCode} classes="mt-10" />
+                <Pin bind:value={pinCode} classes="mt-10" on:submit={onSubmit} />
                 <Text type="p" bold classes="mt-4 text-center">
                     {attempts > 0 ? locale('views.login.incorrect_attempts', {
                               values: { attempts: attempts.toString() },
                           }) : locale('actions.enter_your_pin')}
                 </Text>
             </div>
-            <Button classes="w-96" disabled={!hasCorrectLength || hasReachedMaxAttempts} onClick={() => handleContinueClick()}>
+            <Button classes="w-96" disabled={!hasCorrectLength || hasReachedMaxAttempts} onClick={() => onSubmit()}>
                 {hasReachedMaxAttempts ? buttonText : locale('actions.continue')}
             </Button>
         </div>

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -15,16 +15,18 @@
     $: valid = strength === 4 && password === confirmedPassword
 
     function handleContinueClick() {
-        api.setStrongholdPassword(password, {
-            onSuccess() {
-                dispatch('next', { password })
-            },
-            onError(error) {
-                // TODO: handle error
-                console.log(error)
-                alert('set password error')
-            },
-        })
+        if (valid) {
+            api.setStrongholdPassword(password, {
+                onSuccess() {
+                    dispatch('next', { password })
+                },
+                onError(error) {
+                    // TODO: handle error
+                    console.log(error)
+                    alert('set password error')
+                },
+            })
+        }
     }
     function handleBackClick() {
         dispatch('previous')
@@ -36,20 +38,22 @@
 {:else}
     <OnboardingLayout onBackClick={handleBackClick}>
         <div slot="leftpane__content">
-            <Text type="h2" classes="mb-5">{locale('views.password.title')}</Text>
-            <Text type="p" secondary classes="mb-8">{locale('views.password.body')}</Text>
-            <Password
-                classes="mb-6"
-                bind:value={password}
-                strengthLevels={4}
-                showRevealToggle
-                showStrengthLevel
-                {strength}
-                {locale} />
-            <Password bind:value={confirmedPassword} {locale} placeholder={locale('general.confirm_password')} />
+            <form on:submit={handleContinueClick} id="password-form">
+                <Text type="h2" classes="mb-5">{locale('views.password.title')}</Text>
+                <Text type="p" secondary classes="mb-8">{locale('views.password.body')}</Text>
+                <Password
+                    classes="mb-6"
+                    bind:value={password}
+                    strengthLevels={4}
+                    showRevealToggle
+                    showStrengthLevel
+                    {strength}
+                    {locale} />
+                <Password bind:value={confirmedPassword} {locale} placeholder={locale('general.confirm_password')} />
+            </form>
         </div>
         <div slot="leftpane__action">
-            <Button classes="w-full" disabled={!valid} onClick={() => handleContinueClick()}>
+            <Button type="submit" form="password-form" classes="w-full" disabled={!valid}>
                 {locale('actions.save_password')}
             </Button>
         </div>

--- a/packages/shared/routes/setup/Setup.svelte
+++ b/packages/shared/routes/setup/Setup.svelte
@@ -48,7 +48,7 @@
     <OnboardingLayout onBackClick={handleBackClick}>
         <div slot="leftpane__content">
             <Text type="h2" classes="mb-4">{locale('views.setup.title')}</Text>
-            <Input bind:value={profileName} placeholder="Profile Name" classes="w-full mb-4" />
+            <Input bind:value={profileName} placeholder={locale('views.setup.profile_name')} classes="w-full mb-4" />
             {#if $developerMode}
                 <Checkbox label={locale('general.developerProfile')} bind:checked={isDeveloperProfile} />
             {/if}

--- a/packages/shared/routes/setup/backup/views/BackupToFile.svelte
+++ b/packages/shared/routes/setup/backup/views/BackupToFile.svelte
@@ -12,8 +12,10 @@
 
     $: valid = strongholdPassword === confirmPassword
 
-    function handleContinueClick() {
-        dispatch('next')
+    function onSubmit() {
+        if (valid) {
+            dispatch('next')
+        }
     }
     function handleBackClick() {
         dispatch('previous')
@@ -25,12 +27,14 @@
 {:else}
     <OnboardingLayout onBackClick={handleBackClick}>
         <div slot="leftpane__content">
-            <Text type="h2" classes="mb-5">{locale('views.backup_wallet.title')}</Text>
-            <Text type="p" secondary classes="mb-8">{locale('views.backup_wallet.body')}</Text>
-            <Password bind:value={confirmPassword} {locale} />
+            <form on:submit={onSubmit} id="backup-form">
+                <Text type="h2" classes="mb-5">{locale('views.backup_wallet.title')}</Text>
+                <Text type="p" secondary classes="mb-8">{locale('views.backup_wallet.body')}</Text>
+                <Password bind:value={confirmPassword} {locale} />
+            </form>
         </div>
         <div slot="leftpane__action">
-            <Button classes="w-full" disabled={!valid} onClick={() => handleContinueClick()}>{locale('actions.continue')}</Button>
+            <Button type="submit" form="backup-form" classes="w-full" disabled={!valid}>{locale('actions.continue')}</Button>
         </div>
         <div slot="rightpane" class="w-full h-full flex justify-end items-center">
             <Illustration width="100%" illustration="backup-recovery-phrase-desktop" />

--- a/packages/shared/routes/setup/protect/views/Pin.svelte
+++ b/packages/shared/routes/setup/protect/views/Pin.svelte
@@ -15,8 +15,10 @@
         ? Number.isInteger(pinInput) && `${pinInput}`.length === 6 && pinInput === pinCandidate
         : Number.isInteger(pinInput) && `${pinInput}`.length === 6
 
-    function handleContinueClick() {
-        dispatch('next', !confirmInput ? { pinCandidate: pinInput } : null)
+    function onSubmit() {
+        if (valid) {
+            dispatch('next', !confirmInput ? { pinCandidate: pinInput } : null)
+        }
     }
     function handleBackClick() {
         dispatch('previous')
@@ -32,16 +34,16 @@
                 <Text type="h2" classes="mb-5">{locale('views.pin.title')}</Text>
                 <Text type="p" secondary classes="mb-4">{locale('views.pin.body_1')}</Text>
                 <Text type="p" secondary highlighted classes="mb-8 font-bold">{locale('views.pin.body_2')}</Text>
-                <Pin bind:value={pinInput} classes="w-full mx-auto block" />
+                <Pin bind:value={pinInput} classes="w-full mx-auto block" on:submit={onSubmit} />
             {:else}
                 <Text type="h2" classes="mb-5">{locale('views.confirm_pin.title')}</Text>
                 <Text type="p" secondary classes="mb-8">{locale('views.confirm_pin.body')}</Text>
-                <Pin bind:value={pinInput} classes="w-full mx-auto block" />
+                <Pin bind:value={pinInput} classes="w-full mx-auto block" on:submit={onSubmit} />
             {/if}
         </div>
         <div slot="leftpane__action" class="flex flex-row flex-wrap justify-between items-center space-x-4">
             <Button secondary classes="flex-1" onClick={() => handleBackClick()}>{locale('actions.back')}</Button>
-            <Button classes="flex-1" disabled={!valid} onClick={() => handleContinueClick()}>{locale('actions.set_pin')}</Button>
+            <Button classes="flex-1" disabled={!valid} onClick={() => onSubmit()}>{locale('actions.set_pin')}</Button>
         </div>
         <div slot="rightpane" class="w-full h-full flex justify-end items-center">
             {#if !confirmInput}


### PR DESCRIPTION
# Description of change

Use <form> tags where appropriate so we can use `enter` to submit. Also adds that support to the Pin component.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually :(

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
