### PR TITLE
feature(desktop): Allow hardcoding of NODE_ENV in bundled JS

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -79,6 +79,8 @@ jobs:
     - name: Bundle desktop JS
       run: yarn build
       working-directory: packages/desktop
+      env:
+        HARDCODE_NODE_ENV: true
 
     - name: Build Electron app (macOS)
       run: yarn compile:mac

--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -6,6 +6,7 @@ const sveltePreprocess = require('svelte-preprocess')
 
 const mode = process.env.NODE_ENV || 'development'
 const prod = mode === 'production'
+const hardcodeNodeEnv = typeof process.env.HARDCODE_NODE_ENV !== 'undefined'
 
 /// ------------------------ Resolve ------------------------
 
@@ -159,7 +160,7 @@ module.exports = [
         plugins: mainPlugins,
         devtool: prod ? false : 'cheap-module-source-map',
         optimization: {
-            nodeEnv: false,
+            nodeEnv: hardcodeNodeEnv ? mode : false,
         },
     },
 ]


### PR DESCRIPTION
# Description of change

In #164, issues with dev mode were fixed by disabling Webpack's `optimization.nodeEnv` feature in order to evaluate `process.env.NODE_ENV` at runtime. This change had the side effect of allowing a user of the packaged app to change the app's behavior (including opening DevTools) by setting `NODE_ENV=development` when launching the app (i.e. `NODE_ENV=development /Applications/Firefly.app/Contents/MacOS/Firefly`. This PR allows us to choose whether to hardcode the value of `NODE_ENV` when packaging the app. When deploying and releasing the app, we can set `HARDCODE_NODE_ENV=true` in order to hardcode `NODE_ENV`. Essentially, we can evaluate `NODE_ENV` during development, but hardcode it (and mitigate the potential security issue) when packaging and releaing.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
