### PR TITLE
hotfix: fix password popup onsubmit handler

### DIFF
--- a/packages/shared/components/popups/Password.svelte
+++ b/packages/shared/components/popups/Password.svelte
@@ -37,10 +37,10 @@
     <Text type="h4">{locale('popups.password.title')}</Text>
     <Text type="p" secondary>{locale('popups.password.subtitle')}</Text>
 </div>
-<form class="flex justify-center w-full flex-row flex-wrap" on:submit={handleSubmit}>
+<form id="password-popup-form" class="flex justify-center w-full flex-row flex-wrap" on:submit={handleSubmit}>
     <Password classes="w-full mb-8" bind:value={password} showRevealToggle {locale} placeholder={locale('general.password')} />
     <div class="flex flex-row justify-between w-full space-x-4 px-8">
         <Button secondary classes="w-1/2" onClick={handleCancelClick}>{locale('actions.cancel')}</Button>
-        <Button classes="w-1/2" type="submit">{locale('actions.unlock')}</Button>
+        <Button classes="w-1/2" type="submit" form="password-popup-form">{locale('actions.unlock')}</Button>
     </div>
 </form>


### PR DESCRIPTION
# Description of change

This PR fixes the password popup `onsubmit` handler. It wasn't working before. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
