### PR TITLE
fix(desktop): Profile creation not cleaned up on cancel

### DIFF
--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -135,6 +135,17 @@ export const createProfile = (profileName, isDeveloperProfile): Profile => {
 }
 
 /**
+ * Disposes a new profile
+ *
+ * @method disposeNewProfile
+ *
+ * @returns {void}
+ */
+export const disposeNewProfile = (): void => {
+    newProfile.set(null)
+}
+
+/**
  * Sets profile with provided id as active
  *
  * @method setActiveProfile

--- a/packages/shared/routes/setup/Setup.svelte
+++ b/packages/shared/routes/setup/Setup.svelte
@@ -1,7 +1,8 @@
 <script>
     import { createEventDispatcher } from 'svelte'
+    import { get } from 'svelte/store'
     import { OnboardingLayout, Illustration, Text, Button, Input, Checkbox } from 'shared/components'
-    import { createProfile, setActiveProfile } from 'shared/lib/profile'
+    import { createProfile, disposeNewProfile, newProfile } from 'shared/lib/profile'
     import { developerMode } from 'shared/lib/app'
     import { initialise, getStoragePath } from 'shared/lib/wallet'
     import { SetupType } from 'shared/lib/typings/routes'
@@ -12,12 +13,11 @@
     const dispatch = createEventDispatcher()
 
     let isDeveloperProfile = false
-    let profileName = ''
+    let profileName = get(newProfile)?.name ?? ''
 
     const MAX_PROFILE_NAME_LENGTH = 250
 
     function handleContinueClick(setupType) {
-        // TOOD (laumair): What happens if a user cancels at this point? We need to detect and remove this profile.
         let profile
 
         if (profileName.length > MAX_PROFILE_NAME_LENGTH) {
@@ -25,7 +25,6 @@
         } else {
             try {
                 profile = createProfile(profileName, isDeveloperProfile)
-                setActiveProfile(profile.id)
 
                 return window['Electron'].getUserDataPath().then((path) => {
                     initialise(profile.id, getStoragePath(path, profile.name))
@@ -38,6 +37,7 @@
     }
 
     function handleBackClick() {
+        disposeNewProfile();
         dispatch('previous')
     }
 </script>


### PR DESCRIPTION
# Description of change

When creating a profile if you cancelled the operation and then selected an existing profile to login it displayed the details for the creating profile.

Also when stepping back to first step of creating profile it did not repopulate the name for the profile.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test locally on windows.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
