### PR TITLE
fix(onboarding): set active profile on finish

### DIFF
--- a/packages/shared/routes/setup/Congratulations.svelte
+++ b/packages/shared/routes/setup/Congratulations.svelte
@@ -1,7 +1,7 @@
 <script>
     import { onMount, createEventDispatcher } from 'svelte'
     import { OnboardingLayout, Illustration, Text, Button } from 'shared/components'
-    import { newProfile, saveProfile } from 'shared/lib/profile'
+    import { newProfile, saveProfile, setActiveProfile } from 'shared/lib/profile'
 
     export let locale
     export let mobile
@@ -10,6 +10,7 @@
         // This is the last screen in onboarding for all flows i.e., if you create a new wallet or import stronghold
         // When this component mounts, ensure that the profile is persisted in the local storage.
         saveProfile($newProfile)
+        setActiveProfile($newProfile.id)
 
         newProfile.set(null)
     })


### PR DESCRIPTION
# Description of change

When the onboarding process is finished, we need to set the active profile, otherwise the app uses the previous used profile, which is not initialized (leading to a backend crash).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running the onboarding process several times :D

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
