### PR TITLE
hotfix: ensure callback deletion after receiving a response from wallet.rs

### DIFF
--- a/packages/shared/lib/walletApi.ts
+++ b/packages/shared/lib/walletApi.ts
@@ -101,6 +101,8 @@ const defaultCallbacks = {
     },
 }
 
+const eventsApiResponseTypes = Object.values(eventsApiToResponseTypeMap)
+
 /**
  * Response subscriber.
  * Receives messages from wallet.rs.
@@ -108,7 +110,7 @@ const defaultCallbacks = {
 Wallet.onMessage((message: MessageResponse) => {
     const _deleteCallbackId = (_id: string) => {
         // Do not delete callback ids for events api methods
-        if (!Object.values(eventsApiToResponseTypeMap).includes(message.type)) {
+        if (!eventsApiResponseTypes.includes(message.type)) {
             delete callbacksStore[_id]
         }
     }


### PR DESCRIPTION
# Description of change

Callback store wasn't deleting callback ids in all cases. This PR fixes the issue and ensures that callback store always deletes the id after a response is received from wallet.rs

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
