### PR TITLE
feat(desktop): Native menu auto updater

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -1,34 +1,42 @@
 <script lang="typescript">
-    import { onMount } from 'svelte'
-    import { get } from 'svelte/store'
+    import { Popup, Route, ToastContainer, Toggle } from 'shared/components'
+    import { darkMode, loggedIn, mobile } from 'shared/lib/app'
+    import { refreshVersionDetails, versionDetails } from 'shared/lib/appUpdater'
+    import { goto } from 'shared/lib/helpers'
+    import { activeLocale, dir, isLocaleLoaded, setupI18n, _ } from 'shared/lib/i18n'
     import { fetchMarketData } from 'shared/lib/marketData'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
-    import { setupI18n, isLocaleLoaded, dir, _, activeLocale } from 'shared/lib/i18n'
-    import { darkMode, mobile, loggedIn } from 'shared/lib/app'
+    import { openPopup, popupState } from 'shared/lib/popup'
     import { activeProfile } from 'shared/lib/profile'
-    import { goto } from 'shared/lib/helpers'
-    import { initRouter, routerNext, routerPrevious, route as appRoute, dashboardRoute, walletRoute, settingsRoute } from 'shared/lib/router'
-    import { AppRoute, Tabs } from 'shared/lib/typings/routes'
-    import { popupState } from 'shared/lib/popup'
-    import { requestMnemonic } from 'shared/lib/wallet'
-    import { Route, Toggle, Popup } from 'shared/components'
-    import { refreshVersionDetails } from 'shared/lib/appUpdater'
     import {
-        Splash,
-        Welcome,
-        Legal,
-        Setup,
-        Language,
-        Password,
-        Protect,
+        dashboardRoute,
+        initRouter,
+        route as appRoute,
+        routerNext,
+        routerPrevious,
+        settingsRoute,
+        walletRoute,
+    } from 'shared/lib/router'
+    import { AppRoute, Tabs } from 'shared/lib/typings/routes'
+    import { requestMnemonic } from 'shared/lib/wallet'
+    import {
         Backup,
-        Import,
         Balance,
-        Migrate,
         Congratulations,
         Dashboard,
+        Import,
+        Language,
+        Legal,
         Login,
+        Migrate,
+        Password,
+        Protect,
+        Setup,
+        Splash,
+        Welcome,
     } from 'shared/routes'
+    import { onMount } from 'svelte'
+    import { get } from 'svelte/store'
     import { getLocalisedMenuItems } from './lib/helpers'
 
     const locale = activeLocale
@@ -66,13 +74,21 @@
         })
         window['Electron'].onEvent('menu-navigate-settings', (route) => {
             if (get(appRoute) !== AppRoute.Dashboard) {
-                  // TODO: Add settings from login
+                // TODO: Add settings from login
             } else if (get(dashboardRoute) !== Tabs.Settings) {
                 dashboardRoute.set(Tabs.Settings)
             }
             settingsRoute.set(route)
         })
-
+        window['Electron'].onEvent('menu-check-for-update', async () => {
+            await refreshVersionDetails()
+            openPopup({
+                type: 'version',
+                props: {
+                    currentVersion: $versionDetails.currentVersion,
+                },
+            })
+        })
     })
 </script>
 
@@ -159,4 +175,5 @@
     <Route route={AppRoute.Login}>
         <Login on:next={routerNext} on:previous={routerPrevious} mobile={$mobile} locale={$_} {goto} />
     </Route>
+    <ToastContainer />
 {/if}

--- a/packages/desktop/electron/lib/menu.js
+++ b/packages/desktop/electron/lib/menu.js
@@ -50,9 +50,7 @@ const buildTemplate = () => {
                 },
                 {
                     label: `${state.strings.checkForUpdates}...`,
-                    click: () => {
-                        // TODO: Check for updates
-                    },
+                    click: () => getWindow('main').webContents.send('menu-check-for-update'),
                     enabled: state.enabled,
                 },
                 {

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -1,16 +1,15 @@
 <script lang="typescript">
-    import { get } from 'svelte/store'
-    import { onMount } from 'svelte'
     import { Idle, Sidebar } from 'shared/components'
-    import { Wallet, Settings } from 'shared/routes'
-    import { parseDeepLink } from 'shared/lib/utils'
-    import { sendParams, logout } from 'shared/lib/app'
+    import { logout, sendParams } from 'shared/lib/app'
     import { deepLinkRequestActive } from 'shared/lib/deepLinking'
     import { activeProfile } from 'shared/lib/profile'
-    import { routerNext, dashboardRoute } from 'shared/lib/router'
-    import { api } from 'shared/lib/wallet'
+    import { dashboardRoute, routerNext } from 'shared/lib/router'
     import { Tabs } from 'shared/lib/typings/routes'
-    import { ToastContainer } from 'shared/components'
+    import { parseDeepLink } from 'shared/lib/utils'
+    import { api } from 'shared/lib/wallet'
+    import { Settings, Wallet } from 'shared/routes'
+    import { onMount } from 'svelte'
+    import { get } from 'svelte/store'
 
     export let locale
     export let mobile
@@ -19,7 +18,7 @@
         wallet: Wallet,
         settings: Settings,
     }
-    
+
     const DeepLinkManager = window['Electron']['DeepLinkManager']
 
     onMount(() => {
@@ -72,6 +71,5 @@
         <Sidebar bind:activeTab={$dashboardRoute} {locale} />
         <!-- Dashboard Pane -->
         <svelte:component this={tabs[$dashboardRoute]} {locale} on:next={routerNext} />
-        <ToastContainer />
     </div>
 {/if}


### PR DESCRIPTION
# Description of change

The native electron menu can now call the auto updater. 
The toast container has been moved from the dashboard further up the component hierarchy to allow the updater to show its toast notifications even when logged out.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested locally on windows with dummy update version, see video.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

https://user-images.githubusercontent.com/5030334/109619894-90f10900-7b39-11eb-8000-8de74323a00a.mp4

