### PR TITLE
feat: Busy popup for loading accounts

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -123,7 +123,7 @@
     <Splash />
 {:else}
     {#if $popupState.active}
-        <Popup type={$popupState.type} props={$popupState.props} locale={$_} />
+        <Popup type={$popupState.type} props={$popupState.props} hideClose={$popupState.hideClose} locale={$_} />
     {/if}
     <!-- dummy toggles -->
     <div class="dummy-toggles flex flex-row">

--- a/packages/shared/components/popups/Busy.svelte
+++ b/packages/shared/components/popups/Busy.svelte
@@ -1,0 +1,12 @@
+<script lang="typescript">
+    import { Logo, Text } from 'shared/components'
+
+    export let statusMessage = ''
+</script>
+
+<div class={"flex flex-col justify-center align-center items-center"}>
+    <Logo width="50%" classes="pt-8" logo="logo-firefly-full" />
+    {#if statusMessage}
+        <Text type="p" classes="pt-8">{statusMessage}</Text>
+    {/if}
+</div>

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -9,10 +9,12 @@
     import DeleteAccount from './DeleteAccount.svelte'
     import AddressHistory from './AddressHistory.svelte'
     import AddNode from './AddNode.svelte'
+    import Busy from './Busy.svelte'
 
     export let locale = 'en'
     export let type = undefined
     export let props = undefined
+    export let hideClose = undefined
 
     const types = {
         qr: QR,
@@ -22,10 +24,11 @@
         deleteAccount: DeleteAccount,
         addressHistory: AddressHistory,
         addNode: AddNode,
+        busy: Busy,
     }
 
     const onkey = (e) => {
-        if (e.key === 'Escape') {
+        if (!hideClose && e.key === 'Escape') {
             closePopup()
         }
     }
@@ -47,9 +50,11 @@
     class="flex items-center justify-center fixed top-0 left-0 w-screen p-6
                 h-screen overflow-hidden z-10 bg-gray-800 bg-opacity-40">
     <popup-content class="bg-white dark:bg-gray-900 rounded-xl pt-6 px-8 pb-14 relative">
-        <button on:click={closePopup} class="absolute top-6 right-8">
-            <Icon icon="close" classes="text-gray-800 dark:text-white" />
-        </button>
+        {#if !hideClose}
+            <button on:click={closePopup} class="absolute top-6 right-8">
+                <Icon icon="close" classes="text-gray-800 dark:text-white" />
+            </button>
+        {/if}
         <svelte:component this={types[type]} {...props} {locale} />
     </popup-content>
 </popup>

--- a/packages/shared/lib/popup.ts
+++ b/packages/shared/lib/popup.ts
@@ -3,8 +3,9 @@ import { writable } from 'svelte/store'
 interface PopupState {
     active: boolean
     type: string
+    hideClose: boolean
     props?: any
 }
-export const popupState = writable<PopupState>({ active: false, type: null })
-export const openPopup = ({ type, props = null }) => popupState.set({ active: true, type, props })
-export const closePopup = () => popupState.set({ active: false, type: null })
+export const popupState = writable<PopupState>({ active: false, type: null, hideClose: false, props: null })
+export const openPopup = ({ type, props = null, hideClose = false }) => popupState.set({ active: true, hideClose, type, props })
+export const closePopup = () => popupState.set({ active: false, type: null, hideClose: false, props: null })

--- a/packages/shared/routes/dashboard/wallet/views/WalletActions.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletActions.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { AccountTile, Button, Text } from 'shared/components'
+    import { closePopup, openPopup } from 'shared/lib/popup'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
     import { selectedAccountId, WalletAccount } from 'shared/lib/wallet'
@@ -14,6 +15,22 @@
 
     const accounts = getContext<Writable<WalletAccount[]>>('walletAccounts')
     const accountsLoaded = getContext<Writable<boolean>>('walletAccountsLoaded')
+
+    if ($walletRoute === WalletRoutes.Init) {
+        openPopup({
+            type: 'busy',
+            props: {
+                statusMessage: locale('general.loading_accounts'),
+            },
+            hideClose: true,
+        })
+    }
+
+    $: {
+        if ($accountsLoaded) {
+            closePopup()
+        }
+    }
 
     function handleAccountClick(accountId) {
         selectedAccountId.set(accountId)
@@ -40,22 +57,22 @@
                     {locale('actions.create')}
                 </Button>
             </div>
-            {#if !$accountsLoaded}
-                <Text overrideColor classes={'text-gray-600'}>{locale('general.loading_accounts')}</Text>
-            {:else if $accounts.length > 0}
-                <div class="grid grid-cols-{$accounts.length <= 2 ? $accounts.length : '3'} gap-2 w-full flex-auto">
-                    {#each $accounts as account}
-                        <AccountTile
-                            color={account.color}
-                            name={account.alias}
-                            balance={account.balance}
-                            balanceEquiv={account.balanceEquiv}
-                            size={$accounts.length >= 3 ? 's' : $accounts.length === 2 ? 'm' : 'l'}
-                            onClick={() => handleAccountClick(account.id)} />
-                    {/each}
-                </div>
-            {:else}
-                <Text>{locale('general.no_accounts')}</Text>
+            {#if $accountsLoaded}
+                {#if $accounts.length > 0}
+                    <div class="grid grid-cols-{$accounts.length <= 2 ? $accounts.length : '3'} gap-2 w-full flex-auto">
+                        {#each $accounts as account}
+                            <AccountTile
+                                color={account.color}
+                                name={account.alias}
+                                balance={account.balance}
+                                balanceEquiv={account.balanceEquiv}
+                                size={$accounts.length >= 3 ? 's' : $accounts.length === 2 ? 'm' : 'l'}
+                                onClick={() => handleAccountClick(account.id)} />
+                        {/each}
+                    </div>
+                {:else}
+                    <Text>{locale('general.no_accounts')}</Text>
+                {/if}
             {/if}
         </div>
         {#if $accounts.length > 0}


### PR DESCRIPTION
# Description of change

Show a busy popup when loading the accounts, component can be shown with any message, so can be used in other long running processes.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

See screenshot

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

![image](https://user-images.githubusercontent.com/5030334/109945804-e95e0d00-7cd7-11eb-8b6f-1562e729bae4.png)
