### PR TITLE
fix: set dev profiles by default

### DIFF
--- a/packages/shared/routes/setup/Setup.svelte
+++ b/packages/shared/routes/setup/Setup.svelte
@@ -13,7 +13,8 @@
 
     const dispatch = createEventDispatcher()
 
-    let isDeveloperProfile = false
+    // TODO: Remove defaulting to dev profile
+    let isDeveloperProfile = true
     let profileName = get(newProfile)?.name ?? ''
 
     const MAX_PROFILE_NAME_LENGTH = 20


### PR DESCRIPTION
# Description of change

Create dev profiles by default. To be disabled when Chrysalis hits mainnet.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested in Mac development 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
