### PR TITLE
feat: make sure we sync accounts when accounts are retrieved

### DIFF
--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -128,16 +128,15 @@
     function getAccounts() {
         api.getAccounts({
             onSuccess(accountsResponse) {
+                syncAccounts()
+
                 const _totalBalance = {
                     balance: 0,
                     incoming: 0,
                     outgoing: 0,
                 }
 
-                if (accountsResponse.payload.length === 0) {
-                    accountsLoaded.set(true)
-                } else {
-                    for (const [idx, storedAccount] of accountsResponse.payload.entries()) {
+                for (const [idx, storedAccount] of accountsResponse.payload.entries()) {
                         getAccountMeta(storedAccount.id, (err, meta) => {
                             if (!err) {
                                 _totalBalance.balance += meta.balance
@@ -149,14 +148,12 @@
 
                                 if (idx === accountsResponse.payload.length - 1) {
                                     updateBalanceOverview(_totalBalance.balance, _totalBalance.incoming, _totalBalance.outgoing)
-                                    accountsLoaded.set(true)
                                 }
                             } else {
                                 console.error(err)
                             }
                         })
                     }
-                }
             },
             onError(err) {
                 showAppNotification({
@@ -216,12 +213,14 @@
         })
     }
 
-    function syncAccounts(payload) {
+    function syncAccounts() {
         api.syncAccounts({
             onSuccess(syncAccountsResponse) {
                 const syncedAccounts = syncAccountsResponse.payload
 
                 updateAccounts(syncedAccounts)
+
+                accountsLoaded.set(true)
             },
             onError(err) {
                 showAppNotification({


### PR DESCRIPTION
# Description of change

This PR ensures we sync accounts when `Wallet.svelte` is mounted and the accounts are successfully retrieved

# Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
