### PR TITLE
Feat: tweak tailwind purge

### DIFF
--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -10,7 +10,6 @@ module.exports = {
         // purgeLayersByDefault: true,
     },
     purge: {
-        enabled: true,
         content: ['../shared/**/*.svelte', '../shared/**/*.scss'],
         options: {
             // Needed to prevent purgecss from removing classes declared with string concatenation
@@ -213,7 +212,7 @@ module.exports = {
     },
     plugins: [
         // Reference: https://dev.to/smartmointy/tailwind-css-dark-mode-switch-with-javascript-2kl9
-        plugin(function ({ addVariant, prefix }) {
+        plugin(function({ addVariant, prefix }) {
             addVariant('dark', ({ modifySelectors, separator }) => {
                 modifySelectors(({ selector }) => {
                     return selectorParser((selectors) => {
@@ -225,7 +224,7 @@ module.exports = {
                 })
             })
         }),
-        plugin(function ({ addVariant, e }) {
+        plugin(function({ addVariant, e }) {
             addVariant('dark-hover', ({ modifySelectors, separator }) => {
                 modifySelectors(({ className }) => {
                     return `.scheme-dark .${e(`dark\:hover${separator}${className}`)}:hover`


### PR DESCRIPTION
# Description of change

- Disable manual purge to fallback to default behavior based on environment variables: dev disabled, prod enabled. This should help UI devs as it is not needed anymore to remember to disable purge while developing.
- Add more classes to whitelist to prevent purging needed classes.

In order to prevent purge from removing used classes, we should avoid defining classes as string concatenations, [source](https://tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html). 
I will investigate further options.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Electron Linux 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
