### PR TITLE
hotfix: ensure messages are not duplicated in latest transactions panel

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -346,7 +346,10 @@ export const saveNewMessage = (accountId: string, message: Message): void => {
  * @returns {AccountMessage[]}
  */
 export const getLatestMessages = (accounts: WalletAccount[], count = 10): AccountMessage[] => {
-    const messages: Set<AccountMessage> = new Set();
+    const messages: {
+        [key: string]: AccountMessage
+    } = {};
+
     const addresses: string[] = [];
 
     accounts.forEach((account) => {
@@ -355,20 +358,18 @@ export const getLatestMessages = (accounts: WalletAccount[], count = 10): Accoun
         })
 
         account.messages.forEach((message) => {
-            messages.add(
-                Object.assign<
-                    AccountMessage,
-                    Message,
-                    Partial<AccountMessage>
-                >(
-                    {} as AccountMessage,
-                    message,
-                    { account: account.index })
-            )
+            messages[message.id] = Object.assign<
+                AccountMessage,
+                Message,
+                Partial<AccountMessage>
+            >(
+                {} as AccountMessage,
+                message,
+                { account: account.index });
         })
     });
 
-    return Array.from(messages)
+    return Object.values(messages)
         .map(
             (message) => {
                 const outputs = message.payload.data.essence.data.outputs;


### PR DESCRIPTION
# Description of change

This PR fixes the deduplication logic of messages in latest transactions panel. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
