### PR TITLE
feat: Moved sync account from menu to icon on transactions panel

### DIFF
--- a/packages/shared/components/modals/AccountActions.svelte
+++ b/packages/shared/components/modals/AccountActions.svelte
@@ -3,10 +3,9 @@
     import { openPopup } from 'shared/lib/popup'
     import { accountRoute } from 'shared/lib/router'
     import { AccountRoutes } from 'shared/lib/typings/routes'
-    import { WalletAccount, api, selectedAccountId, isSyncing } from 'shared/lib/wallet'
+    import type { WalletAccount } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import type { Readable, Writable } from 'svelte/store'
-    import { NotificationData, NOTIFICATION_TIMEOUT_NEVER, showAppNotification, updateDisplayNotification } from 'shared/lib/notifications'
 
     const account = getContext<Readable<WalletAccount>>('selectedAccount')
     const accounts = getContext<Writable<WalletAccount[]>>('walletAccounts')
@@ -18,40 +17,7 @@
         accountRoute.set(AccountRoutes.Manage)
         isActive = false
     }
-    const handleSyncAccountClick = () => {
-        if (!$isSyncing) {
-            $isSyncing = true
 
-            const notificationData: NotificationData = {
-                type: 'info',
-                message: locale("general.accountSyncing"),
-                timeout: NOTIFICATION_TIMEOUT_NEVER
-            }
-
-            const notificationId = showAppNotification(notificationData)
-
-            api.syncAccount($selectedAccountId, {
-                onSuccess() {
-                    updateDisplayNotification(notificationId, {
-                        ...notificationData,
-                        message: locale("general.accountSyncComplete"),
-                        timeout: undefined
-                    })
-                    $isSyncing = false
-                },
-                onError(err) {
-                    updateDisplayNotification(notificationId, {
-                        ...notificationData,
-                        type: "error",
-                        message: locale(err.error),
-                        timeout: undefined
-                    })
-                    $isSyncing = false
-                },
-            })
-        }
-        isActive = false
-    }
     const handlViewAddressHistoryClick = () => {
         openPopup({ type: 'addressHistory', props: { account } })
         isActive = false
@@ -80,16 +46,8 @@
             <Icon icon="customize" classes="text-gray-500 ml-1 mr-3 group-hover:text-blue-500" />
             <Text smaller classes="group-hover:text-blue-500">{locale(`actions.customize_account`)}</Text>
         </button>
-        <!-- Sync -->
-        <button
-            on:click={() => handleSyncAccountClick()}
-            disabled={$isSyncing}
-            class={`group flex flex-row justify-start items-center py-3 px-3 w-full ${$isSyncing ? "cursor-auto opacity-30" : "hover:bg-blue-50"}`}>
-            <Icon icon="refresh" classes={`text-gray-500 ml-1 mr-3 ${$isSyncing ? "" : "group-hover:text-blue-500"}`} />
-            <Text smaller classes={`${$isSyncing ? "" : "group-hover:text-blue-500"}`}>{locale(`actions.sync_account`)}</Text>
-        </button>
         <!-- Address history -->
-       <!-- TODO: Implement and enable -->
+        <!-- TODO: Implement and enable -->
         <button
             disabled
             on:click={() => handlViewAddressHistoryClick()}

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -386,7 +386,6 @@
         "restart_now": "Restart now",
         "save_backup": "Save backup",
         "customize_account": "Customise account",
-        "sync_account": "Sync account",
         "view_address_history": "View address history",
         "delete_account": "Delete account",
         "max": "Max",
@@ -491,9 +490,7 @@
         "transferBroadcasting": "Broadcasting transaction",
         "transferComplete": "Transfer complete",
         "creatingAccount": "Creating account, please wait...",
-        "updatingAccount": "Updating account, please wait...",
-        "accountSyncing": "Account is syncing",
-        "accountSyncComplete": "Account sync complete"
+        "updatingAccount": "Updating account, please wait..."
     },
     "dates": {
         "today": "Today",

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { ActivityDetail, ActivityRow, Icon, Text } from 'shared/components'
-    import { selectedMessage } from 'shared/lib/wallet'
+    import { showAppNotification } from 'shared/lib/notifications'
+    import { api, isSyncing, selectedAccountId, selectedMessage } from 'shared/lib/wallet'
 
     export let locale
     export let transactions = []
@@ -13,6 +14,25 @@
     function handleBackClick() {
         selectedMessage.set(null)
     }
+
+    const handleSyncAccountClick = () => {
+        if (!$isSyncing) {
+            $isSyncing = true
+
+            api.syncAccount($selectedAccountId, {
+                onSuccess() {
+                    $isSyncing = false
+                },
+                onError(err) {
+                    $isSyncing = false
+                    showAppNotification({
+                        type: 'error',
+                        message: locale(err.error),
+                    })
+                },
+            })
+        }
+    }
 </script>
 
 <div class="h-full p-8 flex flex-col flex-auto flex-grow flex-shrink-0">
@@ -22,7 +42,14 @@
                 <Icon icon="arrow-left" classes="text-blue-500" />
             </button>
         {/if}
-        <Text type="h4">{locale('general.transactions')}</Text>
+        <div class="flex flex-1 flex-row justify-between">
+            <Text type="h4">{locale('general.transactions')}</Text>
+            {#if !$selectedMessage}
+                <button on:click={handleSyncAccountClick} class:pointer-events-none={$isSyncing}>
+                    <Icon icon="refresh" classes="{$isSyncing && 'animate-spin'} text-gray-500 dark:text-white" />
+                </button>
+            {/if}
+        </div>
     </div>
     {#if $selectedMessage}
         <ActivityDetail onBackClick={handleBackClick} {...$selectedMessage} {locale} />


### PR DESCRIPTION
# Description of change

Removed the "Sync Account" menu entry and notifications, and replaced with refresh icon on Transactions panel.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
![image](https://user-images.githubusercontent.com/5030334/110453197-35d58e00-80c6-11eb-8b0c-20552c3fdc1a.png)

