### PR TITLE
fix: Format the amount shown in notifications

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -198,7 +198,7 @@ export const initialiseListeners = () => {
 
                 const locale = get(_) as (string) => string
                 const notificationMessage = locale('notifications.valueTx')
-                    .replace('{{value}}', message.value.toString())
+                    .replace('{{value}}', formatUnit(message.value))
                     .replace('{{account}}', account.alias)
 
                 showSystemNotification({ type: "info", message: notificationMessage })
@@ -222,7 +222,7 @@ export const initialiseListeners = () => {
 
                 const locale = get(_) as (string) => string
                 const notificationMessage = locale(`notifications.${messageKey}`)
-                    .replace('{{value}}', message.value.toString())
+                    .replace('{{value}}', formatUnit(message.value))
                     .replace('{{account}}', account.alias)
 
                 showSystemNotification({ type: "info", message: notificationMessage })


### PR DESCRIPTION
# Description of change

The notification amounts were shown as raw iotas, they are now formatted with best units.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/315

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
