### PR TITLE
fix: Account rounding

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -290,7 +290,7 @@ export const updateAccountAfterBalanceChange = (
 
                 return Object.assign<WalletAccount, Partial<WalletAccount>, Partial<WalletAccount>>({} as WalletAccount, storedAccount, {
                     rawIotaBalance,
-                    balance: formatUnit(rawIotaBalance, 1),
+                    balance: formatUnit(rawIotaBalance, 2),
                     balanceEquiv: `${convertToFiat(
                         rawIotaBalance,
                         get(currencies)[CurrencyTypes.USD],

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -115,7 +115,7 @@
             depositAddress,
             alias,
             rawIotaBalance: balance,
-            balance: formatUnit(balance, 1),
+            balance: formatUnit(balance, 2),
             balanceEquiv: `${convertToFiat(
                 balance,
                 $currencies[CurrencyTypes.USD],


### PR DESCRIPTION
# Description of change

Accounts currently round balance to 0dp, this does not provide a very accurate representation of the balance in the account.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/321

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on accounts with fractional balances.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
