### PR TITLE
fix: Close native about when main window closes

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -152,6 +152,10 @@ function createWindow() {
     windows.main.webContents.on('will-navigate', _handleNavigation)
     windows.main.webContents.on('new-window', _handleNavigation)
 
+    windows.main.on('close', () => {
+        closeAboutWindow()
+    })
+
     /**
      * Handle permissions requests
      */
@@ -329,3 +333,11 @@ export const openAboutWindow = () => {
 
     return windows.about
 }
+
+export const closeAboutWindow = () => {
+    if (windows.about) {
+        windows.about.close()
+        windows.about = null
+    }
+}
+


### PR DESCRIPTION
# Description of change

The native Electron about window does not close if you close the main window.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/310

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Opened native window, then close the main app

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
