### PR TITLE
fix: Account index overflows the AccountColors list

### DIFF
--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -121,7 +121,7 @@
                 $currencies[CurrencyTypes.USD],
                 $exchangeRates[get(activeProfile).settings.currency]
             )} ${$activeProfile.settings.currency}`,
-            color: AccountColors[index],
+            color: AccountColors[index % AccountColors.length],
         })
     }
 


### PR DESCRIPTION
# Description of change

The account color was calculate from the account index looking up in an array, this had no bounds checking so randomly picked something from nowhere after 6 accounts.

## Links to any relevant issues

fixes: https://github.com/iotaledger/firefly/issues/300

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with more than 6 accounts

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
