### PR TITLE
feat: Add manual sync accounts

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -4,7 +4,7 @@ import { persistent } from 'shared/lib/helpers'
 import { _ } from 'shared/lib/i18n'
 import type { HistoryData, PriceData } from 'shared/lib/marketData'
 import { HistoryDataProps } from 'shared/lib/marketData'
-import { showSystemNotification } from 'shared/lib/notifications'
+import { showAppNotification, showSystemNotification } from 'shared/lib/notifications'
 import { activeProfile, updateProfile } from 'shared/lib/profile'
 import { formatUnit } from 'shared/lib/units'
 import { get, writable, Writable } from 'svelte/store'
@@ -573,4 +573,28 @@ export const getWalletBalanceHistory = (accountsBalanceHistory: BalanceHistory):
         })
     })
     return balanceHistory
+}
+
+/**
+ * Sync the accounts
+ */
+export function syncAccounts() {
+    isSyncing.set(true)
+    api.syncAccounts({
+        onSuccess(syncAccountsResponse) {
+            const syncedAccounts = syncAccountsResponse.payload
+
+            updateAccounts(syncedAccounts)
+
+            isSyncing.set(false)
+        },
+        onError(err) {
+            isSyncing.set(false)
+            const locale = get(_) as (string) => string
+            showAppNotification({
+                type: 'error',
+                message: locale(err.error),
+            })
+        },
+    })
 }

--- a/packages/shared/routes/dashboard/settings/views/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Advanced.svelte
@@ -3,12 +3,12 @@
     import { Button, Checkbox, Dropdown, Radio, Text } from 'shared/components'
     import { developerMode } from 'shared/lib/app'
     import { DEFAULT_NODE, DEFAULT_NODES } from 'shared/lib/network'
+    import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, updateProfile } from 'shared/lib/profile'
     import type { Node } from 'shared/lib/typings/client'
-    import { api, updateAccounts, wallet, WalletAccount } from 'shared/lib/wallet'
+    import { api, isSyncing, syncAccounts, wallet, WalletAccount } from 'shared/lib/wallet'
     import { get } from 'svelte/store'
-    import { showAppNotification } from 'shared/lib/notifications'
 
     export let locale
 
@@ -155,30 +155,6 @@
     function handleErrorLogClick() {
         openPopup({ type: 'errorLog' })
     }
-
-    function resyncAccounts() {
-        const _sync = () => {
-            api.syncAccounts({
-                onSuccess(syncAccountsResponse) {
-                    const syncedAccounts = syncAccountsResponse.payload
-
-                    updateAccounts(syncedAccounts)
-                },
-                onError(err) {
-                    showAppNotification({
-                        type: 'error',
-                        message: locale(err.error),
-                    })
-                },
-            })
-        }
-
-        if ($activeProfile.isStrongholdLocked) {
-            openPopup({ type: 'password', props: { onSuccess: _sync } })
-        } else {
-            _sync()
-        }
-    }
 </script>
 
 <div>
@@ -236,7 +212,7 @@
     <section id="resyncAccounts" class="w-3/4">
         <Text type="h4" classes="mb-3">{locale('views.settings.resyncAccounts.title')}</Text>
         <Text type="p" secondary classes="mb-5">{locale('views.settings.resyncAccounts.description')}</Text>
-        <Button classes="w-1/4" onClick={resyncAccounts}>{locale('actions.syncAll')}</Button>
+        <Button classes="w-1/4" onClick={syncAccounts} disabled={$isSyncing}>{locale('actions.syncAll')}</Button>
     </section>
     <hr class="border-t border-gray-100 w-full border-solid pb-5 mt-5 justify-center" />
     <section id="errorLog" class="w-3/4">

--- a/packages/shared/routes/dashboard/wallet/views/WalletActions.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletActions.svelte
@@ -61,26 +61,24 @@
         <div data-label="accounts" class="w-full h-full flex flex-col flex-no-wrap justify-start mb-6">
             <div class="flex flex-row mb-6 justify-between items-center">
                 <Text type="h5">{locale('general.accounts')}</Text>
-                <Button onClick={handleCreateClick} secondary small icon="plus" disabled={!$accountsLoaded}>
+                <Button onClick={handleCreateClick} secondary small icon="plus">
                     {locale('actions.create')}
                 </Button>
             </div>
-            {#if $accountsLoaded}
-                {#if $accounts.length > 0}
-                    <div class="grid grid-cols-{$accounts.length <= 2 ? $accounts.length : '3'} gap-2 w-full flex-auto">
-                        {#each $accounts as account}
-                            <AccountTile
-                                color={account.color}
-                                name={account.alias}
-                                balance={account.balance}
-                                balanceEquiv={account.balanceEquiv}
-                                size={$accounts.length >= 3 ? 's' : $accounts.length === 2 ? 'm' : 'l'}
-                                onClick={() => handleAccountClick(account.id)} />
-                        {/each}
-                    </div>
-                {:else}
-                    <Text>{locale('general.no_accounts')}</Text>
-                {/if}
+            {#if $accounts.length > 0}
+                <div class="grid grid-cols-{$accounts.length <= 2 ? $accounts.length : '3'} gap-2 w-full flex-auto">
+                    {#each $accounts as account}
+                        <AccountTile
+                            color={account.color}
+                            name={account.alias}
+                            balance={account.balance}
+                            balanceEquiv={account.balanceEquiv}
+                            size={$accounts.length >= 3 ? 's' : $accounts.length === 2 ? 'm' : 'l'}
+                            onClick={() => handleAccountClick(account.id)} />
+                    {/each}
+                </div>
+            {:else}
+                <Text>{locale('general.no_accounts')}</Text>
             {/if}
         </div>
         {#if $accounts.length > 0}

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -1,9 +1,8 @@
 <script lang="typescript">
-    import { ActivityRow, Text } from 'shared/components'
+    import { ActivityRow, Icon, Text } from 'shared/components'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
-    import type { AccountMessage, WalletAccount } from 'shared/lib/wallet'
-    import { selectedAccountId, selectedMessage } from 'shared/lib/wallet'
+    import { AccountMessage, isSyncing, selectedAccountId, selectedMessage, syncAccounts, WalletAccount } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import type { Readable, Writable } from 'svelte/store'
     import { get } from 'svelte/store'
@@ -12,7 +11,6 @@
 
     const accounts = getContext<Writable<WalletAccount[]>>('walletAccounts')
     const transactions = getContext<Readable<AccountMessage[]>>('walletTransactions')
-    const accountsLoaded = getContext<Writable<boolean>>('walletAccountsLoaded')
 
     function handleTransactionClick(transaction) {
         const sourceAccount = get(accounts).find((acc) => acc.index === transaction.account)
@@ -28,21 +26,24 @@
 </script>
 
 <div data-label="latest-transactions" class="h-full p-8 flex-grow flex flex-col">
-    <Text type="h4" classes="mb-5">{locale('general.latest_transactions')}</Text>
-    {#if $accountsLoaded}
-        <div class="overflow-y-auto flex-auto h-1 space-y-2">
-            {#if $transactions?.length}
-                {#each $transactions as transaction}
-                    <ActivityRow
-                        {...transaction}
-                        onClick={() => handleTransactionClick(transaction)}
-                        color={$accounts.find((acc) => acc.index === transaction.account)?.color} />
-                {/each}
-            {:else}
-                <div class="h-full flex flex-col items-center justify-center text-center">
-                    <Text secondary>{locale('general.no_recent_history')}</Text>
-                </div>
-            {/if}
-        </div>
-    {/if}
+    <div class="w-full flex flex-row justify-between items-start">
+        <Text type="p" smaler bold classes="mb-5">{locale('general.latest_transactions')}</Text>
+        <button on:click={syncAccounts} class:pointer-events-none={$isSyncing}>
+            <Icon icon="refresh" classes="{$isSyncing && 'animate-spin'} text-gray-500 dark:text-white" />
+        </button>
+    </div>
+    <div class="overflow-y-auto flex-auto h-1 space-y-2">
+        {#if $transactions?.length}
+            {#each $transactions as transaction}
+                <ActivityRow
+                    {...transaction}
+                    onClick={() => handleTransactionClick(transaction)}
+                    color={$accounts.find((acc) => acc.index === transaction.account)?.color} />
+            {/each}
+        {:else}
+            <div class="h-full flex flex-col items-center justify-center text-center">
+                <Text secondary>{locale('general.no_recent_history')}</Text>
+            </div>
+        {/if}
+    </div>
 </div>


### PR DESCRIPTION
# Description of change

Adds the ability to manual sync accounts with refresh on transactions panel.
The sync at login is also now done as a background task, which reduces the time it shows the busy screen for when logging in. This was very slow on large accounts (or stopped if no internet connection), making it look like the app had crashed, instead the manual sync indicator is active on login.
The settings->resync is also wired in to the same processing (possible we could remove this now that you can sync from the main UI)

# Fixes

https://github.com/iotaledger/firefly/issues/351 https://github.com/iotaledger/firefly/issues/331

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Test on windows, mac and ubuntu

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
