### PR TITLE
feat: disable "Add Node" option if there are no accounts in wallet

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Advanced.svelte
@@ -203,7 +203,16 @@
                     value: node.url,
                     label: node.url,
                 }))} />
-            <Button classes="w-1/4 mt-4" onClick={() => handleAddNodeClick()}>{locale('actions.add_node')}</Button>
+            
+            <!-- As client options (nodes) have association with accounts, disable "Add node" button if there are no accounts in wallet -->
+            <Button 
+            classes="w-1/4 mt-4"
+            
+             disabled={!$accounts.length} 
+             onClick={() => handleAddNodeClick()}
+             >
+             {locale('actions.add_node')}
+             </Button>
             <Button
                 classes="w-1/2 mt-4"
                 onClick={() => handleRemoveNodeClick()}


### PR DESCRIPTION
# Description of change

This PR disables `Add Node` button if there are no accounts in wallet. The node is associated with each account in wallet.rs and therefore we do not allow any new node to be added to wallet if there are zero accounts. 

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested macOS development

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
