### PR TITLE
fix: Disable user select of content

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -98,6 +98,8 @@
         &.scheme-dark {
             @apply bg-blue-900;
         }
+
+        @apply select-none;
     }
 </style>
 


### PR DESCRIPTION
# Description of change

A user can drag select all the content in the app, this applies -user-select: none to the root of the app.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/338

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
