### PR TITLE
feature(ci): Run Crowdin sync daily

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Sync translations from Crowdin
-        uses: crowdin/github-action@1.0.16
+        uses: crowdin/github-action@1.0.20
         with:
           upload_sources: true
           download_translations: true


### PR DESCRIPTION
# Description of change

- Run Crowdin sync daily at 6pm UTC
- Bump `crowdin/github-action` to 1.0.20

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
