### PR TITLE
fix(shared): Disable spellcheck on password field

### DIFF
--- a/packages/shared/components/inputs/Password.svelte
+++ b/packages/shared/components/inputs/Password.svelte
@@ -66,6 +66,7 @@
             {disabled}
             placeholder={placeholder || locale('general.password')} 
             {submitHandler}
+            spellcheck="false"
         />
         {#if showRevealToggle === true && !disabled}
             <button type="button" on:click={() => revealToggle()} tabindex="-1" class="absolute top-3">


### PR DESCRIPTION
# Description of change

Disables spellcheck on Password input field, as it is enabled by default in the "revealed" mode. The request to the spellchecker may present a route for the Stronghold password to leave Firefly.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on macOS in dev mode

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code