### PR TITLE
fix: Reset the settings router to the home view on mount

### DIFF
--- a/packages/shared/routes/dashboard/settings/Settings.svelte
+++ b/packages/shared/routes/dashboard/settings/Settings.svelte
@@ -3,7 +3,7 @@
     import { activeProfile } from 'shared/lib/profile'
     import { settingsRoute } from 'shared/lib/router'
     import { SettingsRoutes } from 'shared/lib/typings/routes'
-    import { createEventDispatcher, onMount } from 'svelte'
+    import { createEventDispatcher, onDestroy } from 'svelte'
     import { get } from 'svelte/store'
     import { SettingsHome, SettingsViewer } from './views'
 
@@ -23,7 +23,7 @@
         }
     }
 
-    onMount(() => {
+    onDestroy(() => {
         settingsRoute.set(SettingsRoutes.Init)
     })
 </script>


### PR DESCRIPTION
# Description of change

At the moment if you are in a subpage of the settings and switch back to wallet view, when you open settings again it is still in the subpage not the home page.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
