### PR TITLE
fix: Don't reset account when generating address

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -14,7 +14,7 @@
     const accounts = getContext<Writable<WalletAccount[]>>('walletAccounts')
     const currentAccount = getContext<Readable<WalletAccount>>('selectedAccount')
 
-    $: selectedAccount = $currentAccount || $accounts[0]
+    let selectedAccount = $currentAccount || $accounts[0]
 
     const handleDropdownSelect = (item) => {
         selectedAccount = item


### PR DESCRIPTION
# Description of change

The selected account was reactive so when the generated address updated its triggered an update in the selected account, and since no account was selected with selectedAccountId it reset to account[0].

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/472

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
