### PR TITLE
fix: Stronghold import failed with larger files

### DIFF
--- a/packages/shared/components/inputs/Dropzone.svelte
+++ b/packages/shared/components/inputs/Dropzone.svelte
@@ -2,37 +2,38 @@
     import { Text, Button } from 'shared/components'
 
     export let locale = undefined
-    export let onDrop = () => {}
+    export let onDrop = (buffer?, name?, path?) => {}
     export let extentionsLabel = ''
-    export let allowedExtensions = '*'
+    export let allowedExtensions
 
     let dropping = false
     let fileName = null
 
-    // TODO: allow drop only allowedExtensions
     const onFile = (e) => {
         e.preventDefault()
         dropping = false
 
         const file = e.dataTransfer ? e.dataTransfer.files[0] : e.target.files[0]
-        fileName = file.name
 
-        // TODO: should we limit by size?
-        if (!file || file.size > 100000) {
+        if (!file) {
             fileName = null
-            return onDrop(false)
+            return onDrop()
         }
 
-        const filePath = file.path
+        if (allowedExtensions && allowedExtensions.length > 0) {
+            const ext = /\.([0-9a-z]+)$/i.exec(file.name)
+            if (!ext || !allowedExtensions.includes(ext[1])) {
+                fileName = null
+                return onDrop()
+            }
+        }
+
+        fileName = file.name
 
         const reader = new FileReader()
-        reader.fileName = fileName
-        reader.filePath = filePath
 
         reader.onload = (e) => {
-            const buffer = e.target.result
-            const name = e.target.fileName
-            onDrop(buffer, name, filePath)
+            onDrop(e.target.result, file.name, file.path)
         }
 
         reader.readAsArrayBuffer(file)
@@ -88,7 +89,11 @@
                     17.6445L25 32C25 33.1045 25.8954 34 27 34L38 34C44.6274 34 50 28.6274 50 22C50 15.658 45.0802 10.4651 38.8489
                     10.0296C36.4827 4.15025 30.726 0 24 0C15.1634 0 8 7.16344 8 16L8.00009 16.0549C3.5001 16.5523 0 20.3674 0 25Z" />
             </svg>
-            <input class="absolute opacity-0 w-full h-full" type="file" on:change={onFile} accept={allowedExtensions} />
+            <input
+                class="absolute opacity-0 w-full h-full"
+                type="file"
+                on:change={onFile}
+                accept={allowedExtensions ? allowedExtensions.map((e) => `.${e}`).join(',') : '*'} />
             <Text type="h4">{locale('actions.dragDrop')}</Text>
             <Text classes="mb-12" type="p" secondary smaller>{extentionsLabel}</Text>
             <Button secondary onClick={onFile}>{locale('actions.chooseFile')}</Button>

--- a/packages/shared/routes/setup/import/views/FileImport.svelte
+++ b/packages/shared/routes/setup/import/views/FileImport.svelte
@@ -43,7 +43,7 @@
                 {onDrop}
                 {locale}
                 extentionsLabel={locale('actions.importExtentions')}
-                allowedExtensions=".kdbx,.stronghold" />
+                allowedExtensions={["kdbx", "stronghold"]} />
         </div>
         <div slot="leftpane__action" class="flex flex-row flex-wrap justify-between items-center space-x-4">
             <Button secondary classes="flex-1" onClick={() => handleBackClick()}>{locale('actions.back')}</Button>


### PR DESCRIPTION
# Description of change

Stronghold files with only a small amount of data could not be imported as there was a limit on the file size.
Cleaned up the drop zone code.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
