### PR TITLE
fix: Stop drop down scrolling whole page

### DIFF
--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -12,6 +12,7 @@
     export let onSelect = (_) => {}
 
     let dropdown = false
+    let navContainer
 
     items = sortItems ? items.sort((a, b) => (a.label > b.label ? 1 : -1)) : items
 
@@ -72,9 +73,11 @@
     on:click={(e) => {
         e.stopPropagation()
         dropdown = !dropdown
-        const elem = document.getElementById(value)
-        if (elem) {
-            elem.scrollIntoView()
+        if (dropdown) {
+            const elem = document.getElementById(value)
+            if (elem) {
+                navContainer.scrollTop = elem.offsetTop
+            }
         }
     }}
     use:clickOutside
@@ -88,7 +91,7 @@
         class="absolute w-full overflow-hidden pointer-events-none opacity-0 z-10 text-left 
         bg-gray-50 dark:bg-gray-800
             border border-solid border-gray-300 hover:border-gray-500 dark:border-gray-700 dark:hover:border-gray-700">
-        <div class="inner overflow-y-auto">
+        <div class="inner overflow-y-auto" bind:this={navContainer}>
             {#each items as item}
                 <button
                     class="relative flex items-center p-4 w-full whitespace-nowrap


### PR DESCRIPTION
# Description of change

If you open a dropdown when the page is already scroll, for example in a long settings page, the page scroll the drop down to the top to move it into view. This fix only scroll the nav container for the drop down.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
