### PR TITLE
fix(dashboard): account transaction list not showing all messages

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Account.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Account.svelte
@@ -13,9 +13,8 @@
 
     const account = getContext<Readable<WalletAccount>>('selectedAccount')
     const accounts = getContext<Writable<WalletAccount[]>>('walletAccounts')
-    const walletTransactions = getContext<Readable<AccountMessage[]>>('walletTransactions')
 
-    $: transactions = $account ? $walletTransactions.filter((tx) => tx.account === $account.index) : []
+    $: transactions = $account ? $account.messages : []
     $: navAccounts = $account ? $accounts.map(({ id, alias, color }) => ({ id, alias, color, active: $account.id === id })) : []
 
     let showActionsModal = false


### PR DESCRIPTION
# Description of change

The individual account transaction list shouldn't use the `walletTransactions` list since that is parsed to remove duplicated messages (internal transactions). This PR changes the list to use `account.messages` instead, which represents all account messages. We should do something about reattachments later.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Making an internal tx, opening the accounts tx list.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
