### PR TITLE
fix: Always load en as a backup language

### DIFF
--- a/packages/shared/lib/i18n.ts
+++ b/packages/shared/lib/i18n.ts
@@ -83,6 +83,16 @@ const setupI18n = (options = { withLocale: null }) => {
                 language: _locale
             })
             isDownloading.set(false)
+
+            // If we have not loaded "en" make sure we have it as a backup language
+            // in case the chosen language does not have all the translations
+            if (_locale !== "en" && !hasLoadedLocale("en")) {
+                const messagesFileUrl = MESSAGE_FILE_URL_TEMPLATE.replace('{locale}', 'en')
+                loadJson(messagesFileUrl)
+                    .then((messages) => {
+                        addMessages("en", messages)
+                    })
+            }
         })
     }
 }


### PR DESCRIPTION
# Description of change

Always load en as a backup locals if not main language

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with non en primary language

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
