### PR TITLE
fix(router): redirect to PIN route after importing stronghold backup

### DIFF
--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -163,8 +163,10 @@ export const routerNext = (event) => {
             nextRoute = AppRoute.Congratulations
             const { importType } = params
             walletSetupType.set(importType)
-            if (importType === SetupType.Mnemonic || importType === SetupType.Stronghold) {
+            if (importType === SetupType.Mnemonic) {
                 nextRoute = AppRoute.Secure
+            } else if (importType === SetupType.Stronghold) {
+                nextRoute = AppRoute.Protect
             } else if (importType === SetupType.Seed || importType === SetupType.Seedvault) {
                 nextRoute = AppRoute.Balance
             }


### PR DESCRIPTION
# Description of change

Currently when importing a profile from a stronghold backup, users are redirect to the "set stronghold password" page. This is not needed since the stronghold password is already defined (from the backup snapshot password). This PR changes the router to redirect to the "set PIN" page instead.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Importing a stronghold file, checking which path it goes, and logging out / in again into the created profile.
