### PR TITLE
fix: Radio button alignment changes with active state

### DIFF
--- a/packages/shared/components/inputs/Radio.svelte
+++ b/packages/shared/components/inputs/Radio.svelte
@@ -18,7 +18,7 @@
         }
         div {
             &.active {
-                @apply border-0;
+                @apply border-transparent;
                 @apply bg-blue-500;
             }
         }


### PR DESCRIPTION
# Description of change

By setting the border width to 0 when the radio button is active the position jumps by 1 pixel, so they don't align with the other buttons. Instead of using width 0, the color is set to transparent which maintains its position while still hiding the border.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
