### PR TITLE
fix: input floating label overlapping placeholder when disabled

### DIFF
--- a/packages/shared/components/inputs/Address.svelte
+++ b/packages/shared/components/inputs/Address.svelte
@@ -23,7 +23,7 @@
 
         &:disabled {
             &,
-            + floating-label {
+            + floating-label.floating-active {
                 @apply pointer-events-none;
                 @apply opacity-50;
             }

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -69,7 +69,7 @@
 
         &:disabled {
             &,
-            + floating-label {
+            + floating-label.floating-active {
                 @apply pointer-events-none;
                 @apply opacity-50;
             }


### PR DESCRIPTION
# Description of change

fix: input floating label overlapping placeholder when disabled

![image](https://user-images.githubusercontent.com/3624944/111903611-78db1e00-8a43-11eb-8185-5952ab3b1749.png)

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Electron Linux

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
