### PR TITLE
fix: ensure wallet route resets correctly on send

### DIFF
--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -3,9 +3,8 @@
     import { getInitials } from 'shared/lib/helpers'
     import { networkStatus } from 'shared/lib/networkStatus'
     import { activeProfile } from 'shared/lib/profile'
-    import { accountRoute, dashboardRoute, settingsRoute, walletRoute } from 'shared/lib/router'
-    import { AccountRoutes, SettingsRoutes, WalletRoutes, Tabs } from 'shared/lib/typings/routes'
-    import { selectedAccountId } from 'shared/lib/wallet'
+    import { dashboardRoute, settingsRoute, resetWalletRoute } from 'shared/lib/router'
+    import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
     import { onDestroy } from 'svelte'
     import { get } from 'svelte/store'
 
@@ -38,10 +37,7 @@
     }
 
     function openWallet() {
-        dashboardRoute.set(Tabs.Wallet)
-        walletRoute.set(WalletRoutes.Init)
-        accountRoute.set(AccountRoutes.Init)
-        selectedAccountId.set(null)
+        resetWalletRoute()
     }
 </script>
 

--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -1,5 +1,6 @@
 import { cleanupSignup, login, strongholdPassword, walletPin } from 'shared/lib/app'
 import { profiles } from 'shared/lib/profile'
+import { selectedAccountId } from 'shared/lib/wallet'
 import { AccountRoutes, AppRoute, SettingsRoutes, SetupType, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
 import { get, readable, writable } from 'svelte/store'
 import { deepLinkRequestActive } from './deepLinking'
@@ -224,4 +225,11 @@ export const resetRouter = () => {
     settingsRoute.set(SettingsRoutes.Init)
     dashboardRoute.set(Tabs.Wallet)
     deepLinkRequestActive.set(false)
+}
+
+export const resetWalletRoute = () => {
+    dashboardRoute.set(Tabs.Wallet)
+    walletRoute.set(WalletRoutes.Init)
+    accountRoute.set(AccountRoutes.Init)
+    selectedAccountId.set(null)
 }

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -8,7 +8,7 @@
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, isStrongholdLocked } from 'shared/lib/profile'
-    import { walletRoute } from 'shared/lib/router'
+    import { walletRoute, resetWalletRoute } from 'shared/lib/router'
     import { WalletRoutes } from 'shared/lib/typings/routes'
     import {
         AccountMessage,
@@ -246,7 +246,7 @@
                         setTimeout(() => {
                             sendParams.set({ address: '', amount: 0, message: '' })
                             isTransferring.set(false)
-                            walletRoute.set(WalletRoutes.Init)
+                            resetWalletRoute()
                         }, 3000)
                     },
                     onError(err) {
@@ -315,7 +315,7 @@
                     setTimeout(() => {
                         sendParams.set({ address: '', amount: 0, message: '' })
                         isTransferring.set(false)
-                        walletRoute.set(WalletRoutes.Init)
+                        resetWalletRoute()
                     }, 3000)
                 },
                 onError(err) {


### PR DESCRIPTION
# Description of change

- Moves wallet route reset to the libs
- Ensures chart resets after send

Fixes #521

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on Mac

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
