### PR TITLE
hotfix: correctly assign incoming property to message

### DIFF
--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -287,6 +287,8 @@
             isTransferring.set(true)
             api.internalTransfer(senderAccountId, receiverAccountId, amount, {
                 onSuccess(response) {
+                    const message = response.payload;
+                    
                     accounts.update((_accounts) => {
                         return _accounts.map((_account) => {
                             const isSenderAccount = _account.id === senderAccountId
@@ -297,8 +299,16 @@
                                     _account,
                                     {
                                         messages: [
-                                            Object.assign({}, response.payload, {
-                                                incoming: isReceiverAccount,
+                                            Object.assign({}, message, {
+                                                payload: Object.assign({}, message.payload, {
+                                                    data: Object.assign({}, message.payload.data, {
+                                                        essence: Object.assign({}, message.payload.data.essence, {
+                                                            data: Object.assign({}, message.payload.data.essence.data, {
+                                                                incoming: isReceiverAccount,
+                                                            }),
+                                                        }),
+                                                    }),
+                                                }),
                                             }),
                                             ..._account.messages,
                                         ],


### PR DESCRIPTION
# Description of change

Correctly assign `incoming` property to internal message. It is now part of the `message.payload`.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
