### PR TITLE
fix: Verify mnemonic on import

### DIFF
--- a/packages/shared/components/inputs/ImportTextfield.svelte
+++ b/packages/shared/components/inputs/ImportTextfield.svelte
@@ -70,7 +70,7 @@
                     error = true
                 } else {
                     try {
-                        await asyncVerifyMnemonic(words.join(' '))
+                        await asyncVerifyMnemonic(trimmedContent)
                         statusMessage = locale('views.importFromText.phraseDetected')
                         value = trimmedContent
                     } catch (err) {


### PR DESCRIPTION
# Description of change

Add additional verification of mnemonic on import text. Validates the words actually are a valid mnemonic using the wallet api, otherwise the import fails later in the process.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

![image](https://user-images.githubusercontent.com/5030334/111955978-80a1cd80-8aea-11eb-816f-016970601598.png)


![image](https://user-images.githubusercontent.com/5030334/111956200-c78fc300-8aea-11eb-90db-6e9fe47d2034.png)
