### PR TITLE
feat: Option for dropdowns to size to their max content length

### DIFF
--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { Icon, Text } from 'shared/components'
     import { clickOutside } from 'shared/lib/actions'
+    import { onMount } from 'svelte'
 
     export let value = undefined
     export let label = undefined
@@ -11,15 +12,24 @@
     export let items = []
     export let small = false
     export let onSelect = (_) => {}
+    export let contentWidth = false
 
     let dropdown = false
     let navContainer
 
     items = sortItems ? items.sort((a, b) => (a.label > b.label ? 1 : -1)) : items
 
+    let navWidth
+
     const handleClickOutside = () => {
         dropdown = false
     }
+
+    onMount(() => {
+        if (contentWidth) {
+            navWidth = `width: ${navContainer.clientWidth + 8}px`
+        }
+    })
 </script>
 
 <style type="text/scss">
@@ -119,7 +129,7 @@
 </style>
 
 <dropdown-input
-    class="w-full relative"
+    class="relative {contentWidth ? "" : "w-full"}"
     on:click={(e) => {
         e.stopPropagation()
         dropdown = !dropdown
@@ -135,7 +145,8 @@
     class:active={dropdown}
     class:small
     class:floating-active={value && label}
-    class:disabled>
+    class:disabled
+    style={navWidth}>
     <div
         class="selection relative flex items-center w-full whitespace-nowrap cursor-pointer
     bg-white dark:bg-gray-800 {dropdown ? 'border-blue-500' : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700'}">

--- a/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
@@ -105,14 +105,15 @@
         {/if}
         <div class="flex space-x-2">
             <span>
-                <Dropdown small value={$chartCurrency.toUpperCase()} items={currencyDropdown} onSelect={handleCurrencySelect} />
+                <Dropdown small value={$chartCurrency.toUpperCase()} items={currencyDropdown} onSelect={handleCurrencySelect} contentWidth={true} />
             </span>
             <span>
                 <Dropdown
                     small
                     value={TIMEFRAME_MAP[$chartTimeframe]}
                     items={Object.keys(TIMEFRAME_MAP).map((value) => ({ label: TIMEFRAME_MAP[value], value }))}
-                    onSelect={(newTimeframe) => chartTimeframe.set(newTimeframe.value)} />
+                    onSelect={(newTimeframe) => chartTimeframe.set(newTimeframe.value)}
+                    contentWidth={true} />
             </span>
         </div>
     </div>


### PR DESCRIPTION
# Description of change

When selecting values from the timescale dropdown above the charts the drop down changes size depending on the option selected. This new option for the dropdowns makes sure the components is sized to always allow the max length item by measuring the values in the dropdown.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
