### PR TITLE
fix: When deleting account and transferring funds switch to internal

### DIFF
--- a/packages/shared/components/popups/DeleteAccount.svelte
+++ b/packages/shared/components/popups/DeleteAccount.svelte
@@ -58,7 +58,7 @@
     }
     function handleMoveFundsClick() {
         closePopup()
-        sendParams.update((params) => ({ ...params, amount: $account.rawIotaBalance })) // TODO: fix input amount
+        sendParams.update((params) => ({ ...params, amount: $account.rawIotaBalance, isInternal: true }))
         accountRoute.set(AccountRoutes.Send)
     }
     function handleCancelClick() {

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -31,13 +31,14 @@ interface SendParams {
     amount: number
     address: string
     message: string
+    isInternal: boolean
 }
 
 /**
  * Input paramaters for sending transactions
  */
-export const sendParams = writable<SendParams>({ amount: 0, address: '', message: '' })
-export const clearSendParams = () => sendParams.set({ amount: 0, address: '', message: '' })
+export const sendParams = writable<SendParams>({ amount: 0, address: '', message: '', isInternal: false })
+export const clearSendParams = () => sendParams.set({ amount: 0, address: '', message: '', isInternal: false })
 
 /**
  * Determines whether a user is logged in

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { DashboardPane } from 'shared/components'
-    import { sendParams } from 'shared/lib/app'
+    import { clearSendParams } from 'shared/lib/app'
     import { appSettings } from 'shared/lib/appSettings'
     import { deepLinkRequestActive } from 'shared/lib/deepLinking'
     import { priceData } from 'shared/lib/marketData'
@@ -265,7 +265,7 @@
                         transferState.set('Complete')
 
                         setTimeout(() => {
-                            sendParams.set({ address: '', amount: 0, message: '' })
+                            clearSendParams()
                             isTransferring.set(false)
                             resetWalletRoute()
                         }, 3000)
@@ -344,7 +344,7 @@
                     transferState.set('Complete')
 
                     setTimeout(() => {
-                        sendParams.set({ address: '', amount: 0, message: '' })
+                        clearSendParams()
                         isTransferring.set(false)
                         resetWalletRoute()
                     }, 3000)

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { convertUnits, Unit } from '@iota/unit-converter'
     import { Address, Amount, Button, Dropdown, Icon, ProgressBar, Text } from 'shared/components'
-    import { sendParams } from 'shared/lib/app'
+    import { clearSendParams, sendParams } from 'shared/lib/app'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import type { TransferProgressEventType } from 'shared/lib/typings/events'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
@@ -23,7 +23,7 @@
         INTERNAL = 'moveFunds',
     }
 
-    let selectedSendType = SEND_TYPE.EXTERNAL
+    let selectedSendType = $sendParams.isInternal ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
     let unit = Unit.Mi
     let amount = $sendParams.amount === 0 ? '' : convertUnitsNoE($sendParams.amount, Unit.i, unit)
     let to = undefined
@@ -142,6 +142,7 @@
     }
 
     const handleBackClick = () => {
+        clearSendParams()
         accountRoute.set(AccountRoutes.Init)
         if (!$account) {
             walletRoute.set(WalletRoutes.Init)


### PR DESCRIPTION
# Description of change

If you are deleting an account that has funds the button says "Internal Transfer" but it doesn't actually switch to internal transfer. This fix adds an `isInternal` flag to send params which will initialise the UI to the correct location.

Fixes https://github.com/iotaledger/firefly/issues/545

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
