### PR TITLE
fix: Add spinner when creating account

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/CreateAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/CreateAccount.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Button, Input, Text } from 'shared/components'
+    import { Button, Input, Spinner, Text } from 'shared/components'
     import { walletRoute } from 'shared/lib/router'
     import { WalletRoutes } from 'shared/lib/typings/routes'
     import { wallet, MAX_ACCOUNT_NAME_LENGTH } from 'shared/lib/wallet'
@@ -56,7 +56,7 @@
     </div>
     <!-- Action -->
     {#if isBusy && !error}
-        <Text secondary classes="mb-3">{locale('general.creatingAccount')}</Text>
+        <Spinner busy={true} message={locale('general.creatingAccount')} classes="justify-center mb-4" />
     {/if}
     {#if !isBusy}
         <div class="flex flex-row justify-between px-2">


### PR DESCRIPTION
# Description of change

When creating account you don't always see the "creating" status message at the bottom, this adds the spinner which draw your eye to the message.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
