### PR TITLE
fix: Use pin control in settings

### DIFF
--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -2,7 +2,7 @@
     import { onMount } from 'svelte'
     import { createEventDispatcher } from 'svelte'
     import { validatePinFormat, PIN_LENGTH } from 'shared/lib/utils'
-    import { Icon } from 'shared/components'
+    import { Error, Icon } from 'shared/components'
 
     const dispatch = createEventDispatcher()
 
@@ -11,9 +11,15 @@
     export let disabled = false
     export let autofocus = false
     export let glimpse = false
+    export let smaller = false
+    export let error
 
     let inputs = new Array(PIN_LENGTH)
-    $: value = inputs.join('')
+    $: {
+        if (!value) {
+            inputs = new Array(PIN_LENGTH)
+        }
+    }
 
     let root
     let inputElements = []
@@ -40,6 +46,7 @@
                 break
             }
         }
+        value = inputs.join('')
     }
 
     const changeHandler = function (e, i) {
@@ -69,6 +76,7 @@
                         break
                     }
                 }
+                value = inputs.join('')
             }
         }
         e.preventDefault()
@@ -109,9 +117,6 @@
     pin-input {
         @apply cursor-pointer;
         @apply select-none;
-        @apply h-20;
-        padding-left: 50px;
-        padding-right: 32px;
 
         &:not(.disabled):focus-within,
         &:not(.disabled):hover {
@@ -176,41 +181,44 @@
     }
 </style>
 
-<pin-input
-    style="--pin-input-size: {PIN_LENGTH}"
-    class={`flex items-center justify-between w-full relative z-0 rounded-xl border border-solid
+<div class="w-full {classes}">
+    <pin-input
+        style="--pin-input-size: {PIN_LENGTH}"
+        class={`flex items-center justify-between w-full relative z-0 rounded-xl border border-solid
             bg-gray-50 dark:bg-gray-800 border-gray-300 dark:border-gray-700
-            ${classes}`}
-    class:disabled
-    bind:this={root}
-    on:click={selectFirstEmptyRoot}
-    on:focus={selectFirstEmptyRoot}
-    tabindex="0">
-    <div class="flex flex-row inputs-wrapper">
-        <div class="input-wrapper absolute items-center w-full flex flex-row flex-no-wrap justify-between">
-            {#each inputs as item, i}
-                <input
-                    bind:value={inputs[i]}
-                    maxLength="1"
-                    id={`input-${i}`}
-                    type="text"
-                    pattern="\d{1}"
-                    bind:this={inputElements[i]}
-                    class:active={!inputs[i] || inputs[i].length === 0}
-                    class:glimpse
-                    {disabled}
-                    on:keydown={(event) => changeHandler(event, i)}
-                    on:contextmenu|preventDefault
-                    placeholder="" />
-            {/each}
+            ${smaller ? 'h-14 pl-6 pr-4' : 'h-20 pl-12 pr-8'}`}
+        class:disabled
+        bind:this={root}
+        on:click={selectFirstEmptyRoot}
+        on:focus={selectFirstEmptyRoot}
+        tabindex="0">
+        <div class="flex flex-row inputs-wrapper">
+            <div class="input-wrapper absolute items-center w-full flex flex-row flex-no-wrap justify-between">
+                {#each inputs as item, i}
+                    <input
+                        bind:value={inputs[i]}
+                        maxLength="1"
+                        id={`input-${i}`}
+                        type="text"
+                        bind:this={inputElements[i]}
+                        class:active={!inputs[i] || inputs[i].length === 0}
+                        class:glimpse
+                        {disabled}
+                        on:keydown={(event) => changeHandler(event, i)}
+                        on:contextmenu|preventDefault />
+                {/each}
+            </div>
+            <div class="input-decorator-wrapper items-center absolute w-full flex flex-row flex-no-wrap justify-between">
+                {#each inputs as item, i}
+                    <input-decorator class:active={inputs[i] && inputs[i].length !== 0} class:disabled />
+                {/each}
+            </div>
         </div>
-        <div class="input-decorator-wrapper items-center absolute w-full flex flex-row flex-no-wrap justify-between">
-            {#each inputs as item, i}
-                <input-decorator class:active={inputs[i] && inputs[i].length !== 0} class:disabled />
-            {/each}
-        </div>
-    </div>
-    <button type="button" on:click={handleBackspace} {disabled}>
-        <Icon icon="backspace" classes="text-gray-500" />
-    </button>
-</pin-input>
+        <button type="button" on:click={handleBackspace} {disabled} tabindex="-1">
+            <Icon icon="backspace" classes={smaller ? 'text-blue-500' : 'text-gray-500'} />
+        </button>
+    </pin-input>
+    {#if error}
+        <Error {error} />
+    {/if}
+</div>

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Button, Checkbox, Dropdown, HR, Password, Spinner, Text } from 'shared/components'
+    import { Button, Checkbox, Dropdown, HR, Password, Pin, Spinner, Text } from 'shared/components'
     import { Electron } from 'shared/lib/electron'
     import { showAppNotification } from 'shared/lib/notifications'
     import passwordInfo from 'shared/lib/password'
@@ -40,6 +40,7 @@
     let confirmedPincode = ''
     let currentPincodeError = ''
     let newPincodeError = ''
+    let confirmationPincodeError = ''
     let pinCodeBusy = false
     let pinCodeMessage = ''
 
@@ -196,7 +197,7 @@
                 },
             })
         } else if (newPincode !== confirmedPincode) {
-            newPincodeError = locale('error.pincode.match')
+            confirmationPincodeError = locale('error.pincode.match')
         } else {
             pinCodeBusy = true
             pinCodeMessage = locale('general.pinCodeUpdating')
@@ -207,7 +208,7 @@
                 }, 2000)
                 pinCodeBusy = false
                 if (err) {
-                    newPincodeError = err
+                    currentPincodeError = err
                     pinCodeMessage = locale('general.pinCodeFailed')
                 } else {
                     pinCodeMessage = locale('general.pinCodeSuccess')
@@ -250,6 +251,7 @@
         newPasswordError = ''
         currentPincodeError = ''
         newPincodeError = ''
+        confirmationPincodeError = ''
         passwordChangeBusy = false
         passwordChangeMessage = ''
         pinCodeBusy = false
@@ -338,41 +340,18 @@
         <form on:submit={changePincode} id="pincode-change-form">
             <Text type="h4" classes="mb-3">{locale('views.settings.changePincode.title')}</Text>
             <Text type="p" secondary classes="mb-5">{locale('views.settings.changePincode.description')}</Text>
-            <Password
-                error={currentPincodeError}
-                classes="mb-4"
-                bind:value={currentPincode}
-                showRevealToggle
-                {locale}
-                maxlength="6"
-                integer
-                placeholder={locale('views.settings.changePincode.currentPincode')}
-                disabled={pinCodeBusy} />
-            <Password
-                error={newPincodeError}
-                classes="mb-4"
-                bind:value={newPincode}
-                showRevealToggle
-                {locale}
-                maxlength="6"
-                integer
-                placeholder={locale('views.settings.changePincode.newPincode')}
-                disabled={pinCodeBusy} />
-            <Password
-                classes="mb-5"
-                bind:value={confirmedPincode}
-                showRevealToggle
-                {locale}
-                maxlength="6"
-                integer
-                placeholder={locale('views.settings.changePincode.confirmNewPincode')}
-                disabled={pinCodeBusy} />
+
+            <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.currentPincode')}</Text>
+            <Pin smaller error={currentPincodeError} classes="mb-4" bind:value={currentPincode} disabled={pinCodeBusy} />
+            <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.newPincode')}</Text>
+            <Pin smaller error={newPincodeError} classes="mb-4" bind:value={newPincode} disabled={pinCodeBusy} />
+            <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.confirmNewPincode')}</Text>
+            <Pin smaller error={confirmationPincodeError} classes="mb-4" bind:value={confirmedPincode} disabled={pinCodeBusy} />
             <div class="flex flex-row items-center">
                 <Button
                     medium
                     type="submit"
                     form="pincode-change-form"
-                    classes="mb-5"
                     disabled={!currentPincode || !newPincode || !confirmedPincode || pinCodeBusy}>
                     {locale('views.settings.changePincode.action')}
                 </Button>

--- a/packages/shared/routes/setup/protect/views/Pin.svelte
+++ b/packages/shared/routes/setup/protect/views/Pin.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
-    import { OnboardingLayout, Illustration, Text, Button, Pin } from 'shared/components'
-    import { createEventDispatcher } from 'svelte'
+    import { Button, Illustration, OnboardingLayout, Pin, Text } from 'shared/components'
     import { validatePinFormat } from 'shared/lib/utils'
+    import { createEventDispatcher } from 'svelte'
 
     export let locale
     export let mobile
@@ -9,18 +9,27 @@
     export let busy = false
 
     let pinInput
+    let error = ''
 
     const dispatch = createEventDispatcher()
 
     $: confirmInput = pinCandidate !== null
-    $: valid = !!pinCandidate ? validatePinFormat(pinInput) && pinInput === pinCandidate : validatePinFormat(pinInput)
+    $: pinInput, (error = '')
 
     function onSubmit() {
-        if (valid) {
-            dispatch('next', !confirmInput ? { pinCandidate: pinInput } : null)
+        error = ''
+        if (validatePinFormat(pinInput)) {
+            if (confirmInput && pinInput !== pinCandidate) {
+                error = locale('error.pincode.match')
+            } else {
+                const pin = pinInput
+                pinInput = ''
+                dispatch('next', !confirmInput ? { pinCandidate: pin } : null)
+            }
         }
     }
     function handleBackClick() {
+        pinInput = ''
         dispatch('previous')
     }
 </script>
@@ -40,7 +49,8 @@
                     classes="w-full mx-auto block"
                     on:submit={onSubmit}
                     autofocus
-                    disabled={busy} />
+                    disabled={busy}
+                    {error} />
             {:else}
                 <Text type="h2" classes="mb-5">{locale('views.confirmPin.title')}</Text>
                 <Text type="p" secondary classes="mb-4">{locale('views.confirmPin.body1')}</Text>
@@ -51,11 +61,12 @@
                     classes="w-full mx-auto block"
                     on:submit={onSubmit}
                     autofocus
-                    disabled={busy} />
+                    disabled={busy}
+                    {error} />
             {/if}
         </div>
         <div slot="leftpane__action" class="flex flex-row flex-wrap justify-between items-center space-x-4">
-            <Button classes="flex-1" disabled={!valid || busy} onClick={() => onSubmit()}>
+            <Button classes="flex-1" disabled={!validatePinFormat(pinInput) || busy} onClick={() => onSubmit()}>
                 {locale(confirmInput ? 'actions.confirmPin' : 'actions.setPin')}
             </Button>
         </div>


### PR DESCRIPTION
# Description of change

Use the proper pin control in settings instead of a password box. This introduces a smaller version of the pin control which matches the style of standard inputs.
Also add error support for pin control, and corrects where the errors appear when validating the pin values.

## Link to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/458

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

![image](https://user-images.githubusercontent.com/5030334/112004443-19a00b00-8b22-11eb-837d-a2f5e4e7eee5.png)
