### PR TITLE
fix: Improve windows icon spacing

### DIFF
--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -39,6 +39,8 @@
     function openWallet() {
         resetWalletRoute()
     }
+
+    const hasTitleBar = document.body.classList.contains(`platform-win32`)
 </script>
 
 <style type="text/scss">
@@ -50,7 +52,7 @@
 
 <aside
     class="flex flex-col justify-center items-center bg-white dark:bg-gray-800 h-screen relative w-20 px-5 pb-9 pt-9 border-solid border-r border-gray-100 dark:border-gray-800">
-    <Logo classes="mb-10" width="48px" logo="logo-firefly" />
+    <Logo classes="logo mb-9 {hasTitleBar ? "mt-3": ""}" width="48px" logo="logo-firefly" />
     <nav class="flex flex-grow flex-col items-center justify-between">
         <button class={$dashboardRoute === Tabs.Wallet ? 'text-blue-500' : 'text-gray-500'} on:click={() => openWallet()}>
             <Icon icon="wallet" />


### PR DESCRIPTION
# Description of change

Improves the spacing for sidebar icons in windows mode.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
![image](https://user-images.githubusercontent.com/5030334/112009604-d1cfb280-8b26-11eb-8faa-c4c62f25b271.png)
