### PR TITLE
fix(ci): Build Linux on Ubuntu 18.04

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
# Description of change

GitHub recently completed their rollout of Ubuntu 20.04 and pointed `ubuntu-latest` to those agents. This is causing the Linux version to be linked with a newer version of `glibc`, which can lead to errors on Ubuntu 18.04 and Debian 10.

## Links to any relevant issues

Fixes #628 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code