### PR TITLE
fix: Error log is not available until after restart

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -4,28 +4,29 @@
     import { appSettings } from 'shared/lib/appSettings'
     import { refreshVersionDetails, versionDetails } from 'shared/lib/appUpdater'
     import { Electron } from 'shared/lib/electron'
+    import { addError } from 'shared/lib/errors'
     import { goto } from 'shared/lib/helpers'
-    import { dir, isLocaleLoaded, setupI18n, _ } from 'shared/lib/i18n'
+    import { dir, isLocaleLoaded, localize, setupI18n, _ } from 'shared/lib/i18n'
     import { fetchMarketData } from 'shared/lib/marketData'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
     import { openPopup, popupState } from 'shared/lib/popup'
     import { dashboardRoute, initRouter, routerNext, routerPrevious, walletRoute } from 'shared/lib/router'
     import { AppRoute, Tabs } from 'shared/lib/typings/routes'
     import {
+        Appearance,
         Backup,
         Balance,
         Congratulations,
         Dashboard,
         Import,
-        Appearance,
         Legal,
         Login,
         Migrate,
         Password,
         Protect,
+        Secure,
         Settings,
         Setup,
-        Secure,
         Splash,
         Welcome,
     } from 'shared/routes'
@@ -87,6 +88,9 @@
         })
         Electron.onEvent('menu-diagnostics', async () => {
             openPopup({ type: 'diagnostics' })
+        })
+        Electron.hookErrorLogger((err) => {
+            addError(err)
         })
     })
 </script>

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -3,9 +3,10 @@ const PincodeManager = require('./lib/pincodeManager')
 const DeepLinkManager = require('./lib/deepLinkManager')
 const NotificationManager = require('./lib/notificationManager')
 const { ipcRenderer, contextBridge } = require('electron')
-const { proxyApi } = require('../../shared/lib/walletApi')
 const { menuState } = require('./lib/menuState')
 const fs = require('fs');
+const { proxyApi } = require('shared/lib/shell/walletApi')
+const { hookErrorLogger } = require('shared/lib/shell/errorLogger')
 
 let activeProfileId = null
 
@@ -177,7 +178,11 @@ const Electron = {
             }
         })
     },
-
+    /**
+     * Hook the logger
+     * @returns 
+     */
+    hookErrorLogger
 }
 
 contextBridge.exposeInMainWorld('__WALLET_INIT__', {

--- a/packages/shared/components/popups/ErrorLog.svelte
+++ b/packages/shared/components/popups/ErrorLog.svelte
@@ -1,8 +1,8 @@
 <script lang="typescript">
     import { Button, Text } from 'shared/components'
-    import { errorLog } from 'shared/lib/events'
-    import { setClipboard } from 'shared/lib/utils'
+    import { errorLog } from 'shared/lib/errors'
     import { closePopup } from 'shared/lib/popup'
+    import { setClipboard } from 'shared/lib/utils'
 
     export let locale
 
@@ -16,8 +16,8 @@
 
         for (const err of $errorLog) {
             str.push(new Date(err.time).toUTCString())
-            str.push(`${err.type ?? 'EmptyType'}: ${err.message ? locale(err.message) : 'Missing error message'}`)
-            str.push("")
+            str.push(`${err.type}: ${err.message}`)
+            str.push('')
         }
 
         setClipboard(str.join('\r\n'))
@@ -39,8 +39,8 @@
             <div class="mb-7">
                 <Text type="p" secondary>{new Date(error.time).toUTCString()}</Text>
                 <Text type="p">
-                    {error.type ?? 'EmptyType'}:
-                    {error.message ? locale(error.message) : 'Missing error message'}
+                    {error.type}:
+                    {error.message}
                 </Text>
             </div>
         {/each}

--- a/packages/shared/lib/electron.ts
+++ b/packages/shared/lib/electron.ts
@@ -1,3 +1,4 @@
+import type { Error } from "./errors";
 import type { WalletRoutes } from "./typings/routes";
 
 export type VersionDetails = {
@@ -37,6 +38,7 @@ interface ElectronEventMap {
     "menu-check-for-update": void;
     "menu-error-log": void;
     "menu-diagnostics": void;
+    "log-error": void;
     "deep-link-params": string;
     "version-details": VersionDetails;
     "version-progress": NativeProgress;
@@ -57,6 +59,7 @@ export interface IElectron {
     close(): void;
     saveRecoveryKit(kitData: ArrayBuffer): Promise<void>;
     openUrl(url: string): void;
+    hookErrorLogger(logger: (error: Error) => void): void
 
     NotificationManager: INotificationManager;
 

--- a/packages/shared/lib/errors.ts
+++ b/packages/shared/lib/errors.ts
@@ -1,0 +1,16 @@
+import { persistent } from 'shared/lib/helpers'
+
+/**
+ * Error interface
+ */
+export interface Error {
+    time: number
+    type: string,
+    message: string
+}
+
+export const errorLog = persistent<Error[]>('errorLog', [])
+
+export const addError = (err: Error) => {
+    errorLog.update((log) => [err, ...log])
+}

--- a/packages/shared/lib/shell/errorLogger.ts
+++ b/packages/shared/lib/shell/errorLogger.ts
@@ -1,0 +1,12 @@
+let errorLogger
+
+export function hookErrorLogger(errLogger) {
+    errorLogger = errLogger
+}
+
+export function logError(err) {
+    console.error(err)
+    if (errorLogger) {
+        errorLogger(err)
+    }
+}

--- a/packages/shared/lib/shell/walletErrors.ts
+++ b/packages/shared/lib/shell/walletErrors.ts
@@ -1,6 +1,5 @@
-import type { ErrorTypes as ValidatorErrorTypes } from './validator'
-import type { ErrorType } from './typings/events'
-import { persistent } from 'shared/lib/helpers'
+import type { ErrorTypes as ValidatorErrorTypes } from '../validator'
+import type { ErrorType } from '../typings/events'
 
 const errorMessages: {
     [key in keyof typeof ErrorType]: string;
@@ -63,13 +62,3 @@ export const getErrorMessage = (type: ErrorType | ValidatorErrorTypes): string =
     return message ? message : 'error.global.generic'
 }
 
-/**
- * Error interface
- */
-interface Error {
-    time: number
-    type: ErrorType | ValidatorErrorTypes,
-    message: string
-}
-
-export const errorLog = persistent<Error[]>('errorLog', [])

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -6,14 +6,15 @@ import { HistoryDataProps } from 'shared/lib/marketData'
 import { DEFAULT_NODE, DEFAULT_NODES, network } from 'shared/lib/network'
 import { showAppNotification, showSystemNotification } from 'shared/lib/notifications'
 import { activeProfile, isStrongholdLocked } from 'shared/lib/profile'
-import type { Account, Account as BaseAccount, SyncedAccount } from 'shared/lib/typings/account'
+import type { Account, Account as BaseAccount, AccountToCreate, Balance, SyncedAccount } from 'shared/lib/typings/account'
 import type { Address } from 'shared/lib/typings/address'
 import type { Actor } from 'shared/lib/typings/bridge'
-import type { ErrorEventPayload, TransferProgressEventType } from 'shared/lib/typings/events'
+import type { BalanceChangeEventPayload, ConfirmationStateChangeEventPayload, ErrorEventPayload, Event, ReattachmentEventPayload, TransactionEventPayload, TransferProgressEventPayload, TransferProgressEventType } from 'shared/lib/typings/events'
 import type { Message } from 'shared/lib/typings/message'
 import { formatUnit } from 'shared/lib/units'
-import type { ApiClient } from 'shared/lib/walletApi'
 import { get, writable, Writable } from 'svelte/store'
+import type { ClientOptions } from './typings/client'
+import type { Duration, StrongholdStatus } from './typings/wallet'
 
 const ACCOUNT_COLORS = ['turquoise', 'green', 'orange', 'yellow', 'purple', 'pink']
 
@@ -128,7 +129,47 @@ export const transferState = writable<TransferProgressEventType | "Complete" | n
 
 export const isSyncing = writable<boolean>(false)
 
-export const api: ApiClient = window['__WALLET_API__']
+export const api: {
+    generateMnemonic(callbacks: { onSuccess: (response: Event<string>) => void, onError: (err: ErrorEventPayload) => void })
+    storeMnemonic(mnemonic: string, callbacks: { onSuccess: (response: Event<string>) => void, onError: (err: ErrorEventPayload) => void })
+    verifyMnemonic(mnemonic: string, callbacks: { onSuccess: (response: Event<string>) => void, onError: (err: ErrorEventPayload) => void })
+    getAccounts(callbacks: { onSuccess: (response: Event<Account[]>) => void, onError: (err: ErrorEventPayload) => void })
+    getBalance(accountId: string, callbacks: { onSuccess: (response: Event<Balance>) => void, onError: (err: ErrorEventPayload) => void })
+    latestAddress(accountId: string, callbacks: { onSuccess: (response: Event<Address>) => void, onError: (err: ErrorEventPayload) => void })
+    areLatestAddressesUnused(callbacks: { onSuccess: (response: Event<boolean>) => void, onError: (err: ErrorEventPayload) => void })
+    getUnusedAddress(accountId: string, callbacks: { onSuccess: (response: Event<Address>) => void, onError: (err: ErrorEventPayload) => void })
+    getStrongholdStatus(callbacks: { onSuccess: (response: Event<StrongholdStatus>) => void, onError: (err: ErrorEventPayload) => void })
+    syncAccounts(callbacks: { onSuccess: (response: Event<SyncedAccount[]>) => void, onError: (err: ErrorEventPayload) => void })
+    syncAccount(accountId: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    createAccount(account: AccountToCreate, callbacks: { onSuccess: (response: Event<Account>) => void, onError: (err: ErrorEventPayload) => void })
+    send(accountId: string, transfer: {
+        amount: number,
+        address: string,
+        remainder_value_strategy: {
+            strategy: string,
+        },
+        indexation: { index: string, data: number[] },
+    }, callbacks: { onSuccess: (response: Event<Message>) => void, onError: (err: ErrorEventPayload) => void })
+    internalTransfer(fromId: string, toId: string, amount: number, callbacks: { onSuccess: (response: Event<Message>) => void, onError: (err: ErrorEventPayload) => void })
+    setAlias(accountId: string, alias: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    lockStronghold(callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    setStrongholdPassword(password: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    changeStrongholdPassword(currentPassword: string, newPassword: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    backup(strongholdPath: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    restoreBackup(strongholdPath: string, password: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    removeAccount(accountId: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    setStoragePassword(newPinCode: string, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    removeStorage(callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    setClientOptions(clientOptions: ClientOptions, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+    setStrongholdPasswordClearInterval(interval: Duration, callbacks: { onSuccess: (response: Event<void>) => void, onError: (err: ErrorEventPayload) => void })
+
+    onStrongholdStatusChange(callbacks: { onSuccess: (response: Event<StrongholdStatus>) => void, onError: (err: ErrorEventPayload) => void })
+    onNewTransaction(callbacks: { onSuccess: (response: Event<TransactionEventPayload>) => void, onError: (err: ErrorEventPayload) => void })
+    onReattachment(callbacks: { onSuccess: (response: Event<ReattachmentEventPayload>) => void, onError: (err: ErrorEventPayload) => void })
+    onConfirmationStateChange(callbacks: { onSuccess: (response: Event<ConfirmationStateChangeEventPayload>) => void, onError: (err: ErrorEventPayload) => void })
+    onBalanceChange(callbacks: { onSuccess: (response: Event<BalanceChangeEventPayload>) => void, onError: (err: ErrorEventPayload) => void })
+    onTransferProgress(callbacks: { onSuccess: (response: Event<TransferProgressEventPayload>) => void, onError: (err: ErrorEventPayload) => void })
+} = window['__WALLET_API__']
 
 export const getStoragePath = (appPath: string, profileName: string): string => {
     return `${appPath}/${WALLET_STORAGE_DIRECTORY}/${profileName}`


### PR DESCRIPTION
# Description of change

The error log was handled in the walletApi which is in the shell preload code, so it did not have access to the svelte reactive error log. However, it did persist into local storage so was available after a restart.

Now the error reporting is hooked by the main app so that background errors propagate through the hook to the main window. Also separated the backend and frontend shared logic to make it clearer who is responsible for what.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/537

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
