### PR TITLE
fix: disable send no account

### DIFF
--- a/packages/shared/lib/utils.ts
+++ b/packages/shared/lib/utils.ts
@@ -152,7 +152,7 @@ export const isValidHttpsUrl = (url) => {
  * Validate an address given its prefix.
  * @param prefix The bech32 hrp prefix to match.
  * @param addr The address to validate.
- * @returns True if it matches the bech32 format.
+ * @returns The error string to use if it does not validate.
  */
 export const validateBech32Address = (prefix, addr) => {
     if (!addr || !addr.startsWith(prefix)) {

--- a/packages/shared/lib/utils.ts
+++ b/packages/shared/lib/utils.ts
@@ -155,7 +155,16 @@ export const isValidHttpsUrl = (url) => {
  * @returns True if it matches the bech32 format.
  */
 export const validateBech32Address = (prefix, addr) => {
-    return new RegExp(`^${prefix}1[02-9ac-hj-np-z]{59}$`).test(addr)
+    if (!addr || !addr.startsWith(prefix)) {
+        return localize('error.send.wrongAddressPrefix', {
+            values: {
+                prefix: prefix,
+            },
+        })
+    }
+    if (!new RegExp(`^${prefix}1[02-9ac-hj-np-z]{59}$`).test(addr)) {
+        return localize('error.send.wrongAddressFormat')
+    }
 }
 
 /**

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -629,6 +629,7 @@
             "wrongAddressPrefix": "Addresses start with the prefix {prefix}.",
             "wrongAddressFormat": "The address is not correctly formatted.",
             "insufficientFunds": "This account has insufficient funds.",
+            "noToAccount": "You have not selected an account to send the funds to.",
             "sendingDust": "You cannot send less than 1 Mi.",
             "leavingDust": "You cannot leave less than 1 Mi on your address." 
         },

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -626,7 +626,8 @@
             "amountNoFloat": "If units are `i` you cannot use decimal places.",
             "amountInvalidFormat": "The amount appears to be an invalid number.",
             "amountZero": "The amount must be greater than 0.",
-            "wrongAddressFormat": "Addresses start with the prefix {prefix}.",
+            "wrongAddressPrefix": "Addresses start with the prefix {prefix}.",
+            "wrongAddressFormat": "The address is not correctly formatted.",
             "insufficientFunds": "This account has insufficient funds.",
             "sendingDust": "You cannot send less than 1 Mi.",
             "leavingDust": "You cannot leave less than 1 Mi on your address." 

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -33,6 +33,7 @@
 
     // This looks odd but sets a reactive dependency on amount, so when it changes the error will clear
     $: amount, (amountError = '')
+    $: $sendParams.address, (addressError = '')
 
     let transferSteps: {
         [key in TransferProgressEventType | 'Complete']: {
@@ -119,12 +120,8 @@
                                 length: ADDRESS_LENGTH,
                             },
                         })
-                    } else if (!validateBech32Address(addressPrefix, $sendParams.address)) {
-                        addressError = locale('error.send.wrongAddressFormat', {
-                            values: {
-                                prefix: addressPrefix,
-                            },
-                        })
+                    } else {
+                        addressError = validateBech32Address(addressPrefix, $sendParams.address)
                     }
                 }
 
@@ -259,7 +256,12 @@
     {#if !$isTransferring}
         <div class="flex flex-row justify-between px-2">
             <Button secondary classes="-mx-2 w-1/2" onClick={() => handleBackClick()}>{locale('actions.cancel')}</Button>
-            <Button classes="-mx-2 w-1/2" onClick={() => handleSendClick()} disabled={selectedSendType === SEND_TYPE.INTERNAL && !to}>{locale('actions.send')}</Button>
+            <Button
+                classes="-mx-2 w-1/2"
+                onClick={() => handleSendClick()}
+                disabled={selectedSendType === SEND_TYPE.INTERNAL && !to}>
+                {locale('actions.send')}
+            </Button>
         </div>
     {/if}
     {#if $isTransferring}

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -259,7 +259,7 @@
     {#if !$isTransferring}
         <div class="flex flex-row justify-between px-2">
             <Button secondary classes="-mx-2 w-1/2" onClick={() => handleBackClick()}>{locale('actions.cancel')}</Button>
-            <Button classes="-mx-2 w-1/2" onClick={() => handleSendClick()}>{locale('actions.send')}</Button>
+            <Button classes="-mx-2 w-1/2" onClick={() => handleSendClick()} disabled={selectedSendType === SEND_TYPE.INTERNAL && !to}>{locale('actions.send')}</Button>
         </div>
     {/if}
     {#if $isTransferring}

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { convertUnits, Unit } from '@iota/unit-converter'
-    import { Address, Amount, Button, Dropdown, Icon, ProgressBar, Text } from 'shared/components'
+    import { Address, Amount, Button, Dropdown, Error, Icon, ProgressBar, Text } from 'shared/components'
     import { clearSendParams, sendParams } from 'shared/lib/app'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import type { TransferProgressEventType } from 'shared/lib/typings/events'
@@ -30,9 +30,11 @@
     let amountError = ''
     let addressPrefix = ($account ?? $accounts[0]).depositAddress.split('1')[0]
     let addressError = ''
+    let toError = ''
 
     // This looks odd but sets a reactive dependency on amount, so when it changes the error will clear
     $: amount, (amountError = '')
+    $: to, (toError = '')
     $: $sendParams.address, (addressError = '')
 
     let transferSteps: {
@@ -123,9 +125,13 @@
                     } else {
                         addressError = validateBech32Address(addressPrefix, $sendParams.address)
                     }
+                } else {
+                    if (!to) {
+                        toError = locale('error.send.noToAccount')
+                    }
                 }
 
-                if (!amountError && !addressError) {
+                if (!amountError && !addressError && !toError) {
                     $sendParams.amount = amountAsI
 
                     if (selectedSendType === SEND_TYPE.INTERNAL) {
@@ -240,6 +246,7 @@
                             items={accountsDropdownItems.filter((a) => from && a.id !== from.id)}
                             onSelect={handleToSelect}
                             disabled={$isTransferring || $accounts.length === 2} />
+                        <Error error={toError} />
                     {:else}
                         <Address
                             error={addressError}
@@ -258,8 +265,7 @@
             <Button secondary classes="-mx-2 w-1/2" onClick={() => handleBackClick()}>{locale('actions.cancel')}</Button>
             <Button
                 classes="-mx-2 w-1/2"
-                onClick={() => handleSendClick()}
-                disabled={selectedSendType === SEND_TYPE.INTERNAL && !to}>
+                onClick={() => handleSendClick()}>
                 {locale('actions.send')}
             </Button>
         </div>


### PR DESCRIPTION
# Description of change

When no account has been selected for an internal transfer the send is disabled.
Improves bech32 error reporting

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/715

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
