### PR TITLE
fix: Capture the tab focus inside the dialog popup

### DIFF
--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { Icon } from 'shared/components'
     import { closePopup } from 'shared/lib/popup'
+    import { onMount } from 'svelte'
     import { fade } from 'svelte/transition'
     import AddNode from './AddNode.svelte'
     import AddressHistory from './AddressHistory.svelte'
@@ -21,6 +22,8 @@
     export let hideClose = undefined
     export let fullScreen = undefined
     export let transition = true
+
+    let popupContent
 
     const types = {
         qr: QR,
@@ -45,6 +48,33 @@
             closePopup()
         }
     }
+
+    const focusableElements = () =>
+        [...popupContent.querySelectorAll('a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])')].filter(
+            (el) => !el.hasAttribute('disabled')
+        )
+
+    const handleFocusFirst = (e) => {
+        const elems = focusableElements()
+        if (elems && elems.length > 0) {
+            elems[elems.length - 1].focus()
+        }
+        e.preventDefault()
+    }
+    const handleFocusLast = (e) => {
+        const elems = focusableElements()
+        if (elems && elems.length > 0) {
+            elems[0].focus()
+        }
+        e.preventDefault()
+    }
+
+    onMount(() => {
+        const elems = focusableElements()
+        if (elems && elems.length > 0) {
+            elems[hideClose ? 0 : 1].focus()
+        }
+    })
 </script>
 
 <style type="text/scss">
@@ -66,13 +96,16 @@
     in:fade={{ duration: transition ? 100 : 0 }}
     class={`flex items-center justify-center fixed top-0 left-0 w-screen p-6
                 h-full overflow-hidden z-10 ${fullScreen ? 'bg-white dark:bg-gray-900' : 'bg-gray-800 bg-opacity-40'}`}>
+    <div tabindex="0" on:focus={handleFocusFirst} />
     <popup-content
+        bind:this={popupContent}
         class={`bg-white rounded-xl pt-6 px-8 pb-8 relative ${fullScreen ? 'full-screen dark:bg-gray-900' : 'dark:bg-gray-900'}`}>
         {#if !hideClose}
-            <button on:click={closePopup} class="absolute top-6 right-8">
-                <Icon icon="close" classes="text-gray-800 dark:text-white" />
+            <button on:click={closePopup} class="absolute top-6 right-8 text-gray-800 dark:text-white focus:text-blue-500">
+                <Icon icon="close" />
             </button>
         {/if}
         <svelte:component this={types[type]} {...props} {locale} />
     </popup-content>
+    <div tabindex="0" on:focus={handleFocusLast} />
 </popup>


### PR DESCRIPTION
# Description of change

At the moment continuously tabbing around a popup then moves the focus behind the popup shield.
This captures the focus within the popup.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/625

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
