### PR TITLE
fix: Get decimal separator from locale

### DIFF
--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -2,7 +2,13 @@
     "extends": "@tsconfig/svelte/tsconfig.json",
     "compilerOptions": {
         "isolatedModules": false,
-        "allowJs": true
+        "allowJs": true,
+        "lib": [
+            "DOM",
+            "ESNext"
+        ]
     },
-    "include": ["../shared/**/*.ts"]
+    "include": [
+        "../shared/**/*.ts"
+    ]
 }

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { Unit } from '@iota/unit-converter'
     import { Input, Text } from 'shared/components'
-    import { convertUnitsNoE } from 'shared/lib/units'
+    import { convertUnitsNoE, UNIT_MAP } from 'shared/lib/units'
 
     export let amount = undefined
     export let unit = Unit.Mi
@@ -56,6 +56,7 @@
         maxlength={17}
         {disabled}
         {autofocus}
+        maxDecimals={UNIT_MAP[unit].dp}
         integer={unit === Unit.i}
         float={unit !== Unit.i} />
     <actions class="absolute right-0 top-2.5 h-8 flex flex-row items-center text-12 text-gray-500 dark:text-white">

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -15,6 +15,7 @@
     export let autofocus = false
     export let submitHandler = undefined
     export let disabled = false
+    export let maxDecimals = undefined
 
     let inputElement
     let decimalSeparator = getDecimalSeparator()
@@ -38,6 +39,23 @@
                 } else if ('0123456789'.indexOf(e.key) < 0) {
                     // if float or interger we accept numbers
                     e.preventDefault()
+                } else if (float && maxDecimals !== undefined && '0123456789'.indexOf(e.key) >= 0) {
+                    // If max decimals are set only allow certain number after decimal separator
+                    const sepPos = value.indexOf(decimalSeparator)
+                    if (sepPos >= 0) {
+                        // If caret position is after the separator then check
+                        if (e.target.selectionEnd > sepPos) {
+                            // If sel start and end are different that means
+                            // the text has been highlighted for overwrite
+                            // if they are the same then it single insertion
+                            if (e.target.selectionStart === e.target.selectionEnd) {
+                                const numDecimals = value.length - sepPos - 1
+                                if (numDecimals >= maxDecimals) {
+                                    e.preventDefault()
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -53,6 +71,9 @@
                 const val = Number.parseFloat(pasteVal)
                 // Discard any number we can't parse as floats
                 if (Number.isNaN(val)) {
+                    e.preventDefault()
+                } else if (maxDecimals !== undefined) {
+                    value = Number(val.toFixed(maxDecimals)).toString()
                     e.preventDefault()
                 }
             } else if (integer) {

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Error } from 'shared/components'
+    import { getDecimalSeparator } from 'shared/lib/i18n'
     import { onMount } from 'svelte'
 
     export let value = ''
@@ -16,27 +17,28 @@
     export let disabled = false
 
     let inputElement
+    let decimalSeparator = getDecimalSeparator()
 
     const handleInput = (e) => {
         value = e.target.value
     }
 
     const onKeyPress = (e) => {
-        if (e.keyCode !== 8) {
-            const isReturn = e.keyCode === 13
-            if (isReturn && submitHandler) {
+        if (e.key !== 'Tab') {
+            const isEnter = e.key === 'Enter'
+            if (isEnter && submitHandler) {
                 submitHandler()
             }
             if (maxlength && value.length >= maxlength) {
                 e.preventDefault()
             }
-            if ((float || integer) && !isReturn) {
-                // if the input is float, we accept one dot
-                if (float && (e.keyCode === 46 || e.keyCode === 190)) {
-                    if (value.indexOf('.') >= 0) {
+            if ((float || integer) && !isEnter) {
+                // if the input is float, we accept one dot or comma depending on localization
+                if (float && (e.key === decimalSeparator)) {
+                    if (value.indexOf(decimalSeparator) >= 0) {
                         e.preventDefault()
                     }
-                } else if (e.keyCode < 48 || e.keyCode > 57) {
+                } else if ('0123456789'.indexOf(e.key) < 0) {
                     // if float or interger we accept numbers
                     e.preventDefault()
                 }

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -31,13 +31,40 @@
             }
             if ((float || integer) && !isEnter) {
                 // if the input is float, we accept one dot or comma depending on localization
-                if (float && (e.key === decimalSeparator)) {
+                if (float && e.key === decimalSeparator) {
                     if (value.indexOf(decimalSeparator) >= 0) {
                         e.preventDefault()
                     }
                 } else if ('0123456789'.indexOf(e.key) < 0) {
                     // if float or interger we accept numbers
                     e.preventDefault()
+                }
+            }
+        }
+    }
+
+    const onPaste = (e) => {
+        if (e.clipboardData && (float || integer)) {
+            const pasteVal = e.clipboardData.getData('text')
+            // Discard scientific notation or negative
+            if (pasteVal.indexOf('e') >= 0 || pasteVal.indexOf('-') >= 0) {
+                e.preventDefault()
+            } else if (float) {
+                const val = Number.parseFloat(pasteVal)
+                // Discard any number we can't parse as floats
+                if (Number.isNaN(val)) {
+                    e.preventDefault()
+                }
+            } else if (integer) {
+                // Dicard anything with a decimal separator
+                if (pasteVal.indexOf('.') >= 0 || pasteVal.indexOf(',') >= 0) {
+                    e.preventDefault()
+                } else {
+                    const val = Number.parseInt(pasteVal, 10)
+                    // Discard any number we can't parse as integers
+                    if (Number.isNaN(val)) {
+                        e.preventDefault()
+                    }
                 }
             }
         }
@@ -126,6 +153,7 @@
             class:floating-active={value && label}
             on:input={handleInput}
             on:keypress={onKeyPress}
+            on:paste={onPaste}
             {disabled}
             {...$$restProps}
             {placeholder} />

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -29,9 +29,6 @@
             if (isEnter && submitHandler) {
                 submitHandler()
             }
-            if (maxlength && value.length >= maxlength) {
-                e.preventDefault()
-            }
             if ((float || integer) && !isEnter) {
                 // if the input is float, we accept one dot or comma depending on localization
                 if (float && (e.key === decimalSeparator)) {

--- a/packages/shared/lib/i18n.ts
+++ b/packages/shared/lib/i18n.ts
@@ -147,8 +147,16 @@ const setLanguage = (item) => {
     setupI18n({ withLocale: locale })
 }
 
+const getDecimalSeparator = () => {
+    const numberWithDecimalSeparator = 1.1;
+    return Intl.NumberFormat(get(appSettings).language)
+        .formatToParts(numberWithDecimalSeparator)
+        .find(part => part.type === 'decimal')
+        .value;
+}
+
 const localize = get(_) as (string, values?) => string
 
 // We expose the svelte-i18n _ store so that our app has
 // a single API for i18n
-export { _, setupI18n, dir, isLocaleLoaded, localize, setLanguage }
+export { _, setupI18n, dir, isLocaleLoaded, localize, setLanguage, getDecimalSeparator }

--- a/packages/shared/lib/i18n.ts
+++ b/packages/shared/lib/i18n.ts
@@ -149,7 +149,7 @@ const setLanguage = (item) => {
 
 const getDecimalSeparator = () => {
     const numberWithDecimalSeparator = 1.1;
-    return Intl.NumberFormat(get(appSettings).language)
+    return Intl.NumberFormat(getLocaleFromNavigator())
         .formatToParts(numberWithDecimalSeparator)
         .find(part => part.type === 'decimal')
         .value;

--- a/packages/shared/lib/units.ts
+++ b/packages/shared/lib/units.ts
@@ -7,7 +7,7 @@ Big.NE = -20
 /**
  * IOTA Units Map
  */
-const UNIT_MAP: { [unit in Unit]: { val: number; dp: number } } = {
+export const UNIT_MAP: { [unit in Unit]: { val: number; dp: number } } = {
     i: { val: 1, dp: 0 },
     Ki: { val: 1000, dp: 3 },
     Mi: { val: 1000000, dp: 6 },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,9 +1,14 @@
 {
     "extends": "@tsconfig/svelte/tsconfig.json",
     "compilerOptions": {
-        "outDir": "lib/out",
-        "baseUrl": "./"
+        "outDir": "out",
+        "baseUrl": "./",
+        "lib": [
+            "DOM",
+            "ESNext"
+        ]
     },
-    "include": ["./lib"],
-    "exclude": ["lib/out"]
+    "include": [
+        "./lib"
+    ]
 }


### PR DESCRIPTION
# Description of change

Now uses the selected locale to find out the decimal separator instead of always using "."
The libs in tsconfig are updated as they otherwise don't know about FormatParts api.
Also fixes allowing overwriting value when content is at max length
Allows pasting of valid numbers only.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/639 https://github.com/iotaledger/firefly/issues/704 https://github.com/iotaledger/firefly/issues/670 https://github.com/iotaledger/firefly/issues/701 https://github.com/iotaledger/firefly/issues/632

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows in german

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
