### PR TITLE
fix: Last backup date within 24 hours

### DIFF
--- a/packages/shared/lib/helpers.ts
+++ b/packages/shared/lib/helpers.ts
@@ -92,15 +92,22 @@ export const diffDates = (firstDate: Date, secondDate: Date) => {
 
     if (years > 0) {
         return { unit: 'yearsAgo', value: years }
-    } else if (months > 0) {
+    } 
+    if (months > 0) {
         return { unit: 'monthsAgo', value: months }
-    } else if (weeks > 0) {
+    } 
+    if (weeks > 0) {
         return { unit: 'weeksAgo', value: weeks }
-    } else if (days > 0) {
+    } 
+    if (days > 0) {
         return { unit: 'daysAgo', value: days }
-    } else {
-        return { unit: 'today' }
+    } 
+
+    if (firstDate.getDate() !== secondDate.getDate()) {
+        return { unit: 'yesterday' }
     }
+
+    return { unit: 'today' }
 }
 
 /**

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -569,6 +569,7 @@
     },
     "dates": {
         "today": "Today",
+        "yesterday": "Yesterday",
         "daysAgo": "{time, plural, one {# day} other {# days}} ago",
         "weeksAgo": "{time, plural, one {# week} other {# weeks}} ago",
         "monthsAgo": "{time, plural, one {# month} other {# months}} ago",


### PR DESCRIPTION
# Description of change

When the diff for the last backup date was calculate it assumed less than 1 day means today, this can also mean yesterday so additional check is in place.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/723

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with backup less than 24 hours old

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
