### PR TITLE
fix: Disable contextmenu password

### DIFF
--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -134,7 +134,7 @@
             class:floating-active={value && label}
             on:input={handleInput}
             on:keypress={onKeyPress}
-            on:contextmenu={handleContexMenu}
+            on:contextmenu={handleContextMenu}
             {disabled}
             {...$$restProps}
             {placeholder} />

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -14,6 +14,7 @@
     export let autofocus = false
     export let submitHandler = undefined
     export let disabled = false
+    export let disableContextMenu = false
 
     let inputElement
 
@@ -41,6 +42,12 @@
                     e.preventDefault()
                 }
             }
+        }
+    }
+
+    const handleContexMenu = (e) => {
+        if (disableContextMenu) {
+            e.preventDefault()
         }
     }
 
@@ -127,6 +134,7 @@
             class:floating-active={value && label}
             on:input={handleInput}
             on:keypress={onKeyPress}
+            on:contextmenu={handleContexMenu}
             {disabled}
             {...$$restProps}
             {placeholder} />

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -45,7 +45,7 @@
         }
     }
 
-    const handleContexMenu = (e) => {
+    const handleContextMenu = (e) => {
         if (disableContextMenu) {
             e.preventDefault()
         }

--- a/packages/shared/components/inputs/Password.svelte
+++ b/packages/shared/components/inputs/Password.svelte
@@ -46,8 +46,10 @@
     {#if showStrengthLevel}
         <strength-meter class="flex flex-row justify-between items-center mb-2">
             <div class="flex flex-row">
-                <Text smaller secondary>{locale("general.passwordStrength")}:</Text>
-                <Text smaller overrideColor classes={`text-${STRENGTH_COLORS[strength]} uppercase ml-2`}>{locale(`general.passwordStrength${strength}`)}</Text>
+                <Text smaller secondary>{locale('general.passwordStrength')}:</Text>
+                <Text smaller overrideColor classes={`text-${STRENGTH_COLORS[strength]} uppercase ml-2`}>
+                    {locale(`general.passwordStrength${strength}`)}
+                </Text>
             </div>
             <div class="flex flex-row justify-end">
                 {#each Array(strengthLevels) as _, i}
@@ -67,6 +69,7 @@
             {disabled}
             placeholder={placeholder || locale('general.password')}
             {submitHandler}
+            disableContextMenu={true}
             spellcheck="false" />
         {#if showRevealToggle === true && !disabled}
             <button type="button" on:click={() => revealToggle()} tabindex="-1" class="absolute top-3 right-3">

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -12,25 +12,30 @@
     let password = ''
     let confirmedPassword = ''
     let error = ''
+    let errorConfirm = ''
     let busy = false
 
     const dispatch = createEventDispatcher()
 
     $: passwordStrength = zxcvbn(password)
+    $: password, confirmedPassword, (error = '', errorConfirm='')
 
     async function handleContinueClick() {
+        error = ''
+        errorConfirm = ''
+
         if (password.length > MAX_PASSWORD_LENGTH) {
             error = locale('error.password.length', {
                 values: {
                     length: MAX_PASSWORD_LENGTH,
                 },
             })
-        } else if (password !== confirmedPassword) {
-            error = locale('error.password.doNotMatch')
         } else if (passwordStrength.score !== 4) {
             error = passwordStrength.feedback.warning
                 ? locale(`error.password.${passwordInfo[passwordStrength.feedback.warning]}`)
                 : locale('error.password.tooWeak')
+        } else if (password !== confirmedPassword) {
+            errorConfirm = locale('error.password.doNotMatch')
         } else {
             try {
                 busy = true
@@ -73,6 +78,7 @@
                     autofocus
                     disabled={busy} />
                 <Password
+                    error={errorConfirm}
                     bind:value={confirmedPassword}
                     classes="mb-5"
                     {locale}


### PR DESCRIPTION
# Description of change

We now disallow using the cut/copy/paste on password controls.
Also improves the error handling on password page during setup

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/702

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
