### PR TITLE
fix: Cleanup in progress profiles

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Discord
     url: https://discord.iota.org/
     about: Please ask and answer questions here.
+  - name: Translation issues
+    url: https://crowdin.com/project/iota-firefly
+    about: Issues with translations can be resolved on Crowdin.
   - name: Security vulnerabilities
     url: security@iota.org
     about: Please report security vulnerabilities here.

--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -9,23 +9,24 @@
     import { fetchMarketData } from 'shared/lib/marketData'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
     import { openPopup, popupState } from 'shared/lib/popup'
+    import { cleanupInProgressProfiles} from 'shared/lib/profile'
     import { dashboardRoute, initRouter, routerNext, routerPrevious, walletRoute } from 'shared/lib/router'
     import { AppRoute, Tabs } from 'shared/lib/typings/routes'
     import {
+        Appearance,
         Backup,
         Balance,
         Congratulations,
         Dashboard,
         Import,
-        Appearance,
         Legal,
         Login,
         Migrate,
         Password,
         Protect,
+        Secure,
         Settings,
         Setup,
-        Secure,
         Splash,
         Welcome,
     } from 'shared/routes'
@@ -88,6 +89,8 @@
         Electron.onEvent('menu-diagnostics', async () => {
             openPopup({ type: 'diagnostics' })
         })
+
+        await cleanupInProgressProfiles()
     })
 </script>
 

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -18,6 +18,15 @@ const Electron = {
     updateActiveProfile(id) {
         activeProfileId = id
     },
+    removeProfileFolder(profilePath) {
+        ipcRenderer.invoke('get-path', 'userData').then((userDataPath) => {
+            // Check that the removing profile path matches the user data path
+            // so that we don't try and remove things outside out scope
+            if (profilePath.startsWith(userDataPath)) {
+                fs.rmdirSync(profilePath, { recursive: true })
+            }
+        })
+    },
     PincodeManager,
     DeepLinkManager,
     NotificationManager,

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -22,7 +22,7 @@ const Electron = {
     removeProfileFolder(profilePath) {
         ipcRenderer.invoke('get-path', 'userData').then((userDataPath) => {
             // Check that the removing profile path matches the user data path
-            // so that we don't try and remove things outside out scope
+            // so that we don't try and remove things outside our scope
             if (profilePath.startsWith(userDataPath)) {
                 fs.rmdirSync(profilePath, { recursive: true })
             }

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -41,6 +41,7 @@
                 } finally {
                     isBusy = false
                     closePopup()
+                    logout()
                 }
             },
             onError(err) {

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -4,7 +4,7 @@
     import { Electron } from 'shared/lib/electron'
     import { showAppNotification } from 'shared/lib/notifications'
     import { closePopup } from 'shared/lib/popup'
-    import { activeProfile, removeProfile } from 'shared/lib/profile'
+    import { activeProfile, removeProfile, removeProfileFolder } from 'shared/lib/profile'
     import { api } from 'shared/lib/wallet'
     import { get } from 'svelte/store'
 
@@ -31,6 +31,7 @@
                     logout()
 
                     removeProfile(ap.id)
+                    removeProfileFolder(ap.name)
 
                     isBusy = false
                     closePopup()

--- a/packages/shared/lib/electron.ts
+++ b/packages/shared/lib/electron.ts
@@ -50,6 +50,7 @@ export interface IElectron {
     getDiagnostics(): Promise<{ label: string; value: string; }[]>;
     getOS(): Promise<string>;
     updateActiveProfile(id: string): void;
+    removeProfileFolder(profilePath: string): Promise<void>;
     updateMenu(attribute: string, value: unknown): void;
     popupMenu(): void;
     maximize(): void;

--- a/packages/shared/lib/helpers.ts
+++ b/packages/shared/lib/helpers.ts
@@ -25,7 +25,11 @@ export const persistent = <T>(key: string, initialValue: T): Writable<T> => {
     const state = writable(value)
 
     state.subscribe(($value): void => {
-        localStorage.setItem(key, JSON.stringify($value))
+        if ($value === undefined || $value === null) {
+            localStorage.removeItem(key)
+        } else {
+            localStorage.setItem(key, JSON.stringify($value))
+        }
     })
 
     return state

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -231,7 +231,7 @@ export const cleanupInProgressProfiles = async () => {
     const inProgressProfile = get(profileInProgress)
     if (inProgressProfile) {
         profileInProgress.update(() => undefined)
-        await removeProfileFolder
+        await removeProfileFolder(inProgressProfile)
     }
 }
 
@@ -242,7 +242,7 @@ export const cleanupInProgressProfiles = async () => {
  *
  * @returns {void}
  */
- export const removeProfileFolder = async (profileName) => {
+export const removeProfileFolder = async (profileName) => {
     try {
         const userDataPath = await Electron.getUserDataPath()
         const profileStoragePath = getStoragePath(userDataPath, profileName)

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -2,7 +2,7 @@ import { AvailableExchangeRates } from 'shared/lib/currency'
 import { persistent } from 'shared/lib/helpers'
 import { DEFAULT_NODE } from 'shared/lib/network'
 import { generateRandomId } from 'shared/lib/utils'
-import { api } from 'shared/lib/wallet'
+import { api, getStoragePath } from 'shared/lib/wallet'
 import { derived, get, Readable, writable } from 'svelte/store'
 import { Electron } from './electron'
 import type { Node } from './typings/client'
@@ -41,6 +41,8 @@ export interface UserSettings {
 export const activeProfileId = writable<string | null>(null)
 
 export const profiles = persistent<Profile[]>('profiles', [])
+
+export const profileInProgress = persistent<string | undefined>('profileInProgress', undefined)
 
 export const newProfile = writable<Profile | null>(null)
 
@@ -116,18 +118,11 @@ export const createProfile = (profileName, isDeveloperProfile): Profile => {
  *
  * @returns {void}
  */
-export const disposeNewProfile = (): void => {
+export const disposeNewProfile = () => {
     const np = get(newProfile)
     if (np) {
         api.removeStorage({
             onSuccess() {
-                api.removeAccount(np.id, {
-                    onSuccess() {
-                    },
-                    onError(err) {
-                        console.error(err)
-                    },
-                })
             },
             onError(err) {
                 console.error(err)
@@ -214,5 +209,37 @@ export const updateProfile = (
                 return _profile
             })
         })
+    }
+}
+
+/**
+ * Cleanup any in progress profiles
+ *
+ * @method cleanupInProgressProfiles
+ *
+ * @returns {void}
+ */
+export const cleanupInProgressProfiles = async () => {
+    const inProgressProfile = get(profileInProgress)
+    if (inProgressProfile) {
+        profileInProgress.update(() => undefined)
+        await removeProfileFolder
+    }
+}
+
+/**
+ * Remove the profile folder from storage
+ *
+ * @method removeProfileFolder
+ *
+ * @returns {void}
+ */
+ export const removeProfileFolder = async (profileName) => {
+    try {
+        const userDataPath = await Electron.getUserDataPath()
+        const profileStoragePath = getStoragePath(userDataPath, profileName)
+        await Electron.removeProfileFolder(profileStoragePath)
+    } catch (err) {
+        console.error(err)
     }
 }

--- a/packages/shared/routes/setup/Congratulations.svelte
+++ b/packages/shared/routes/setup/Congratulations.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Button, Illustration, OnboardingLayout, Icon, Text } from 'shared/components'
-    import { newProfile, saveProfile, setActiveProfile } from 'shared/lib/profile'
+    import { newProfile, profileInProgress, saveProfile, setActiveProfile } from 'shared/lib/profile'
     import { createEventDispatcher, onMount } from 'svelte'
 
     export let locale
@@ -12,6 +12,7 @@
         saveProfile($newProfile)
         setActiveProfile($newProfile.id)
 
+        profileInProgress.set(undefined)
         newProfile.set(null)
     })
 

--- a/packages/shared/routes/setup/Setup.svelte
+++ b/packages/shared/routes/setup/Setup.svelte
@@ -4,7 +4,7 @@
     import { Electron } from 'shared/lib/electron'
     import { hasOnlyWhitespaces } from 'shared/lib/helpers'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { createProfile, disposeNewProfile, newProfile, profiles } from 'shared/lib/profile'
+    import { cleanupInProgressProfiles, createProfile, disposeNewProfile, newProfile, profileInProgress, profiles } from 'shared/lib/profile'
     import { SetupType } from 'shared/lib/typings/routes'
     import { getStoragePath, initialise, MAX_PROFILE_NAME_LENGTH } from 'shared/lib/wallet'
     import { createEventDispatcher } from 'svelte'
@@ -41,6 +41,7 @@
             }
 
             profile = createProfile(profileName, isDeveloperProfile)
+            profileInProgress.set(profileName)
 
             try {
                 busy = true
@@ -59,9 +60,10 @@
         }
     }
 
-    function handleBackClick() {
+    async function handleBackClick() {
         cleanupSignup()
         disposeNewProfile()
+        await cleanupInProgressProfiles()
         dispatch('previous')
     }
 </script>


### PR DESCRIPTION
# Description of change

If you exit the app during profile creation it leaves debris in the storage folder, so that any subsequent attempts to use the same profile name fail.

The in progress profile name is now persisted in the app storage and removed when a profile is completely setup. If on app start this value is still set it removes the folder.

This might have been the cause of multiple issues people were having if they got an error during setup and restarted the app.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with aborting the profile creation process at various stages.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
