### PR TITLE
fix: Don't reset the wallet route on a transfer completion

### DIFF
--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -38,7 +38,7 @@ interface SendParams {
  * Input paramaters for sending transactions
  */
 export const sendParams = writable<SendParams>({ amount: 0, address: '', message: '', isInternal: false })
-export const clearSendParams = () => sendParams.set({ amount: 0, address: '', message: '', isInternal: false })
+export const clearSendParams = (isInternal = false) => sendParams.set({ amount: 0, address: '', message: '', isInternal })
 
 /**
  * Determines whether a user is logged in

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -8,7 +8,7 @@
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, isStrongholdLocked } from 'shared/lib/profile'
-    import { resetWalletRoute, walletRoute } from 'shared/lib/router'
+    import { walletRoute } from 'shared/lib/router'
     import { WalletRoutes } from 'shared/lib/typings/routes'
     import {
         AccountMessage,
@@ -267,7 +267,6 @@
                         setTimeout(() => {
                             clearSendParams()
                             isTransferring.set(false)
-                            resetWalletRoute()
                         }, 3000)
                     },
                     onError(err) {
@@ -344,9 +343,8 @@
                     transferState.set('Complete')
 
                     setTimeout(() => {
-                        clearSendParams()
+                        clearSendParams(true)
                         isTransferring.set(false)
-                        resetWalletRoute()
                     }, 3000)
                 },
                 onError(err) {


### PR DESCRIPTION
# Description of change

On a send/internalTransfer completion we would reset the wallet routes and go back to the main view. If you had already navigated somewhere else this then navigated away from what you were viewing.

This removes the router reset, as even under normal circumstances you might want to make additional transfers so navigating away makes less sense.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/734

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows navigating to another location when transferring

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
