### PR TITLE
fix: Dropdown disabled contrast

### DIFF
--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -14,11 +14,68 @@
 
     let dropdown = false
     let navContainer
+    let divContainer
+    let focusedItem
 
     items = sortItems ? items.sort((a, b) => (a.label > b.label ? 1 : -1)) : items
 
     const handleClickOutside = () => {
         dropdown = false
+    }
+
+    const toggleDropDown = () => {
+        dropdown = !dropdown
+        if (dropdown) {
+            let elem = document.getElementById(value)
+            if (!elem) {
+                elem = navContainer.firstChild
+            }
+            if (elem) {
+                navContainer.scrollTop = elem.offsetTop
+                elem.focus()
+            }
+        } else {
+            divContainer.focus()
+            focusedItem = undefined
+        }
+    }
+
+    const focusItem = (itemId) => {
+        let elem = document.getElementById(itemId)
+        focusedItem = elem
+    }
+
+    const handleKey = (e) => {
+        if (!dropdown) {
+            // Note that space uses code not key, this is intentional
+            if (e.key === 'Enter' || e.key === 'ArrowDown' || e.code === 'Space') {
+                toggleDropDown()
+                e.preventDefault()
+            }
+        } else {
+            if (e.key === 'Escape') {
+                toggleDropDown()
+                e.preventDefault()
+            } else if (e.key === 'ArrowDown') {
+                if (focusedItem) {
+                    const children = [...navContainer.children]
+                    const idx = children.indexOf(focusedItem)
+                    if (idx < children.length - 1) {
+                        children[idx + 1].focus()
+                        e.preventDefault()
+                    }
+                }
+            } else if (e.key === 'ArrowUp') {
+                if (focusedItem) {
+                    const children = [...navContainer.children]
+                    const idx = children.indexOf(focusedItem)
+                    if (idx > 0) {
+                        children[idx - 1].focus()
+                        e.preventDefault()
+                    }
+                }
+            }
+        }
     }
 </script>
 
@@ -122,26 +179,21 @@
     class="w-full relative"
     on:click={(e) => {
         e.stopPropagation()
-        dropdown = !dropdown
-        if (dropdown) {
-            const elem = document.getElementById(value)
-            if (elem) {
-                navContainer.scrollTop = elem.offsetTop
-            }
-        }
+        toggleDropDown()
     }}
     use:clickOutside
     on:clickOutside={handleClickOutside}
+    on:keydown={handleKey}
     class:active={dropdown}
     class:small
     class:floating-active={value && label}
     class:disabled>
     <div
         class="selection relative flex items-center w-full whitespace-nowrap cursor-pointer
-    bg-white dark:bg-gray-800 {dropdown ? 'border-blue-500' : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700'}">
-        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white">
-            {value || placeholder}
-        </div>
+    bg-white dark:bg-gray-800 focus:border-blue-500 {dropdown ? 'border-blue-500' : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700'}"
+        tabindex="0"
+        bind:this={divContainer}>
+        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white">{value || placeholder}</div>
         <Icon
             icon={small ? 'small-chevron-down' : 'chevron-down'}
             width={small ? 16 : 24}
@@ -161,9 +213,12 @@
                 <button
                     class="relative flex items-center p-4 w-full whitespace-nowrap
                         {item[valueKey] === value && 'bg-gray-100 dark:bg-gray-700 dark:bg-opacity-20'} 
-                        hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20"
+                        hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20
+                        focus:bg-gray-200 dark:focus:bg-gray-800 dark:focus:bg-opacity-20"
                     id={item[valueKey]}
                     on:click={() => onSelect(item)}
+                    on:focus={() => focusItem(item[valueKey])}
+                    tabindex={dropdown ? 0 : -1}
                     class:active={item[valueKey] === value}><Text type="p" smaller>{item[valueKey]}</Text></button>
             {/each}
         </div>

--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -139,7 +139,7 @@
     <div
         class="selection relative flex items-center w-full whitespace-nowrap cursor-pointer
     bg-white dark:bg-gray-800 {dropdown ? 'border-blue-500' : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700'}">
-        <div class="w-full text-12 leading-140 {disabled ? 'text-gray-400 dark:text-gray-700' : 'text-gray-800 dark:text-white'}">
+        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white">
             {value || placeholder}
         </div>
         <Icon


### PR DESCRIPTION
# Description of change

The inner div of the dropdown had colors changed when it was disabled, this wasn't needed as the whole control had an opacity set, which resulted in making the inner content hard to read. The inner text color changes have been removed.

Added keyboard and focus support.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/716

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows in light and dark mode.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
