### PR TITLE
fix: Scroll bars too small to click on

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -109,7 +109,7 @@
         }
     }
     ::-webkit-scrollbar {
-        @apply w-1;
+        @apply w-3;
     }
     ::-webkit-scrollbar-thumb {
         @apply bg-gray-300;


### PR DESCRIPTION
# Description of change

The scroll bar width is very small and hard to click on, this increases the width.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/647

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
