### PR TITLE
fix: Multiple account navigation

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
@@ -1,9 +1,10 @@
 <script lang="typescript">
-    import { Button, Text, Icon } from 'shared/components'
+    import { Icon, Text } from 'shared/components'
     import { getInitials } from 'shared/lib/helpers'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
     import { selectedAccountId, selectedMessage } from 'shared/lib/wallet'
+    import { onDestroy, onMount } from 'svelte'
 
     export let locale
     export let accounts: {
@@ -12,6 +13,10 @@
         color: string
         active: boolean
     }[]
+
+    let rootElement
+    let buttonElement
+    let accountElement
 
     $: activeAccount = accounts.find((acc) => acc.active)
 
@@ -25,24 +30,58 @@
         walletRoute.set(WalletRoutes.Init)
         accountRoute.set(AccountRoutes.Init)
     }
+
+    const calculateWidth = () => {
+        // By setting the root element width it removes the need to use absolute positioning
+        rootElement.style.width = `${window.document.body.clientWidth - 160}px`
+        // If we don't show the scroll bar for the account container we align the accounts right
+        // if there is a scroll container they need to be left aligned
+        // We calculate if scroll is needed by comparing the account element width
+        // to that of the back button container, all 3 items across the navigation
+        // are equally sized
+        accountElement.parentNode.style.justifyContent =
+            accountElement.clientWidth > buttonElement.clientWidth ? 'flex-start' : 'flex-end'
+    }
+
+    onMount(() => {
+        calculateWidth()
+
+        window.addEventListener('resize', calculateWidth)
+    })
+
+    onDestroy(() => {
+        window.removeEventListener('resize', calculateWidth)
+    })
 </script>
 
-<div class="relative flex flex-row justify-center items-center w-full py-5">
-    <button data-label="back-button" class="absolute left-0" on:click={handleBackClick}>
-        <div class="flex items-center space-x-3">
-            <Icon icon="arrow-left" classes="text-blue-500" />
-            <Text type="h5">{locale('actions.back')}</Text>
+<style type="text/scss">
+    button {
+        + button {
+            @apply ml-4;
+        }
+    }
+</style>
+
+<div bind:this={rootElement} class="py-3">
+    <div class="flex flex-row justify-between items-start">
+        <button data-label="back-button" class="flex-1 mt-1" on:click={handleBackClick} bind:this={buttonElement}>
+            <div class="flex items-center space-x-3">
+                <Icon icon="arrow-left" classes="text-blue-500" />
+                <Text type="h5">{locale('actions.back')}</Text>
+            </div>
+        </button>
+        <Text type="h3" classes="flex-1 text-center mt-1">{activeAccount.alias}</Text>
+        <div class="flex-1 flex flex-row justify-end ml-8 overflow-x-auto">
+            <div class="flex flex-row pb-1" bind:this={accountElement}>
+                {#each accounts as acc}
+                    <button
+                        on:click={() => handleAccountClick(acc.id)}
+                        class="w-10 h-10 rounded-xl p-2 text-14 leading-100 font-bold text-center
+            {activeAccount.id === acc.id ? `bg-${acc.color}-500 text-white` : 'bg-gray-200 dark:bg-gray-700 text-gray-500'} 
+            hover:bg-{acc.color}-500 hover:text-white">{getInitials(acc.alias, 2)}
+                    </button>
+                {/each}
+            </div>
         </div>
-    </button>
-    <Text type="h3" classes="text-center">{activeAccount.alias}</Text>
-    <div class="absolute right-0 flex flex-row space-x-4 account-switch">
-        {#each accounts as acc}
-            <button
-                on:click={() => handleAccountClick(acc.id)}
-                class="w-10 h-10 rounded-xl p-2 text-14 leading-100 font-bold text-center
-                {activeAccount.id === acc.id ? `bg-${acc.color}-500 text-white` : 'bg-gray-200 dark:bg-gray-700 text-gray-500'} 
-                hover:bg-{acc.color}-500 hover:text-white">{getInitials(acc.alias, 2)}
-            </button>
-        {/each}
     </div>
 </div>

--- a/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
@@ -62,26 +62,24 @@
     }
 </style>
 
-<div bind:this={rootElement} class="py-3">
-    <div class="flex flex-row justify-between items-start">
-        <button data-label="back-button" class="flex-1 mt-1" on:click={handleBackClick} bind:this={buttonElement}>
-            <div class="flex items-center space-x-3">
-                <Icon icon="arrow-left" classes="text-blue-500" />
-                <Text type="h5">{locale('actions.back')}</Text>
-            </div>
-        </button>
-        <Text type="h3" classes="flex-1 text-center mt-1 mx-5">{activeAccount.alias}</Text>
-        <div class="flex-1 flex flex-row justify-end overflow-x-auto">
-            <div class="flex flex-row pb-1" bind:this={accountElement}>
-                {#each accounts as acc}
-                    <button
-                        on:click={() => handleAccountClick(acc.id)}
-                        class="w-10 h-10 rounded-xl p-2 text-14 leading-100 font-bold text-center
+<div class="flex flex-row justify-between items-start py-3" bind:this={rootElement}>
+    <button data-label="back-button" class="flex-1 mt-1" on:click={handleBackClick} bind:this={buttonElement}>
+        <div class="flex items-center space-x-3">
+            <Icon icon="arrow-left" classes="text-blue-500" />
+            <Text type="h5">{locale('actions.back')}</Text>
+        </div>
+    </button>
+    <Text type="h3" classes="flex-1 text-center mt-1 mx-5">{activeAccount.alias}</Text>
+    <div class="flex-1 flex flex-row justify-end overflow-x-auto">
+        <div class="flex flex-row pb-1" bind:this={accountElement}>
+            {#each accounts.concat(accounts).concat(accounts).concat(accounts).concat(accounts) as acc}
+                <button
+                    on:click={() => handleAccountClick(acc.id)}
+                    class="w-10 h-10 rounded-xl p-2 text-14 leading-100 font-bold text-center
             {activeAccount.id === acc.id ? `bg-${acc.color}-500 text-white` : 'bg-gray-200 dark:bg-gray-700 text-gray-500'} 
             hover:bg-{acc.color}-500 hover:text-white">{getInitials(acc.alias, 2)}
-                    </button>
-                {/each}
-            </div>
+                </button>
+            {/each}
         </div>
     </div>
 </div>

--- a/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
@@ -70,8 +70,8 @@
                 <Text type="h5">{locale('actions.back')}</Text>
             </div>
         </button>
-        <Text type="h3" classes="flex-1 text-center mt-1">{activeAccount.alias}</Text>
-        <div class="flex-1 flex flex-row justify-end ml-8 overflow-x-auto">
+        <Text type="h3" classes="flex-1 text-center mt-1 mx-5">{activeAccount.alias}</Text>
+        <div class="flex-1 flex flex-row justify-end overflow-x-auto">
             <div class="flex flex-row pb-1" bind:this={accountElement}>
                 {#each accounts as acc}
                     <button


### PR DESCRIPTION
# Description of change

When you have a multitude of accounts the account navigation overflows all over the place. 
This adds a scroll bar if there is not enough space to display them, or right aligned if there is space.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/303

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with lots of accounts, see screenshot

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

![image](https://user-images.githubusercontent.com/5030334/112649392-af050d00-8e4a-11eb-9187-9ba404c982c2.png)

![image](https://user-images.githubusercontent.com/5030334/112649503-cd6b0880-8e4a-11eb-8f6e-863f9cab1ec5.png)
