### PR TITLE
fix: Add ellipsis to account name on tile if it overflows

### DIFF
--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -26,9 +26,11 @@
 <button
     on:click={onClick}
     class="size-{size} group rounded-xl bg-gray-100 dark:bg-gray-900 hover:bg-{color}-500 font-400 flex flex-col justify-between text-left p-{size === 's' ? '3' : '6'}">
-    <Text bold smaller={size === 's'} overrideColor classes="mb-2 text-gray-800 dark:text-white group-hover:text-white">
-        {name}
-    </Text>
+    <div class="w-full">
+        <Text bold smaller={size === 's'} overrideColor classes="mb-2 text-gray-800 dark:text-white group-hover:text-white overflow-hidden overflow-ellipsis">
+            {name}
+        </Text>
+    </div>
     <div
         class="flex {size === 'l' ? 'flex-row space-x-4' : 'flex-col space-y-1'} justify-between w-full flex-{size === 'l' ? 'nowrap' : 'wrap'}">
         <Text smaller overrideColor classes="block text-gray-800 dark:text-white group-hover:text-white">{balance}</Text>


### PR DESCRIPTION
# Description of change

If the account name overflows the account tile width we use ellipsis. see pic

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/650

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with long account names

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


![image](https://user-images.githubusercontent.com/5030334/112657704-f7c0c400-8e52-11eb-9b86-cccdb915d489.png)
