### PR TITLE
fix: Style the amount drop down like other dropdowns

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -17,6 +17,9 @@
     const Units = Object.values(Unit).filter((x) => x !== 'Pi')
 
     let dropdown = false
+    let navContainer
+    let unitsButton
+    let focusedItem
 
     const clickOutside = () => {
         dropdown = false
@@ -25,18 +28,65 @@
         amount = convertUnitsNoE(amount, unit, index)
         unit = index
     }
+
+    const focusItem = (itemId) => {
+        let elem = document.getElementById(itemId)
+        focusedItem = elem
+    }
+
+    const handleKey = (e) => {
+        if (dropdown) {
+            if (e.key === 'Escape') {
+                toggleDropDown()
+                e.preventDefault()
+            } else if (e.key === 'ArrowDown') {
+                if (focusedItem) {
+                    const children = [...navContainer.children]
+                    const idx = children.indexOf(focusedItem)
+                    if (idx < children.length - 1) {
+                        children[idx + 1].focus()
+                        e.preventDefault()
+                    }
+                }
+            } else if (e.key === 'ArrowUp') {
+                if (focusedItem) {
+                    const children = [...navContainer.children]
+                    const idx = children.indexOf(focusedItem)
+                    if (idx > 0) {
+                        children[idx - 1].focus()
+                        e.preventDefault()
+                    }
+                }
+            }
+        }
+    }
+
+    const toggleDropDown = () => {
+        dropdown = !dropdown
+        if (dropdown) {
+            let elem = document.getElementById(unit)
+            if (!elem) {
+                elem = navContainer.firstChild
+            }
+            if (elem) {
+                elem.focus()
+            }
+        } else {
+            unitsButton.focus()
+            focusedItem = undefined
+        }
+    }
 </script>
 
 <style type="text/scss">
     amount-input {
         nav {
-            &.active {
+            &.dropdown {
                 @apply opacity-100;
                 @apply pointer-events-auto;
             }
         }
-    }
-    amount-input {
+
         &.disabled {
             @apply pointer-events-none;
             actions {
@@ -47,7 +97,7 @@
 </style>
 
 <svelte:window on:click={clickOutside} />
-<amount-input class:disabled class="relative block {classes}">
+<amount-input class:disabled class="relative block {classes}" on:keydown={handleKey}>
     <Input
         {error}
         label={label || locale('general.amount')}
@@ -57,7 +107,9 @@
         {disabled}
         {autofocus}
         integer={unit === Unit.i}
-        float={unit !== Unit.i} />
+        float={unit !== Unit.i}
+        style={dropdown ? "border-bottom-right-radius: 0" : ""} 
+        isFocused={dropdown} />
     <actions class="absolute right-0 top-2.5 h-8 flex flex-row items-center text-12 text-gray-500 dark:text-white">
         <button
             on:click={maxClick}
@@ -67,26 +119,30 @@
             on:click={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
-                dropdown = !dropdown
+                toggleDropDown()
             }}
+            bind:this={unitsButton}
             class={`w-10 h-full text-center px-2 border-l border-solid border-gray-300 dark:border-gray-700 ${disabled ? 'cursor-auto' : 'hover:text-blue-500 focus:text-blue-500 cursor-pointer'}`}
             {disabled}>
             {unit}
-            {#if !disabled && dropdown}
-                <nav
-                    class="absolute w-10 overflow-y-auto z-10 text-left top-11 right-0 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-300 dark:border-gray-700">
-                    {#each Units as _unit}
-                        <button
-                            id={_unit}
-                            class="text-center w-full py-2 {unit === _unit && 'bg-gray-100 dark:bg-gray-700 dark:bg-opacity-20'} 
-                            hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20"
-                            on:click={() => onSelect(_unit)}
-                            class:active={unit === _unit}>
-                            <Text type="p" smaller>{_unit}</Text>
-                        </button>
-                    {/each}
-                </nav>
-            {/if}
+            <nav
+                class="absolute w-10 overflow-y-auto pointer-events-none opacity-0 z-10 text-left top-10 right-0 rounded-b-lg bg-white dark:bg-gray-800 border border-solid border-blue-500"
+                class:dropdown
+                bind:this={navContainer}>
+                {#each Units as _unit}
+                    <button
+                        id={_unit}
+                        class="text-center w-full py-2 {unit === _unit && 'bg-gray-100 dark:bg-gray-700 dark:bg-opacity-20'} 
+                        hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20
+                        focus:bg-gray-200 dark:focus:bg-gray-800 dark:focus:bg-opacity-20"
+                        on:click={() => onSelect(_unit)}
+                        on:focus={() => focusItem(_unit)}
+                        class:active={unit === _unit}
+                        tabindex={dropdown ? 0 : -1}>
+                        <Text type="p" smaller>{_unit}</Text>
+                    </button>
+                {/each}
+            </nav>
         </button>
     </actions>
 </amount-input>

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -4,6 +4,7 @@
 
     export let value = ''
     export let classes = ''
+    export let style = undefined
     export let label = undefined
     export let placeholder = undefined
     export let type = 'text'
@@ -14,6 +15,7 @@
     export let autofocus = false
     export let submitHandler = undefined
     export let disabled = false
+    export let isFocused = false
 
     let inputElement
 
@@ -123,13 +125,16 @@
             {maxlength}
             class="w-full text-12 leading-140 border border-solid
                 {disabled ? 'text-gray-400 dark:text-gray-700' : 'text-gray-800 dark:text-white'} bg-white dark:bg-gray-800 
-                {error ? 'border-red-300 hover:border-red-500 focus:border-red-500' : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-blue-500 dark:focus:border-gray-600'}"
+                {isFocused ? "border-blue-500": (
+                    error ? 'border-red-300 hover:border-red-500 focus:border-red-500' : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-blue-500 dark:focus:border-gray-600'
+                )}"
             class:floating-active={value && label}
             on:input={handleInput}
             on:keypress={onKeyPress}
             {disabled}
             {...$$restProps}
-            {placeholder} />
+            {placeholder}
+            style={style} />
         {#if label}
             <floating-label class:floating-active={value && label}>{label}</floating-label>
         {/if}


### PR DESCRIPTION
# Description of change

The amount drop down for units it was not styled like other dropdowns.
Also adds keyboard support.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/631

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

![image](https://user-images.githubusercontent.com/5030334/112817965-ed810e80-907a-11eb-9324-3d4b6c80ac72.png)
