### PR TITLE
fix: Enforce stronghold extension of save dialog

### DIFF
--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -22,7 +22,13 @@ const Electron = {
     DeepLinkManager,
     NotificationManager,
     getStrongholdBackupDestination: (defaultPath) => {
-        return ipcRenderer.invoke('show-save-dialog', { properties: ['createDirectory', 'showOverwriteConfirmation'], defaultPath }).then((result) => {
+        return ipcRenderer.invoke('show-save-dialog', { 
+            properties: ['createDirectory', 'showOverwriteConfirmation'], 
+            defaultPath,
+            filters: [
+                { name: 'Stronghold Files', extensions: ['stronghold'] }
+            ]
+        }).then((result) => {
             if (result.canceled) {
                 return null
             }


### PR DESCRIPTION
# Description of change

The save dialog for stronghold now enforces the `.stronghold` extension.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/539

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows trying to save with different extension will still append stronghold.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
