### PR TITLE
fix: Update display if sendParams updated externally

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -79,7 +79,7 @@
     $: from = $account ? format($account) : accountsDropdownItems[0]
 
     const handleSendTypeClick = (type) => {
-        selectedSendType = type
+        $sendParams.isInternal = type === SEND_TYPE.INTERNAL
         amountError = ''
     }
     const handleFromSelect = (item) => {

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -8,7 +8,7 @@
     import { convertUnitsNoE } from 'shared/lib/units'
     import { ADDRESS_LENGTH, validateBech32Address } from 'shared/lib/utils'
     import { isTransferring, transferState, WalletAccount } from 'shared/lib/wallet'
-    import { getContext, onMount } from 'svelte'
+    import { getContext, onDestroy, onMount } from 'svelte'
     import type { Readable, Writable } from 'svelte/store'
 
     export let locale
@@ -33,6 +33,11 @@
 
     // This looks odd but sets a reactive dependency on amount, so when it changes the error will clear
     $: amount, (amountError = '')
+
+    const sendSubscription = sendParams.subscribe(s => {
+        selectedSendType = s.isInternal ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
+        amount = s.amount === 0 ? '' : convertUnitsNoE(s.amount, Unit.i, unit)
+    })
 
     let transferSteps: {
         [key in TransferProgressEventType | 'Complete']: {
@@ -161,6 +166,9 @@
     }
     onMount(() => {
         to = $accounts.length === 2 ? accountsDropdownItems[from.id === $accounts[0].id ? 1 : 0] : to
+    })
+    onDestroy(() => {
+        sendSubscription()
     })
 </script>
 


### PR DESCRIPTION
# Description of change

If the send/transfer page was already open when deleting an account it did not populate the parameters. A subscription to `sendParams` now guarantees external changes are updated on the display.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/627

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
