### PR TITLE
fix: App updater notification disappears too quickly

### DIFF
--- a/packages/shared/lib/appUpdater.ts
+++ b/packages/shared/lib/appUpdater.ts
@@ -109,7 +109,7 @@ export function updateDownload(): void {
             updateDisplayNotification(
                 notificationId,
                 {
-                    type: "info",
+                    ...downloadingNotification,
                     message: localize('notifications.updateReady'),
                     subMessage: localize('notifications.restartInstall'),
                     progress: undefined,
@@ -136,6 +136,7 @@ export function updateDownload(): void {
             updateDisplayNotification(
                 notificationId,
                 {
+                    ...downloadingNotification,
                     type: "error",
                     message: localize('notifications.updateError'),
                     progress: undefined,


### PR DESCRIPTION
# Description of change

The app updater did not retain the infinite timeout when showing the "ready to install" notification so it disappeared too quickly. The notification now stays until dismissed.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/672

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
