### PR TITLE
fix: update chart data based on active profile currency

### DIFF
--- a/packages/shared/lib/marketData.ts
+++ b/packages/shared/lib/marketData.ts
@@ -221,7 +221,7 @@ export async function addProfileCurrencyPriceData(): Promise<void> {
     if (profile) {
         // get selected profile currency and add its estimated history
         const profileCurrency: string = profile.settings.currency.toLowerCase()
-        if (!get(priceData)[profileCurrency.toLowerCase()]) {
+        if (!Object.values(CurrencyTypes.USD).includes(profileCurrency)) {
             const profileCurrencyRate: number = get(exchangeRates)[profileCurrency.toUpperCase()]
             const usdHistory = get(priceData)[CurrencyTypes.USD]
             let profileCurrencyHistory = {};

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -3,7 +3,7 @@
     import { clearSendParams } from 'shared/lib/app'
     import { appSettings } from 'shared/lib/appSettings'
     import { deepLinkRequestActive } from 'shared/lib/deepLinking'
-    import { priceData } from 'shared/lib/marketData'
+    import { addProfileCurrencyPriceData, priceData } from 'shared/lib/marketData'
     import { DEFAULT_NODE, DEFAULT_NODES, network } from 'shared/lib/network'
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
@@ -398,6 +398,8 @@
                 console.error(error)
             },
         })
+
+        addProfileCurrencyPriceData()
     })
 </script>
 

--- a/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
@@ -69,6 +69,10 @@
         if (!CurrencyTypes[profileCurrency]) {
             currencyDropdown.push({ value: profileCurrency.toLocaleLowerCase(), label: profileCurrency })
         }
+        // display USD values if previously selected currency is not in the list anymore
+        if (!currencyDropdown.some(({ value }) => value === $chartCurrency)) {
+            chartCurrency.set(CurrencyTypes.USD)
+        }
     })
 
     function handleCurrencySelect({ value: currency }) {


### PR DESCRIPTION
# Description of change

Update chart data based on active profile currency. 
After a currency change, if the previously selected chart currency is not available anymore on the list, it will fallback to USD. 

## Links to any relevant issues

Fixes issue #681.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Electron Linux

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
