### PR TITLE
fix: Exception setting focus when dialog has no controls other than close

### DIFF
--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -72,7 +72,7 @@
     onMount(() => {
         const elems = focusableElements()
         if (elems && elems.length > 0) {
-            elems[hideClose ? 0 : 1].focus()
+            elems[hideClose || elems.length === 1 ? 0 : 1].focus()
         }
     })
 </script>


### PR DESCRIPTION
# Description of change

If a popup dialog has no controls other than the close button it triggered an exception trying to auto set focus. e.g. The error log when there and no entries, only the close button is available to focus.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with empty error log

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
