### PR TITLE
fix: Add icon for linux app

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -129,6 +129,7 @@ function createWindow() {
         height: 720,
         titleBarStyle: 'hidden',
         frame: process.platform === 'linux',
+        icon: process.platform === 'linux' ? path.join(__dirname, '../assets/icons/linux/icon256x256.png') : undefined,
         webPreferences: {
             ...defaultWebPreferences,
             preload: paths.preload,


### PR DESCRIPTION
# Description of change

Although there was an icon for the AppImage the executable itself did not show an icon in title bar/docks.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/730

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on ubuntu

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

The highlighted area was empty before this fix

![image](https://user-images.githubusercontent.com/5030334/113150950-873bed80-922c-11eb-84d0-b171dd800247.png)
