### PR TITLE
fix: Allow the backup password to be submitted with enter

### DIFF
--- a/packages/shared/routes/setup/import/views/BackupPassword.svelte
+++ b/packages/shared/routes/setup/import/views/BackupPassword.svelte
@@ -13,7 +13,9 @@
     const dispatch = createEventDispatcher()
 
     function handleContinue() {
-        dispatch('next', { password })
+        if (password) {
+            dispatch('next', { password })
+        }
     }
     function handleBackClick() {
         dispatch('previous')
@@ -29,7 +31,7 @@
             <Text type="h3" highlighted classes="mb-5">{locale(`general.${importType}`)}</Text>
             <Text type="p" secondary classes="mb-4">{locale('views.importBackupPassword.body1')}</Text>
             <Text type="p" secondary classes="mb-8">{locale('views.importBackupPassword.body2')}</Text>
-            <Password classes="mb-6" {error} bind:value={password} {locale} showRevealToggle autofocus disabled={busy} />
+            <Password classes="mb-6" {error} bind:value={password} {locale} showRevealToggle autofocus disabled={busy} submitHandler={handleContinue} />
         </div>
         <div slot="leftpane__action" class="flex flex-row flex-wrap justify-between items-center space-x-4">
             <Button classes="flex-1" disabled={password.length === 0 || busy} onClick={() => handleContinue()}>


### PR DESCRIPTION
# Description of change

During backup onboarding the import password doesn't allow an enter keypress to submit the form, this fixes that issue.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/785

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
