### PR TITLE
feat: Auto submit the pin instead of having to click continue

### DIFF
--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -172,8 +172,8 @@
                 @apply rounded-full;
                 @apply bg-blue-500;
                 @apply opacity-0;
-                transition: opacity 1s;
                 &.active {
+                    transition: opacity 1s;
                     @apply opacity-100;
                 }
             }

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -24,8 +24,12 @@
 
     let timeRemainingBeforeNextAttempt = WAITING_TIME_AFTER_MAX_INCORRECT_ATTEMPTS
 
-    $: hasCorrectFormat = validatePinFormat(pinCode)
     $: hasReachedMaxAttempts = attempts >= MAX_PINCODE_INCORRECT_ATTEMPTS
+    $: {
+        if (validatePinFormat(pinCode)) {
+            onSubmit()
+        }
+    }
 
     let buttonText = setButtonText(timeRemainingBeforeNextAttempt)
 
@@ -121,7 +125,7 @@
             </div>
         </button>
         <div class="pt-40 pb-16 flex w-full h-full flex-col items-center justify-between">
-            <div class="w-96 flex flex-row flex-wrap justify-center mb-20">
+            <div class="w-96 flex flex-col flex-wrap items-center mb-20">
                 <Profile name={$activeProfile?.name} bgColor="blue" />
                 <Pin
                     bind:this={pinRef}
@@ -135,10 +139,10 @@
                               values: { attempts: attempts.toString() },
                           }) : locale('actions.enterYourPin')}
                 </Text>
+                {#if hasReachedMaxAttempts}
+                    <Text error classes="mt-6">{buttonText}</Text>
+                {/if}
             </div>
-            <Button classes="w-96" disabled={!hasCorrectFormat || hasReachedMaxAttempts || isBusy} onClick={() => onSubmit()}>
-                {hasReachedMaxAttempts ? buttonText : locale('actions.continue')}
-            </Button>
         </div>
     </div>
 {/if}

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -113,7 +113,7 @@
 
     onDestroy(() => {
         clearInterval(maxAttemptsTimer)
-        clearInterval(shakeTimeout)
+        clearTimeout(shakeTimeout)
     })
 </script>
 

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -220,9 +220,27 @@ module.exports = {
                         transform: 'rotate(0deg)',
                     },
                 },
+                shake: {
+                    '8%, 41%': {
+                        transform: 'translateX(-10px)',
+                    },
+                    '25%, 58%': {
+                        transform: 'translateX(10px)',
+                    },
+                    '75%': {
+                        transform: 'translateX(-5px)',
+                    },
+                    '92%': {
+                        transform: 'translateX(5px)',
+                    },
+                    '0%, 100%': {
+                        transform: 'translateX(0)',
+                    },
+                },
             },
             animation: {
                 'spin-reverse': 'spinReverse 1s linear infinite;',
+                shake: 'shake .5s linear;',
             },
         },
     },


### PR DESCRIPTION
# Description of change

On the PIN entry page entering 6 digits now automatically submits instead of having to click continue.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/332

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows with correct and incorrrect PINs.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
