### PR TITLE
fix: Inset the draggable title bar so it does not overlap resize areas

### DIFF
--- a/packages/shared/components/TitleBar.svelte
+++ b/packages/shared/components/TitleBar.svelte
@@ -23,8 +23,8 @@
 <div class="h-full w-full">
     {#if os === 'win32'}
         <nav
-            class={`fixed z-10 left-0 right-0 flex flex-row h-12 justify-between ${showingDashboard && !showingSettings ? 'bg-gray-50' : 'bg-white'} dark:bg-gray-900`}
-            style="-webkit-app-region: drag">
+            class={`fixed z-10 left-0 right-0 top-0 flex flex-row h-12 justify-between ${showingDashboard && !showingSettings ? 'bg-gray-50' : 'bg-white'} dark:bg-gray-900`}>
+            <div class="absolute left-16 top-1 right-36 h-9" style="-webkit-app-region: drag" />
             <button
                 on:click={() => Electron.popupMenu()}
                 class={`flex justify-center p-4 stroke-current text-gray-500 dark:text-gray-100 w-20 ${showingDashboard ? 'bg-white dark:bg-gray-800 border-solid border-r border-gray-100 dark:border-gray-800' : ''}`}


### PR DESCRIPTION
# Description of change

On windows the draggable region of the title bar overlapped the resize portions of the window. This reduces the size of the draggable region to provide access to the resize regions.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/695

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
