### PR TITLE
feat: Reduce scroll bar width but maintain active area

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -6,7 +6,7 @@
     import { Electron } from 'shared/lib/electron'
     import { addError } from 'shared/lib/errors'
     import { goto } from 'shared/lib/helpers'
-    import { dir, isLocaleLoaded, localize, setupI18n, _ } from 'shared/lib/i18n'
+    import { dir, isLocaleLoaded, setupI18n, _ } from 'shared/lib/i18n'
     import { fetchMarketData } from 'shared/lib/marketData'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
     import { openPopup, popupState } from 'shared/lib/popup'
@@ -105,22 +105,62 @@
         @apply bg-white;
         @apply select-none;
         -webkit-user-drag: none;
+
+        ::-webkit-scrollbar {
+            @apply w-5;
+            @apply h-5;
+        }
+
+        ::-webkit-scrollbar-track {
+            @apply bg-transparent;
+        }
+
+        ::-webkit-scrollbar-corner {
+            @apply bg-transparent;
+        }
+
+        ::-webkit-scrollbar-thumb {
+            @apply bg-gray-300;
+            @apply border-solid;
+            @apply rounded-2xl;
+            border-width: 7px;
+            /* This needs to match the background it is displayed on
+               and can be override in local components using the secondary 
+               and tertiary styles */
+            @apply border-white;
+        }
+
+        .scroll-secondary {
+            &::-webkit-scrollbar-thumb {
+                @apply border-white;
+            }
+        }
+
+        .scroll-tertiary {
+            &::-webkit-scrollbar-thumb {
+                @apply border-gray-50;
+            }
+        }
+
         &.scheme-dark {
             @apply bg-gray-900;
             :global(::-webkit-scrollbar-thumb) {
                 @apply bg-gray-700;
+                @apply border-gray-900;
+            }
+
+            .scroll-secondary {
+                &::-webkit-scrollbar-thumb {
+                    @apply border-gray-800;
+                }
+            }
+            
+            .scroll-tertiary {
+                &::-webkit-scrollbar-thumb {
+                    @apply border-gray-900;
+                }
             }
         }
-    }
-    ::-webkit-scrollbar {
-        @apply w-3;
-    }
-    ::-webkit-scrollbar-thumb {
-        @apply bg-gray-300;
-        border-radius: 10px;
-    }
-    ::-webkit-scrollbar-track {
-        @apply bg-transparent;
     }
 </style>
 
@@ -161,11 +201,7 @@
             <Protect on:next={routerNext} on:previous={routerPrevious} mobile={$mobile} locale={$_} />
         </Route>
         <Route route={AppRoute.Backup} transition={false}>
-            <Backup
-                on:next={routerNext}
-                on:previous={routerPrevious}
-                mobile={$mobile}
-                locale={$_} />
+            <Backup on:next={routerNext} on:previous={routerPrevious} mobile={$mobile} locale={$_} />
         </Route>
         <Route route={AppRoute.Import} transition={false}>
             <Import on:next={routerNext} on:previous={routerPrevious} mobile={$mobile} locale={$_} />

--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -79,7 +79,7 @@
             {/if}
         </div>
     </div>
-    <div class="mb-6 h-full overflow-y-auto pr-2">
+    <div class="mb-6 h-full overflow-y-auto pr-2 scroll-secondary">
         <div class="mb-5">
             <Text secondary>{locale('general.status')}</Text>
             <Text smaller>{locale(`general.${confirmed ? 'confirmed' : 'pending'}`)}</Text>

--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -218,7 +218,7 @@
         class="absolute w-full overflow-hidden pointer-events-none opacity-0 z-10 text-left 
         bg-white dark:bg-gray-800
             border border-solid border-blue-500 border-t-gray-500 dark:border-t-gray-700">
-        <div class="inner overflow-y-auto" bind:this={navContainer}>
+        <div class="inner overflow-y-auto scroll-secondary" bind:this={navContainer}>
             {#each items as item}
                 <button
                     class="relative flex items-center p-4 w-full whitespace-nowrap

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -56,7 +56,7 @@
     {#if $selectedMessage}
         <ActivityDetail onBackClick={handleBackClick} {...$selectedMessage} {locale} />
     {:else}
-        <div class="overflow-y-auto flex-auto h-1 space-y-2.5 -mr-2 pr-2">
+        <div class="overflow-y-auto flex-auto h-1 space-y-2.5 -mr-2 pr-2 scroll-secondary">
             {#if transactions.length}
                 {#each transactions as transaction}
                     <ActivityRow onClick={() => handleTransactionClick(transaction)} {...transaction} {color} />

--- a/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
@@ -70,7 +70,7 @@
         </div>
     </button>
     <Text type="h3" classes="flex-1 text-center mt-1 mx-5">{activeAccount.alias}</Text>
-    <div class="flex-1 flex flex-row justify-end overflow-x-auto">
+    <div class="flex-1 flex flex-row justify-end overflow-x-auto scroll-tertiary">
         <div class="flex flex-row pb-1" bind:this={accountElement}>
             {#each accounts as acc}
                 <button

--- a/packages/shared/routes/dashboard/wallet/views/Security.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Security.svelte
@@ -59,7 +59,7 @@
 
 <div data-label="security" class="pt-6 pb-8 px-8 flex-grow flex flex-col h-full">
     <Text type="h5" classes="mb-5">{locale('general.security')}</Text>
-    <div class="grid grid-cols-2 gap-3 auto-rows-max w-full overflow-y-auto flex-auto h-1 -mr-2 pr-2">
+    <div class="grid grid-cols-2 gap-3 auto-rows-max w-full overflow-y-auto flex-auto h-1 -mr-2 pr-2 scroll-secondary">
         <!-- Stronghold backup -->
         <SecurityTile
             title={locale('views.dashboard.security.strongholdBackup.title')}

--- a/packages/shared/routes/dashboard/wallet/views/WalletActions.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletActions.svelte
@@ -66,7 +66,7 @@
             </div>
             {#if $accounts.length > 0}
                 <div
-                    class="grid grid-cols-{$accounts.length <= 2 ? $accounts.length : '3'} auto-rows-max {$accounts.length <= 2 ? 'gap-4' : 'gap-2.5'} w-full flex-auto overflow-y-auto h-1 -mr-2 pr-2">
+                    class="grid grid-cols-{$accounts.length <= 2 ? $accounts.length : '3'} auto-rows-max {$accounts.length <= 2 ? 'gap-4' : 'gap-2.5'} w-full flex-auto overflow-y-auto h-1 -mr-2 pr-2 scroll-secondary">
                     {#each $accounts as account}
                         <AccountTile
                             color={account.color}

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -32,7 +32,7 @@
             <Icon icon="refresh" classes="{$isSyncing && 'animate-spin-reverse'} text-gray-500 dark:text-white" />
         </button>
     </div>
-    <div class="overflow-y-auto flex-auto h-1 space-y-2.5 -mr-2 pr-2">
+    <div class="overflow-y-auto flex-auto h-1 space-y-2.5 -mr-2 pr-2 scroll-secondary">
         {#if $transactions?.length}
             {#each $transactions as transaction}
                 <ActivityRow


### PR DESCRIPTION
# Description of change

Reduce the visible width of the scroll bar but maintain the active area around the visible part.
Some element may need to apply the `scroll-secondary` or `scroll-tertiary` styles if they are on a different background color to the default.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows in light and dark mode

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
