### PR TITLE
fix: Regularly checks for new version while app is open

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -2,11 +2,11 @@
     import { Popup, Route, TitleBar, ToastContainer } from 'shared/components'
     import { loggedIn, mobile } from 'shared/lib/app'
     import { appSettings } from 'shared/lib/appSettings'
-    import { getVersionDetails, updateCheck, versionDetails } from 'shared/lib/appUpdater'
+    import { getVersionDetails, pollVersion, versionDetails } from 'shared/lib/appUpdater'
     import { Electron } from 'shared/lib/electron'
     import { addError } from 'shared/lib/errors'
     import { goto } from 'shared/lib/helpers'
-    import { dir, isLocaleLoaded, localize, setupI18n, _ } from 'shared/lib/i18n'
+    import { dir, isLocaleLoaded, setupI18n, _ } from 'shared/lib/i18n'
     import { fetchMarketData } from 'shared/lib/marketData'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
     import { openPopup, popupState } from 'shared/lib/popup'
@@ -58,10 +58,7 @@
         // @ts-ignore: This value is replaced by Webpack DefinePlugin
         if (!devMode) {
             await getVersionDetails()
-
-            setInterval(() => {
-                updateCheck()
-            }, 900000) // 15 minutes
+            await pollVersion()
         }
         Electron.onEvent('menu-navigate-wallet', (route) => {
             if (get(dashboardRoute) !== Tabs.Wallet) {

--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -2,7 +2,7 @@
     import { Popup, Route, TitleBar, ToastContainer } from 'shared/components'
     import { loggedIn, mobile } from 'shared/lib/app'
     import { appSettings } from 'shared/lib/appSettings'
-    import { refreshVersionDetails, versionDetails } from 'shared/lib/appUpdater'
+    import { getVersionDetails, updateCheck, versionDetails } from 'shared/lib/appUpdater'
     import { Electron } from 'shared/lib/electron'
     import { addError } from 'shared/lib/errors'
     import { goto } from 'shared/lib/helpers'
@@ -57,7 +57,11 @@
 
         // @ts-ignore: This value is replaced by Webpack DefinePlugin
         if (!devMode) {
-            await refreshVersionDetails()
+            await getVersionDetails()
+
+            setInterval(() => {
+                updateCheck()
+            }, 900000) // 15 minutes
         }
         Electron.onEvent('menu-navigate-wallet', (route) => {
             if (get(dashboardRoute) !== Tabs.Wallet) {
@@ -75,7 +79,6 @@
             }
         })
         Electron.onEvent('menu-check-for-update', async () => {
-            await refreshVersionDetails()
             openPopup({
                 type: 'version',
                 props: {

--- a/packages/desktop/electron/lib/appUpdater.js
+++ b/packages/desktop/electron/lib/appUpdater.js
@@ -21,6 +21,7 @@ export function initAutoUpdate(mainWindow) {
         ipcMain.handle('update-download', () => updateDownload())
         ipcMain.handle('update-cancel', () => updateCancel())
         ipcMain.handle('update-install', () => updateInstall())
+        ipcMain.handle('update-check', () => updateCheck())
         ipcMain.handle('update-get-version-details', () => getVersionDetails())
         ipcHandlersRegistered = true
     }
@@ -54,7 +55,8 @@ export function initAutoUpdate(mainWindow) {
     })
 
     mainWindow.webContents.send('version-details', versionDetails)
-    autoUpdater.checkForUpdates()
+
+    updateCheck()
 }
 
 export function updateDownload() {
@@ -71,6 +73,10 @@ export function updateCancel() {
 
 export function updateInstall() {
     autoUpdater.quitAndInstall()
+}
+
+export function updateCheck() {
+    autoUpdater.checkForUpdates()
 }
 
 export function getVersionDetails() {

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -86,6 +86,14 @@ const Electron = {
      */
     updateInstall: () => ipcRenderer.invoke('update-install'),
     /**
+     * Check for an update of the application
+     *
+     * @method updateCheck
+     *
+     * @returns void
+     */
+     updateCheck: () => ipcRenderer.invoke('update-check'),
+     /**
      * Get version details
      *
      * @method getVersionDetails

--- a/packages/shared/components/popups/Version.svelte
+++ b/packages/shared/components/popups/Version.svelte
@@ -1,9 +1,9 @@
 <script lang="typescript">
-    import { date } from 'svelte-i18n'
+    import { Button, Logo, Text } from 'shared/components'
+    import { getVersionDetails, updateBusy, updateCheck, updateDownload, versionDetails } from 'shared/lib/appUpdater'
     import { closePopup } from 'shared/lib/popup'
-    import { Text, Button, Logo } from 'shared/components'
-
-    import { versionDetails, updateDownload, updateBusy } from 'shared/lib/appUpdater'
+    import { onMount } from 'svelte'
+    import { date } from 'svelte-i18n'
 
     export let locale
 
@@ -14,6 +14,14 @@
     function handleCancelClick() {
         closePopup()
     }
+
+    onMount(async () => {
+        // @ts-ignore: This value is replaced by Webpack DefinePlugin
+        if (!devMode) {
+            await getVersionDetails()
+            await updateCheck()
+        }
+    })
 </script>
 
 <style type="text/scss">

--- a/packages/shared/lib/appUpdater.ts
+++ b/packages/shared/lib/appUpdater.ts
@@ -166,7 +166,11 @@ export function updateInstall(): void {
     Electron.updateInstall()
 }
 
-export async function refreshVersionDetails(): Promise<void> {
+export function updateCheck(): void {
+    Electron.updateCheck()
+}
+
+export async function getVersionDetails(): Promise<void> {
     const verDetails = await Electron.getVersionDetails();
     versionDetails.set(verDetails)
 }

--- a/packages/shared/lib/appUpdater.ts
+++ b/packages/shared/lib/appUpdater.ts
@@ -6,6 +6,8 @@ import {
 } from 'shared/lib/notifications'
 import { writable } from 'svelte/store'
 
+const DEFAULT_APP_UPDATER_POLL_INTERVAL = 900000 // 15 Minutes
+
 export const versionDetails = writable<VersionDetails>({
     upToDate: true,
     currentVersion: '',
@@ -173,4 +175,8 @@ export function updateCheck(): void {
 export async function getVersionDetails(): Promise<void> {
     const verDetails = await Electron.getVersionDetails();
     versionDetails.set(verDetails)
+}
+
+export async function pollVersion(): Promise<void> {
+    setInterval(async () => updateCheck(), DEFAULT_APP_UPDATER_POLL_INTERVAL)
 }

--- a/packages/shared/lib/electron.ts
+++ b/packages/shared/lib/electron.ts
@@ -68,6 +68,7 @@ export interface IElectron {
     PincodeManager: IPincodeManager;
 
     getVersionDetails(): Promise<VersionDetails>;
+    updateCheck(): Promise<void>
     updateInstall(): Promise<void>
     updateCancel(): Promise<void>
     updateDownload(): Promise<void>


### PR DESCRIPTION
# Description of change

The app now checks in the background every 15 mins if there is a new version, the update check is also triggered if someone opens the version popup.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/673

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
