### PR TITLE
fix: Fallback if password error message not found

### DIFF
--- a/packages/shared/lib/password.ts
+++ b/packages/shared/lib/password.ts
@@ -11,6 +11,8 @@ const passwordReasons = {
     'This is a very common password': 'common',
     'This is similar to a commonly used password': 'similar',
     'A word by itself is easy to guess': 'word',
+    'This is a top-10 common password': 'common',
+    'This is a top-100 common password': 'common',
 };
 
 export default passwordReasons;

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -606,7 +606,7 @@
             "dates": "Dates are easy to guess.",
             "common": "This is a very common password.",
             "similar": "This is similar to a common password.",
-            "reasonWord": "A single word is easy to guess.",
+            "word": "A single word is easy to guess.",
             "incorrect": "Your password is incorrect.",
             "length": "Your password can't be longer than {length, plural, one {1 character} other {# characters}}."
         },

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -125,9 +125,11 @@
         } else if (newPassword !== confirmedPassword) {
             newPasswordError = locale('error.password.doNotMatch')
         } else if (passwordStrength.score !== 4) {
-            newPasswordError = passwordStrength.feedback.warning
-                ? locale(`error.password.${passwordInfo[passwordStrength.feedback.warning]}`)
-                : locale('error.password.tooWeak')
+            let errKey = 'error.password.tooWeak'
+            if (passwordStrength.feedback.warning && passwordInfo[passwordStrength.feedback.warning]) {
+                errKey = `error.password.${passwordInfo[passwordStrength.feedback.warning]}`
+            }
+            newPasswordError = locale(errKey)
         } else {
             passwordChangeBusy = true
             passwordChangeMessage = locale('general.passwordUpdating')

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -31,9 +31,11 @@
                 },
             })
         } else if (passwordStrength.score !== 4) {
-            error = passwordStrength.feedback.warning
-                ? locale(`error.password.${passwordInfo[passwordStrength.feedback.warning]}`)
-                : locale('error.password.tooWeak')
+            let errKey = 'error.password.tooWeak'
+            if (passwordStrength.feedback.warning && passwordInfo[passwordStrength.feedback.warning]) {
+                errKey = `error.password.${passwordInfo[passwordStrength.feedback.warning]}`
+            }
+            error = locale(errKey)
         } else if (password !== confirmedPassword) {
             errorConfirm = locale('error.password.doNotMatch')
         } else {


### PR DESCRIPTION
# Description of change

The password error display looked up the zxcvbn warning to create a localizable key, not all messages were in the lookup table so we ended up with `undefined` for the key. The code has some additional lookups, but also a fallback mechanism if a message can not be found.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/711

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
