### PR TITLE
fix: Truncate string now behaves when the string is null or undefined

### DIFF
--- a/packages/shared/lib/helpers.ts
+++ b/packages/shared/lib/helpers.ts
@@ -101,7 +101,7 @@ export const getInitials = (name: string | undefined, maxChars: number) => {
 
 export const truncateString = (str: string = '', firstCharCount: number = 5, endCharCount: number = 5, dotCount: number = 3) => {
     const MAX_LENGTH = 13
-    if (str.length <= MAX_LENGTH) {
+    if (!str || str.length <= MAX_LENGTH) {
         return str
     }
     let convertedStr = ''


### PR DESCRIPTION
# Description of change

The `truncateString` helper functions that displays the abbreviated addresses aaa...zzz was passed a null or undefined parameter, which triggered an exception. 

This fixes the exception in the helper, but the real question is why was the address in the payload empty!

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/797

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
