### PR TITLE
fix: Corrects the order of the accounts in the transfers notification message

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -451,14 +451,14 @@ export const initialiseListeners = () => {
             // Notify user
             const messageKey = confirmed ? 'confirmed' : 'failed'
 
-            const _notify = (senderAccountAlias: string | null = null) => {
+            const _notify = (accountFrom: string | null = null, accountTo: string | null = null) => {
                 let notificationMessage
 
-                if (senderAccountAlias) {
+                if (accountFrom) {
                     notificationMessage = localize(`notifications.${messageKey}Internal`)
                         .replace('{{value}}', formatUnit(message.payload.data.essence.data.value))
-                        .replace('{{senderAccount}}', senderAccountAlias)
-                        .replace('{{receiverAccount}}', account.alias)
+                        .replace('{{senderAccount}}', accountFrom)
+                        .replace('{{receiverAccount}}', accountTo)
                 } else {
                     notificationMessage = localize(`notifications.${messageKey}`)
                         .replace('{{value}}', formatUnit(message.payload.data.essence.data.value))
@@ -482,9 +482,13 @@ export const initialiseListeners = () => {
                 } else {
                     // If this is an internal message, check if we have already receive confirmation state of this message
                     if (Object.keys(messageIds).includes(message.id)) {
-                        _notify(
-                            get(accounts).find((account) => account.index === messageIds[message.id]).alias
-                        );
+                        const account1 = get(accounts).find((account) => account.index === messageIds[message.id]).alias
+                        const account2 = account.alias
+                        if (essence.data.incoming) {
+                            _notify(account1, account2);
+                        } else {
+                            _notify(account2, account1);
+                        }
 
                         confirmedInternalMessageIds.update((ids) => {
                             delete ids[message.id]


### PR DESCRIPTION
# Description of change

The notification message for transfer assumed the order of the messages confirming, this PR looks at the content of the payloads to work out which accounts sent/received the transfer.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/624

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

