### PR TITLE
fix: dont display sync alert from wallet tab

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -28,7 +28,7 @@
 <div data-label="latest-transactions" class="h-full pt-6 pb-8 px-8 flex-grow flex flex-col">
     <div class="w-full flex flex-row justify-between items-start">
         <Text type="h5" classes="mb-5">{locale('general.latestTransactions')}</Text>
-        <button on:click={syncAccounts} class:pointer-events-none={$isSyncing}>
+        <button on:click={() => syncAccounts(false)} class:pointer-events-none={$isSyncing}>
             <Icon icon="refresh" classes="{$isSyncing && 'animate-spin-reverse'} text-gray-500 dark:text-white" />
         </button>
     </div>


### PR DESCRIPTION
# Description of change

- Remove alert on manual syncs from the wallet tab

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on Mac

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
