### PR TITLE
fix: validate password before trying to export stronghold

### DIFF
--- a/packages/shared/components/popups/Password.svelte
+++ b/packages/shared/components/popups/Password.svelte
@@ -6,23 +6,20 @@
     export let locale
 
     export let onSuccess
-    export let onSubmit
     export let onError
     export let onCancelled
     export let subtitle
-    
+    export let returnPassword = false
+
     let password
     let error = ''
 
     function handleSubmit() {
-        if (onSubmit) {
-            return onSubmit(password)
-        }
         api.setStrongholdPassword(password, {
             onSuccess(response) {
                 closePopup()
                 if ('function' === typeof onSuccess) {
-                    onSuccess(response)
+                    onSuccess(returnPassword ? password : response)
                 }
             },
             onError(err) {

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -3,7 +3,7 @@
     import { Electron } from 'shared/lib/electron'
     import { showAppNotification } from 'shared/lib/notifications'
     import passwordInfo from 'shared/lib/password'
-    import { openPopup, closePopup } from 'shared/lib/popup'
+    import { openPopup } from 'shared/lib/popup'
     import { activeProfile, updateProfile } from 'shared/lib/profile'
     import { getDefaultStrongholdName, PIN_LENGTH } from 'shared/lib/utils'
     import { api, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
@@ -76,13 +76,13 @@
         openPopup({
             type: 'password',
             props: {
-                onSubmit: (password) => {
+                onSuccess: (password) => {
                     exportBusy = true
                     exportMessage = locale('general.exportingStronghold')
                     exportStronghold(password, _callback)
-                    closePopup()
                 },
-                subtitle: locale('popups.password.backup')
+                returnPassword: true,
+                subtitle: locale('popups.password.backup'),
             },
         })
     }


### PR DESCRIPTION
# Description of change

This PRs aims to fix PR #805 where there is no password validation before trying to export stronghold. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Instructions:
- Go to settings > security > export backup
- Enter a wrong password: the popup should validate it and show you an error
- Enter a correct password: the popup should close and the backup should export succesfully

OS: Ubuntu 18.04

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
