### PR TITLE
fix: Onboarding exception when switching modes

### DIFF
--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -2,7 +2,7 @@ import { AvailableExchangeRates } from 'shared/lib/currency'
 import { persistent } from 'shared/lib/helpers'
 import { DEFAULT_NODE } from 'shared/lib/network'
 import { generateRandomId } from 'shared/lib/utils'
-import { api, getStoragePath } from 'shared/lib/wallet'
+import { api, destroyActor, getStoragePath } from 'shared/lib/wallet'
 import { derived, get, Readable, writable } from 'svelte/store'
 import type { ChartSelectors } from './chart'
 import { Electron } from './electron'
@@ -136,6 +136,7 @@ export const disposeNewProfile = () => {
                 console.error(err)
             },
         })
+        destroyActor(np.id)
     }
     newProfile.set(null)
     activeProfileId.set(null)

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -176,6 +176,9 @@ export const getStoragePath = (appPath: string, profileName: string): string => 
 }
 
 export const initialise = (id: string, storagePath: string): void => {
+    if (Object.keys(actors).length > 0) {
+        console.error("Initialise called when another actor already initialised")
+    }
     const actor: Actor = window['__WALLET_INIT__'].run(id, storagePath)
 
     actors[id] = actor
@@ -204,15 +207,15 @@ export const removeEventListeners = (id: string): void => {
  * @returns {void}
  */
 export const destroyActor = (id: string): void => {
-    if (!actors[id]) {
-        throw new Error('No actor found for provided id.')
+    if (actors[id]) {
+        try {
+            actors[id].destroy()
+        } catch (err) {
+            console.error(err)
+        } finally {
+            delete actors[id]
+        }
     }
-
-    // Destroy actor
-    actors[id].destroy()
-
-    // Delete actor id from state
-    delete actors[id]
 }
 
 /**

--- a/packages/shared/routes/setup/Setup.svelte
+++ b/packages/shared/routes/setup/Setup.svelte
@@ -4,10 +4,17 @@
     import { Electron } from 'shared/lib/electron'
     import { getTrimmedLength, validateFilenameChars } from 'shared/lib/helpers'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { cleanupInProgressProfiles, createProfile, disposeNewProfile, newProfile, profileInProgress, profiles } from 'shared/lib/profile'
+    import {
+        cleanupInProgressProfiles,
+        createProfile,
+        disposeNewProfile,
+        newProfile,
+        profileInProgress,
+        profiles,
+    } from 'shared/lib/profile'
     import { SetupType } from 'shared/lib/typings/routes'
-    import { getStoragePath, initialise, MAX_PROFILE_NAME_LENGTH } from 'shared/lib/wallet'
-    import { createEventDispatcher } from 'svelte'
+    import { destroyActor, getStoragePath, initialise, MAX_PROFILE_NAME_LENGTH } from 'shared/lib/wallet'
+    import { createEventDispatcher, onMount } from 'svelte'
     import { get } from 'svelte/store'
 
     export let locale
@@ -49,19 +56,33 @@
                 return (error = locale('error.profile.duplicate'))
             }
 
-            profile = createProfile(trimmedProfileName, isDeveloperProfile)
-            profileInProgress.set(trimmedProfileName)
+            const previousInitializedId = $newProfile?.id
+            const nameChanged = $newProfile?.name !== trimmedProfileName
+
+            // If the name has changed from the previous initialization
+            // then make sure we cleanup the last profile and actor
+            if (nameChanged && previousInitializedId) {
+                // The initialized profile name has changed
+                // so we need to destroy the previous actor
+                destroyActor(previousInitializedId)
+            }
 
             try {
                 busy = true
-                const userDataPath = await Electron.getUserDataPath()
-                initialise($newProfile.id, getStoragePath(userDataPath, $newProfile.name))
+
+                if (nameChanged) {
+                    profile = createProfile(trimmedProfileName, isDeveloperProfile)
+                    profileInProgress.set(trimmedProfileName)
+
+                    const userDataPath = await Electron.getUserDataPath()
+                    initialise($newProfile.id, getStoragePath(userDataPath, $newProfile.name))
+                }
 
                 dispatch('next', { setupType })
             } catch (err) {
                 showAppNotification({
                     type: 'error',
-                    message: locale(err.error),
+                    message: locale(err.error ? err.error : 'error.global.generic'),
                 })
             } finally {
                 busy = false


### PR DESCRIPTION
# Description of change

If you start to create a new profile and then select "Import", go back and click "Create" you can trigger an exception. This is because if the `initialise` method is called twice in quick succession the RocksDB is still locked from the first creation.

This PR only tries to call the initialize again if the profile name has changed when you navigate in and out of those screens.
Also if the name has changed the previous actor will be cleaned up.

There was an additional exception that could be triggered if you backed all the way out of a create because the actor was still active and not cleaned up when the in progress profile was removed.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
