### PR TITLE
fix: Improve the control flow when exporting stronghold

### DIFF
--- a/packages/shared/components/popups/Backup.svelte
+++ b/packages/shared/components/popups/Backup.svelte
@@ -105,7 +105,7 @@
                 <Button secondary classes="w-1/2" onClick={handleCancelClick} disabled={busy}>{locale('actions.cancel')}</Button>
                 <Button classes="w-1/2" type="submit" form="password-popup-form" disabled={!password || password.length === 0 || busy}>
                     {#if busy}
-                        <Spinner busy={true} message={locale('popups.backup.exporting')} classes="justify-center" />
+                        <Spinner busy={true} message={locale('popups.backup.saving')} classes="justify-center" />
                     {:else}
                         {locale('actions.saveBackup')}
                     {/if}

--- a/packages/shared/components/popups/Backup.svelte
+++ b/packages/shared/components/popups/Backup.svelte
@@ -24,12 +24,12 @@
 
     function handleBackupClick() {
         error = ''
-        busy = true
         api.setStrongholdPassword(password, {
-            onSuccess(response) {
+            onSuccess() {
                 Electron.getStrongholdBackupDestination(getDefaultStrongholdName())
                     .then((result) => {
                         if (result) {
+                            busy = true
                             api.backup(result, password, {
                                 onSuccess() {
                                     updateProfile('lastStrongholdBackupTime', new Date())

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -332,7 +332,8 @@
             "backupDescription": "It is important to back up regularly to ensure you have a copy of your accounts and transaction history.",
             "backupWarning": "If you lose your backup and recovery phrase you will lose access to your funds.",
             "notBackedUp": "Not backed up",
-            "notBackedUpDescription": "You have not backed up your Stronghold"
+            "notBackedUpDescription": "You have not backed up your Stronghold",
+            "exporting": "Exporting..."
         },
         "deleteAccount": {
             "title": "Remove {name}?",

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -333,7 +333,7 @@
             "backupWarning": "If you lose your backup and recovery phrase you will lose access to your funds.",
             "notBackedUp": "Not backed up",
             "notBackedUpDescription": "You have not backed up your Stronghold",
-            "exporting": "Exporting..."
+            "saving": "Saving..."
         },
         "deleteAccount": {
             "title": "Remove {name}?",


### PR DESCRIPTION
# Description of change

For the export stronghold popup this PR checks the password is correct and shows and inline error instead of a notification popup if it is incorrect. Also the popup controls are shown as busy while the export is in progress.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
