### PR TITLE
fix: Fixes the exception in chart when there is no longer an active profile

### DIFF
--- a/packages/shared/lib/chart.ts
+++ b/packages/shared/lib/chart.ts
@@ -251,7 +251,7 @@ function formatLabel(timestamp: number): string {
 }
 
 function formatLineChartTooltip(data: (number | string), timestamp: number | string, showMiota: boolean = false): Tooltip {
-    const currency = get(activeProfile)?.settings.chartSelectors.currency
+    const currency = get(activeProfile)?.settings.chartSelectors.currency ?? ''
     const title: string = `${showMiota ? `1 ${Unit.Mi}: ` : ''}${formatCurrencyValue(data, currency, 3)} ${currency}`
     const label: string = get(i18nDate)(new Date(timestamp), {
         year: 'numeric',

--- a/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
@@ -141,6 +141,6 @@
         {labels}
         {color}
         {xMaxTicks}
-        formatYAxis={(value) => formatCurrencyValue(value, $activeProfile?.settings.chartSelectors.currency, undefined, undefined, 5)}
+        formatYAxis={(value) => formatCurrencyValue(value, $activeProfile?.settings.chartSelectors.currency ?? '', undefined, undefined, 5)}
         inlineStyle={$selectedAccount && `height: calc(50vh - ${hasTitleBar ? '190' : '150'}px);`} />
 </div>


### PR DESCRIPTION
# Description of change

If you are in account view and you logout an exception is triggered in the chart currency formatting. This is because as the views are torn down the activeProfile is no longer available and so the currency is undefined.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
