### PR TITLE
fix: Utxo type name case changed so sender could not be found

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -23,7 +23,7 @@
     let receiverAccount: WalletAccount
 
     let senderAddress: string =
-        payload?.data?.essence?.data?.inputs?.find((input) => input?.type === 'UTXO')?.data?.metadata?.address ?? null
+        payload?.data?.essence?.data?.inputs?.find((input) => /utxo/i.test(input?.type))?.data?.metadata?.address ?? null
 
     let receiverAddresses: string[] =
         payload?.data?.essence?.data?.outputs


### PR DESCRIPTION
# Description of change

Activity details displays the sender as `null`, this is because the casing of the UTXO input type changed from `UTXO` to `Utxo` so the input lookup for the senders in the payload fails.

This also explains the underlying issue with https://github.com/iotaledger/firefly/pull/798

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
