### PR TITLE
fix: Scroll bar on legal onboarding page incorrect colour

### DIFF
--- a/packages/shared/routes/setup/Legal.svelte
+++ b/packages/shared/routes/setup/Legal.svelte
@@ -30,6 +30,12 @@
     [slot='rightpane'] section {
         scroll-margin: 3rem;
     }
+
+    :global(.legal-scroll-bar) {
+            &::-webkit-scrollbar-thumb {
+                @apply border-gray-100;
+            }
+        }
 </style>
 
 {#if mobile}
@@ -47,7 +53,7 @@
             </Button>
         </div>
         <div slot="rightpane" class="w-full h-full flex items-center px-40 py-20">
-            <Scroller classes="w-full text-justify py-12 pr-10" threshold={70} bind:progress bind:index bind:this={scroller}>
+            <Scroller classes="w-full text-justify py-12 pr-10 legal-scroll-bar" threshold={70} bind:progress bind:index bind:this={scroller}>
                 <section class="mb-12" bind:this={privacyPolicy}>
                     <Text type="h1" classes="mb-5">{locale('views.legal.privacyPolicy.title')}</Text>
                     <Text type="p" secondary classes="mb-5">{locale('views.legal.privacyPolicy.body1')}</Text>


### PR DESCRIPTION
# Description of change

The colour of the scroll bar for the legal onboarding page was not updated to use the new styling.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows in light and dark mode

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
