### PR TITLE
fix: Exception in diagnostics when manual node mode selected

### DIFF
--- a/packages/shared/components/popups/Diagnostics.svelte
+++ b/packages/shared/components/popups/Diagnostics.svelte
@@ -29,17 +29,10 @@
             label: 'views.settings.currency.title',
             value: $activeProfile.settings.currency,
         })
-        if ($activeProfile.settings.automaticNodeSelection) {
-            appVars.push({
-                label: 'views.settings.nodeSettings.title',
-                value: locale('general.automaticNodeSelection'),
-            })
-        } else {
-            appVars.push({
-                label: 'views.settings.nodeSettings.title',
-                value: $activeProfile.settings.node.url,
-            })
-        }
+        appVars.push({
+            label: 'views.settings.nodeSettings.title',
+            value: locale(`general.${$activeProfile.settings.automaticNodeSelection ? 'automaticNodeSelection' : 'manualNodeSelection'}`),
+        })
     }
 
     contentApp = combineValues(appVars)


### PR DESCRIPTION
# Description of change

If the settings for nodes were set to Manual Selection and then you show diagnostics an exception was triggered. This was due to it referencing some config settings that no longer exist.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
