### PR TITLE
fix: Get trimmed length triggers exception when only whitespace

### DIFF
--- a/packages/shared/lib/helpers.ts
+++ b/packages/shared/lib/helpers.ts
@@ -45,7 +45,7 @@ export const getTrimmedLength = (name: string | undefined) => {
         return 0
     }
 
-    return name.trim().match(/./gu).length
+    return name.trim().match(/./gu)?.length ?? 0
 }
 
 /**


### PR DESCRIPTION
# Description of change

The getTrimmedLength method didn't account for the regex match not finding any characters and called .length on a null value.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/835

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
