### PR TITLE
fix: add support for http nodes on developer profiles

### DIFF
--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -1,7 +1,8 @@
-import { writable } from 'svelte/store'
+import { writable, get } from 'svelte/store'
 import type { Node } from './typings/client'
 import { Network } from './typings/client'
 import { isValidHttpsUrl, isValidUrl } from './utils'
+import { activeProfile } from 'shared/lib/profile'
 
 const DEFAULT_NODES: Node[] = [
     'https://api.hornet-0.testnet.chrysalis2.com',
@@ -34,7 +35,7 @@ export const isNodeUrlValid = (nodesList: Node[], newUrl: string): string | unde
     }
 
     // Only allow HTTPS nodes
-    if (!isValidHttpsUrl(newUrl)) {
+    if (!get(activeProfile).isDeveloperProfile && !isValidHttpsUrl(newUrl)) {
         return 'error.node.https'
     }
 


### PR DESCRIPTION
# Description of change

If a user is in development mode, they should be allowed to connect to a node without TLS.

TODO: Check if CSP needs updating.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Untested

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
