### PR TITLE
fix: Allow password and pin settings to be submitted with keyboard

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -110,137 +110,141 @@
     }
 
     function changePassword() {
-        resetErrors()
+        if (currentPassword && newPassword && confirmedPassword) {
+            resetErrors()
 
-        if (newPassword.length > MAX_PASSWORD_LENGTH) {
-            newPasswordError = locale('error.password.length', {
-                values: {
-                    length: MAX_PASSWORD_LENGTH,
-                },
-            })
-        } else if (newPassword !== confirmedPassword) {
-            newPasswordError = locale('error.password.doNotMatch')
-        } else if (passwordStrength.score !== 4) {
-            let errKey = 'error.password.tooWeak'
-            if (passwordStrength.feedback.warning && passwordInfo[passwordStrength.feedback.warning]) {
-                errKey = `error.password.${passwordInfo[passwordStrength.feedback.warning]}`
-            }
-            newPasswordError = locale(errKey)
-        } else {
-            passwordChangeBusy = true
-            passwordChangeMessage = locale('general.passwordUpdating')
-            let busyStart = Date.now()
-            const _clearMessage = () => {
-                setTimeout(() => (passwordChangeMessage = ''), 2000)
-            }
-            const _hideBusy = (message, timeout) => {
-                const diff = Date.now() - busyStart
-                if (diff < timeout) {
-                    setTimeout(() => {
+            if (newPassword.length > MAX_PASSWORD_LENGTH) {
+                newPasswordError = locale('error.password.length', {
+                    values: {
+                        length: MAX_PASSWORD_LENGTH,
+                    },
+                })
+            } else if (newPassword !== confirmedPassword) {
+                newPasswordError = locale('error.password.doNotMatch')
+            } else if (passwordStrength.score !== 4) {
+                let errKey = 'error.password.tooWeak'
+                if (passwordStrength.feedback.warning && passwordInfo[passwordStrength.feedback.warning]) {
+                    errKey = `error.password.${passwordInfo[passwordStrength.feedback.warning]}`
+                }
+                newPasswordError = locale(errKey)
+            } else {
+                passwordChangeBusy = true
+                passwordChangeMessage = locale('general.passwordUpdating')
+                let busyStart = Date.now()
+                const _clearMessage = () => {
+                    setTimeout(() => (passwordChangeMessage = ''), 2000)
+                }
+                const _hideBusy = (message, timeout) => {
+                    const diff = Date.now() - busyStart
+                    if (diff < timeout) {
+                        setTimeout(() => {
+                            passwordChangeBusy = false
+                            passwordChangeMessage = message
+                            _clearMessage()
+                        }, timeout - diff)
+                    } else {
                         passwordChangeBusy = false
                         passwordChangeMessage = message
                         _clearMessage()
-                    }, timeout - diff)
-                } else {
-                    passwordChangeBusy = false
-                    passwordChangeMessage = message
-                    _clearMessage()
-                }
-            }
-
-            api.changeStrongholdPassword(currentPassword, newPassword, {
-                onSuccess() {
-                    if (exportStrongholdChecked) {
-                        passwordChangeMessage = locale('general.exportingStronghold')
-
-                        return exportStronghold(newPassword, (cancelled, err) => {
-                            if (cancelled) {
-                                _hideBusy('', 0)
-                            } else {
-                                if (err) {
-                                    currentPasswordError = locale(err)
-                                    _hideBusy(locale('general.passwordFailed'), 0)
-                                } else {
-                                    currentPassword = ''
-                                    newPassword = ''
-                                    confirmedPassword = ''
-                                    exportStrongholdChecked = false
-                                    _hideBusy(locale('general.passwordSuccess'), 2000)
-                                }
-                            }
-                        })
-                    } else {
-                        currentPassword = ''
-                        newPassword = ''
-                        confirmedPassword = ''
-                        exportStrongholdChecked = false
-                        _hideBusy(locale('general.passwordSuccess'), 2000)
                     }
-                },
-                onError(err) {
-                    currentPasswordError = locale(err.error)
-                    _hideBusy(locale('general.passwordFailed'), 0)
-                },
-            })
+                }
+
+                api.changeStrongholdPassword(currentPassword, newPassword, {
+                    onSuccess() {
+                        if (exportStrongholdChecked) {
+                            passwordChangeMessage = locale('general.exportingStronghold')
+
+                            return exportStronghold(newPassword, (cancelled, err) => {
+                                if (cancelled) {
+                                    _hideBusy('', 0)
+                                } else {
+                                    if (err) {
+                                        currentPasswordError = locale(err)
+                                        _hideBusy(locale('general.passwordFailed'), 0)
+                                    } else {
+                                        currentPassword = ''
+                                        newPassword = ''
+                                        confirmedPassword = ''
+                                        exportStrongholdChecked = false
+                                        _hideBusy(locale('general.passwordSuccess'), 2000)
+                                    }
+                                }
+                            })
+                        } else {
+                            currentPassword = ''
+                            newPassword = ''
+                            confirmedPassword = ''
+                            exportStrongholdChecked = false
+                            _hideBusy(locale('general.passwordSuccess'), 2000)
+                        }
+                    },
+                    onError(err) {
+                        currentPasswordError = locale(err.error)
+                        _hideBusy(locale('general.passwordFailed'), 0)
+                    },
+                })
+            }
         }
     }
 
     function changePincode() {
-        resetErrors()
+        if (currentPincode && newPincode && confirmedPincode) {
+            resetErrors()
 
-        if (newPincode.length !== PIN_LENGTH) {
-            newPincodeError = locale('error.pincode.length', {
-                values: {
-                    length: PIN_LENGTH,
-                },
-            })
-        } else if (newPincode !== confirmedPincode) {
-            confirmationPincodeError = locale('error.pincode.match')
-        } else {
-            pinCodeBusy = true
-            pinCodeMessage = locale('general.pinCodeUpdating')
+            if (newPincode.length !== PIN_LENGTH) {
+                newPincodeError = locale('error.pincode.length', {
+                    values: {
+                        length: PIN_LENGTH,
+                    },
+                })
+            } else if (newPincode !== confirmedPincode) {
+                confirmationPincodeError = locale('error.pincode.match')
+            } else {
+                pinCodeBusy = true
+                pinCodeMessage = locale('general.pinCodeUpdating')
 
-            const _clear = (err?) => {
-                setTimeout(() => {
-                    pinCodeMessage = ''
-                }, 2000)
-                pinCodeBusy = false
-                if (err) {
-                    currentPincodeError = err
-                    pinCodeMessage = locale('general.pinCodeFailed')
-                } else {
-                    pinCodeMessage = locale('general.pinCodeSuccess')
-                }
-            }
-
-            Electron.PincodeManager.verify(get(activeProfile)?.id, currentPincode)
-                .then((valid) => {
-                    if (valid) {
-                        return new Promise<void>((resolve, reject) => {
-                            api.setStoragePassword(newPincode, {
-                                onSuccess() {
-                                    Electron.PincodeManager.set(get(activeProfile)?.id, newPincode)
-                                        .then(() => {
-                                            currentPincode = ''
-                                            newPincode = ''
-                                            confirmedPincode = ''
-                                            _clear()
-                                            resolve()
-                                        })
-                                        .catch(reject)
-                                },
-                                onError(err) {
-                                    _clear(locale(err.error))
-                                },
-                            })
-                        })
+                const _clear = (err?) => {
+                    setTimeout(() => {
+                        pinCodeMessage = ''
+                    }, 2000)
+                    pinCodeBusy = false
+                    if (err) {
+                        currentPincodeError = err
+                        pinCodeMessage = locale('general.pinCodeFailed')
                     } else {
-                        _clear(locale('error.pincode.incorrect'))
+                        pinCodeMessage = locale('general.pinCodeSuccess')
                     }
-                })
-                .catch((err) => {
-                    _clear(err.message)
-                })
+                }
+
+                Electron.PincodeManager.verify(get(activeProfile)?.id, currentPincode)
+                    .then((valid) => {
+                        if (valid) {
+                            return new Promise<void>((resolve, reject) => {
+                                api.setStoragePassword(newPincode, {
+                                    onSuccess() {
+                                        Electron.PincodeManager.set(get(activeProfile)?.id, newPincode)
+                                            .then(() => {
+                                                currentPincode = ''
+                                                newPincode = ''
+                                                confirmedPincode = ''
+                                                _clear()
+                                                resolve()
+                                            })
+                                            .catch(reject)
+                                    },
+                                    onError(err) {
+                                        _clear(locale(err.error))
+                                    },
+                                })
+                            })
+                        } else {
+                            _clear(locale('error.pincode.incorrect'))
+                        }
+                    })
+                    .catch((err) => {
+                        _clear(err.message)
+                    })
+            }
         }
     }
 
@@ -315,7 +319,8 @@
                 showRevealToggle
                 {locale}
                 placeholder={locale('general.confirmNewPassword')}
-                disabled={passwordChangeBusy} />
+                disabled={passwordChangeBusy} 
+                submitHandler={changePassword} />
             <Checkbox
                 classes="mb-5"
                 label={locale('actions.exportNewStronghold')}
@@ -344,7 +349,7 @@
             <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.newPincode')}</Text>
             <Pin smaller error={newPincodeError} classes="mb-4" bind:value={newPincode} disabled={pinCodeBusy} />
             <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.confirmNewPincode')}</Text>
-            <Pin smaller error={confirmationPincodeError} classes="mb-4" bind:value={confirmedPincode} disabled={pinCodeBusy} />
+            <Pin smaller error={confirmationPincodeError} classes="mb-4" bind:value={confirmedPincode} disabled={pinCodeBusy} on:submit={changePincode} />
             <div class="flex flex-row items-center">
                 <Button
                     medium

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -301,7 +301,8 @@
                 showRevealToggle
                 {locale}
                 placeholder={locale('general.currentPassword')}
-                disabled={passwordChangeBusy} />
+                disabled={passwordChangeBusy} 
+                submitHandler={changePassword} />
             <Password
                 error={newPasswordError}
                 classes="mb-4"
@@ -312,7 +313,8 @@
                 strength={passwordStrength.score}
                 {locale}
                 placeholder={locale('general.newPassword')}
-                disabled={passwordChangeBusy} />
+                disabled={passwordChangeBusy} 
+                submitHandler={changePassword} />
             <Password
                 classes="mb-5"
                 bind:value={confirmedPassword}
@@ -345,9 +347,9 @@
             <Text type="p" secondary classes="mb-5">{locale('views.settings.changePincode.description')}</Text>
 
             <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.currentPincode')}</Text>
-            <Pin smaller error={currentPincodeError} classes="mb-4" bind:value={currentPincode} disabled={pinCodeBusy} />
+            <Pin smaller error={currentPincodeError} classes="mb-4" bind:value={currentPincode} disabled={pinCodeBusy} on:submit={changePincode} />
             <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.newPincode')}</Text>
-            <Pin smaller error={newPincodeError} classes="mb-4" bind:value={newPincode} disabled={pinCodeBusy} />
+            <Pin smaller error={newPincodeError} classes="mb-4" bind:value={newPincode} disabled={pinCodeBusy} on:submit={changePincode} />
             <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.confirmNewPincode')}</Text>
             <Pin smaller error={confirmationPincodeError} classes="mb-4" bind:value={confirmedPincode} disabled={pinCodeBusy} on:submit={changePincode} />
             <div class="flex flex-row items-center">


### PR DESCRIPTION
# Description of change

Added keyboard handlers for submission of password and pin in settings.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/847

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
