### PR TITLE
[Docs] Add information about required Secrets API implementation on Linux

### DIFF
--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -27,6 +27,7 @@ For all platforms, the following are required:
 -   `libssl` (Debian/Ubuntu: `libssl-dev`, Red Hat: `openssl-devel`, Arch Linux: `openssl`)
 -   `libusb` (Debian/Ubuntu: `libusb-1.0-0-dev`)
 -   `libudev` (Debian/Ubuntu: `libudev-dev`)
+-   `gnome-keyring`, `keepassxc`, or another secrets manager that implements the [freedesktop.org Secrets API](https://www.freedesktop.org/wiki/Specifications/secret-storage-spec/)
 
 ## Building Firefly 
 


### PR DESCRIPTION
# Description of change

On Linux, Firefly relies on the freedesktop.org Secrets API being implemented by the secrets manager that is installed on the system. This commit addresses this requirement in the desktop readme file.

## Links to any relevant issues

Fixes #852.

## Type of change

- Documentation Fix

## How the change has been tested

I am running Manjaro KDE, a system that currently does not come with an implementation of the freedesktop.org Secrets API. After installing `keepassxc`, the issue described in #850 was fixed.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation
