### PR TITLE
feat: Cleanup profiles not in app or with no data

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -10,7 +10,7 @@
     import { pollMarketData } from 'shared/lib/marketData'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
     import { openPopup, popupState } from 'shared/lib/popup'
-    import { cleanupInProgressProfiles } from 'shared/lib/profile'
+    import { cleanupEmptyProfiles, cleanupInProgressProfiles } from 'shared/lib/profile'
     import { dashboardRoute, initRouter, routerNext, routerPrevious, walletRoute } from 'shared/lib/router'
     import { AppRoute, Tabs } from 'shared/lib/typings/routes'
     import {
@@ -95,6 +95,7 @@
         })
 
         await cleanupInProgressProfiles()
+        await cleanupEmptyProfiles()
     })
 </script>
 

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -34,6 +34,20 @@ const Electron = {
             }
         })
     },
+    listProfileFolders(profileStoragePath, profiles) {
+        return ipcRenderer.invoke('get-path', 'userData').then((userDataPath) => {
+            // Check that the profile path matches the user data path
+            // so that we don't try and remove things outside our scope
+            if (profileStoragePath.startsWith(userDataPath)) {
+                try {
+                    // Get a list of all the profile folders in storage
+                    return fs.readdirSync(profileStoragePath)
+                } catch (err) {
+                    console.log(err)
+                }
+            }
+        })
+    },
     PincodeManager,
     DeepLinkManager,
     NotificationManager,

--- a/packages/shared/lib/electron.ts
+++ b/packages/shared/lib/electron.ts
@@ -54,6 +54,7 @@ export interface IElectron {
     getOS(): Promise<string>;
     updateActiveProfile(id: string): void;
     removeProfileFolder(profilePath: string): Promise<void>;
+    listProfileFolders(profileStoragePath: string): Promise<string[]>;
     updateMenu(attribute: string, value: unknown): void;
     popupMenu(): void;
     maximize(): Promise<boolean>;

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -183,8 +183,12 @@ export const api: {
     onTransferProgress(callbacks: { onSuccess: (response: Event<TransferProgressEventPayload>) => void, onError: (err: ErrorEventPayload) => void })
 } = window['__WALLET_API__']
 
+export const getWalletStoragePath = (appPath: string): string => {
+    return `${appPath}/${WALLET_STORAGE_DIRECTORY}/`
+}
+
 export const getStoragePath = (appPath: string, profileName: string): string => {
-    return `${appPath}/${WALLET_STORAGE_DIRECTORY}/${profileName}`
+    return `${getWalletStoragePath(appPath)}${profileName}`
 }
 
 export const initialise = (id: string, storagePath: string): void => {


### PR DESCRIPTION
# Description of change

Any profiles that have stored folders but are not listed in the app, or listed in the app but have no stored data are cleaned up.
This eliminates debris that cant be caused from failed signups or interruptions.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
