### PR TITLE
fix: Address history is kept up to date with incoming data

### DIFF
--- a/packages/shared/lib/typings/events.ts
+++ b/packages/shared/lib/typings/events.ts
@@ -1,5 +1,4 @@
 import type { ResponseTypes } from './bridge'
-import type { Address } from './address'
 import type { Message } from './message'
 
 // Reference: https://github.com/iotaledger/wallet.rs/blob/develop/src/error.rs
@@ -84,7 +83,7 @@ export interface ErrorEventPayload {
 export interface BalanceChangeEventPayload {
     indexationId: string    
     accountId: string
-    address: Address
+    address: string
     balanceChange: {
         spent: number;
         received: number;

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -598,7 +598,7 @@ const updateAllMessagesState = (accounts, messageId, confirmation) => {
  */
 export const updateAccountAfterBalanceChange = (
     accountId: string,
-    address: Address,
+    address: string,
     receivedBalance: number,
     spentBalance: number
 ): void => {
@@ -611,7 +611,7 @@ export const updateAccountAfterBalanceChange = (
 
                 const activeCurrency = get(activeProfile)?.settings.currency ?? CurrencyTypes.USD;
 
-                return Object.assign<WalletAccount, Partial<WalletAccount>, Partial<WalletAccount>>({} as WalletAccount, storedAccount, {
+                return Object.assign<WalletAccount, Partial<WalletAccount>>(storedAccount, {
                     rawIotaBalance,
                     balance: formatUnit(rawIotaBalance, 2),
                     balanceEquiv: `${convertToFiat(
@@ -620,8 +620,8 @@ export const updateAccountAfterBalanceChange = (
                         get(exchangeRates)[activeCurrency]
                     )} ${activeCurrency}`,
                     addresses: storedAccount.addresses.map((_address: Address) => {
-                        if (_address.address === address.address) {
-                            return Object.assign<Address, Partial<Address>, Partial<Address>>({} as Address, _address, address)
+                        if (_address.address === address) {
+                            _address.balance += receivedBalance - spentBalance
                         }
 
                         return _address

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -158,13 +158,11 @@
                     accounts.update((accounts) =>
                         accounts.map((account) => {
                             if (account.id === accountId) {
-                                return Object.assign<WalletAccount, WalletAccount, Partial<WalletAccount>>(
-                                    {} as WalletAccount,
-                                    account,
-                                    {
-                                        depositAddress: response.payload.address,
-                                    }
-                                )
+                                account.depositAddress = response.payload.address
+
+                                if (!account.addresses.some(a => a.address === response.payload.address)) {
+                                    account.addresses.push(response.payload)
+                                }
                             }
 
                             return account


### PR DESCRIPTION
# Description of change

When a new address was generated it was not added to the address history, so any future balances changes could not find the address to store the relevant information. 
The typing for balance update event was incorrect so balance updates were never reflected live in the address history.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/828

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
