### PR TITLE
fix: Internal address transfer

### DIFF
--- a/packages/shared/components/inputs/Address.svelte
+++ b/packages/shared/components/inputs/Address.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
-    import { ADDRESS_LENGTH } from 'shared/lib/utils'
     import { Error } from 'shared/components'
+    import { ADDRESS_LENGTH } from 'shared/lib/utils'
+    import { onMount } from 'svelte'
 
     export let address = undefined
     export let classes = ''
@@ -8,6 +9,15 @@
     export let label = undefined
     export let placeholder = undefined
     export let error = ''
+    export let autofocus = false
+
+    let textAreaElement
+
+    onMount(() => {
+        if (autofocus) {
+            textAreaElement.focus()
+        }
+    })
 </script>
 
 <style type="text/scss">
@@ -68,9 +78,10 @@
     }
 </style>
 
-<div class="{classes}">
+<div class={classes}>
     <address-input class="flex relative" {disabled}>
         <textarea
+            bind:this={textAreaElement}
             bind:value={address}
             class="w-full text-12 leading-140 border border-solid resize-none
                 {disabled ? 'text-gray-400 dark:text-gray-700' : 'text-gray-800 dark:text-white'} bg-white dark:bg-gray-800 

--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -15,6 +15,7 @@
     export let contentWidth = false
     export let error = ''
     export let classes = ''
+    export let autofocus = false
 
     let dropdown = false
     let navContainer
@@ -86,6 +87,9 @@
     onMount(() => {
         if (contentWidth) {
             navWidth = `width: ${navContainer.clientWidth + 8}px`
+        }
+        if (autofocus) {
+            divContainer.focus()
         }
     })
 </script>

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -421,7 +421,7 @@
         })
     }
 
-    function onInternalTransfer(senderAccountId, receiverAccountId, amount) {
+    function onInternalTransfer(senderAccountId, receiverAccountId, amount, internal) {
         const _internalTransfer = () => {
             isTransferring.set(true)
             api.internalTransfer(senderAccountId, receiverAccountId, amount, {
@@ -471,7 +471,7 @@
                     transferState.set('Complete')
 
                     setTimeout(() => {
-                        clearSendParams(true)
+                        clearSendParams(internal)
                         isTransferring.set(false)
                     }, 3000)
                 },


### PR DESCRIPTION
# Description of change

If someone enters an address belonging to one of the internal accounts internally we automatically switch to an internal transfer.
The `Address` and `Dropdown` components now have an `autofocus` property which is set on Send/Internal Transfer instead of the value amount.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
