### PR TITLE
Feat: filter out self transactions from chart algorithms

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -30,17 +30,13 @@
             ?.filter((output) => output?.data?.remainder === false)
             ?.map((output) => output?.data?.address) ?? []
 
-    $: senderAccount = !payload.data.essence.data.incoming
-        ? $activeAccount
-        : payload.data.essence.data.internal
-        ? $accounts.find((acc) => acc.addresses.some((add) => senderAddress === add.address))
+    $: senderAccount = senderAddress
+        ? $accounts?.find((acc) => acc.addresses.some((add) => senderAddress === add.address)) ?? null
+        : null
+    $: receiverAccount = receiverAddresses?.length
+        ? $accounts.find((acc) => acc.addresses.some((add) => receiverAddresses.includes(add.address))) ?? null
         : null
 
-    $: receiverAccount = payload.data.essence.data.incoming
-        ? $activeAccount
-        : payload.data.essence.data.internal
-        ? $accounts.find((acc) => acc.addresses.some((add) => receiverAddresses.includes(add.address)))
-        : null
 </script>
 
 <div class="flex flex-col h-full min-h-0">

--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -1,13 +1,13 @@
 <script lang="typescript">
     import { Icon, Text } from 'shared/components'
     import { getInitials, truncateString } from 'shared/lib/helpers'
+    import type { Payload } from 'shared/lib/typings/message'
     import { formatUnit } from 'shared/lib/units'
     import { setClipboard } from 'shared/lib/utils'
     import type { WalletAccount } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import { date } from 'svelte-i18n'
     import type { Readable, Writable } from 'svelte/store'
-    import type { Payload } from 'shared/lib/typings/message'
 
     export let id
     export let timestamp
@@ -37,6 +37,9 @@
         ? $accounts.find((acc) => acc.addresses.some((add) => receiverAddresses.includes(add.address))) ?? null
         : null
 
+    function isAccountSameAsActive(account) {
+        return account && $activeAccount && account?.id === $activeAccount?.id
+    }
 </script>
 
 <div class="flex flex-col h-full min-h-0">
@@ -48,7 +51,7 @@
                     class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold text-center bg-{senderAccount?.color ?? 'blue'}-500 text-white">
                     {getInitials(senderAccount.alias, 2)}
                 </div>
-                {#if !payload.data.essence.data.incoming}
+                {#if isAccountSameAsActive(senderAccount)}
                     <Text smaller>{locale('general.you')}</Text>
                 {/if}
             {:else}
@@ -64,11 +67,10 @@
                     class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold bg-{receiverAccount?.color ?? 'blue'}-500 text-white">
                     {getInitials(receiverAccount.alias, 2)}
                 </div>
-                {#if payload.data.essence.data.incoming}
-                    <Text smaller>{locale('general.you')}</Text>
-                {/if}
             {/if}
-            {#if !payload.data.essence.data.incoming}
+            {#if isAccountSameAsActive(receiverAccount)}
+                <Text smaller>{locale('general.you')}</Text>
+            {:else}
                 {#each receiverAddresses as address}
                     <Text smaller>{truncateString(address, 3, 3, 3)}</Text>
                 {/each}


### PR DESCRIPTION
# Description of change

Due to self transactions missing messages (from acc A to acc A) the portfolio/account chart algorithm was not correctly calculating balances. Now we filter out self transactions from chart algorithms.

Additionally the logic to display the message detail has been improved

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Self transactions should not compute to the charts as they dont change the balance.
You can test sending some transaction to yourself.

Myself: tested on Linux Ubuntu 18.04

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
