### PR TITLE
fix: Wait for logout completion before cleaning up profile

### DIFF
--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -53,7 +53,7 @@ export const developerMode = persistent<boolean>('developerMode', false)
 /**
  * Cleanup the signup vars
  */
- export const cleanupSignup = () => {
+export const cleanupSignup = () => {
     mnemonic.set(null)
     strongholdPassword.set(null)
     walletPin.set(null)
@@ -71,37 +71,41 @@ export const login = () => {
  * Logout from current profile
  */
 export const logout = () => {
-    const ap = get(activeProfile);
+    return new Promise<void>((resolve) => {
+        const ap = get(activeProfile);
 
-    const _cleanup = () => {
-        if (ap) {
-            destroyActor(ap.id)
+        const _cleanup = () => {
+            if (ap) {
+                destroyActor(ap.id)
+            }
+            isStrongholdLocked.set(true)
+            clearSendParams()
+            closePopup()
+            resetWallet()
+            resetRouter()
+            clearActiveProfile()
+            loggedIn.set(false)
+
+            resolve()
         }
-        isStrongholdLocked.set(true)
-        clearSendParams()
-        closePopup()
-        resetWallet()
-        resetRouter()
-        clearActiveProfile()
-        loggedIn.set(false)
-    }
 
-    if (!get(isStrongholdLocked)) {
-        api.lockStronghold({
-            onSuccess() {
-                _cleanup()
-            },
-            onError(err) {
-                _cleanup()
+        if (!get(isStrongholdLocked)) {
+            api.lockStronghold({
+                onSuccess() {
+                    _cleanup()
+                },
+                onError(err) {
+                    _cleanup()
 
-                showAppNotification({
-                    type: 'error',
-                    message: localize(err.error),
-                })
+                    showAppNotification({
+                        type: 'error',
+                        message: localize(err.error),
+                    })
 
-            },
-        })
-    } else {
-        _cleanup()
-    }
+                },
+            })
+        } else {
+            _cleanup()
+        }
+    })
 }


### PR DESCRIPTION
# Description of change

When deleting a profile the stronghold could be in an unlocked state, logout locks the stronghold as one of its steps. However because the delete profile did not wait for this completion callback it tried to perform cleanup operations at the same time.

The changes now make the logout an async call so it can be waited on for completion. Other uses of logout have no following processes so behave the same as they always did.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

From fresh Firefly
* Create profile 1
* Create profile 2
* Delete profile 2 - confirm storage folder for profile 2 has been removed
* Login to profile 1 - Sync happens and completes successfully
* Delete profile 1 - App return to welcome screen and confirm storage folder for profile 1 has been removed

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
