### PR TITLE
fix: New transaction disappears if syncing at same time as arrival

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -411,15 +411,13 @@ export const initialiseListeners = () => {
                 );
             }
 
-            if (!get(isSyncing)) {
-                // Update account with new message
-                saveNewMessage(response.payload.accountId, response.payload.message);
-                const notificationMessage = localize('notifications.valueTx')
-                    .replace('{{value}}', formatUnit(message.payload.data.essence.data.value))
-                    .replace('{{account}}', account.alias);
+            saveNewMessage(response.payload.accountId, response.payload.message);
 
-                showSystemNotification({ type: "info", message: notificationMessage, contextData: { type: "valueTx", accountId: account.id } });
-            }
+            const notificationMessage = localize('notifications.valueTx')
+                .replace('{{value}}', formatUnit(message.payload.data.essence.data.value))
+                .replace('{{account}}', account.alias);
+
+            showSystemNotification({ type: "info", message: notificationMessage, contextData: { type: "valueTx", accountId: account.id } });
         },
         onError(error) {
             console.error(error)
@@ -648,9 +646,11 @@ export const saveNewMessage = (accountId: string, message: Message): void => {
     accounts.update((storedAccounts) => {
         return storedAccounts.map((storedAccount: WalletAccount) => {
             if (storedAccount.id === accountId) {
-                return Object.assign<WalletAccount, Partial<WalletAccount>, Partial<WalletAccount>>({} as WalletAccount, storedAccount, {
-                    messages: [message, ...storedAccount.messages]
-                })
+                const hasMessage = storedAccount.messages.some(m => m.id === message.id)
+
+                if (!hasMessage) {
+                    storedAccount.messages.push(message)
+                }
             }
 
             return storedAccount;


### PR DESCRIPTION
# Description of change

If a sync was in progress at the same time as a new transaction arrived the message was not saved, if the sync data did not contain the new message it was lost forever. It looks like this check was put in place to make sure we didn't end up with duplicates messages i.e. in the sync data and the new transaction event. This also meant that we missed notifications more new transactions as sync doesn't do any message notification.

Instead of not doing any updates if syncing this PR will save and notify, but the save will check to see if it already has the message before adding it again.

This reverses some of the changes made in https://github.com/iotaledger/firefly/pull/523/files

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/862

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
