### PR TITLE
fix: Windows maximize icon color does not match background

### DIFF
--- a/packages/shared/components/TitleBar.svelte
+++ b/packages/shared/components/TitleBar.svelte
@@ -76,7 +76,7 @@
                                 height="11"
                                 stroke="currentColor"
                                 stroke-width="1.5"
-                                fill={darkModeEnabled ? fullConfig.theme.colors.gray['900'] : fullConfig.theme.colors.white} />
+                                fill={darkModeEnabled ? fullConfig.theme.colors.gray['900'] : (showingDashboard && !showingSettings ? fullConfig.theme.colors.gray['50'] : fullConfig.theme.colors.white)} />
                         {:else}
                             <rect x="2.5" y="2.5" width="11" height="11" rx="0.5" stroke="currentColor" stroke-width="1.5" />
                         {/if}


### PR DESCRIPTION
# Description of change

The windows maximize icon always filled white in light theme instead of the background color.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
