### PR TITLE
fix: Always mark internal transfers as true

### DIFF
--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -451,6 +451,7 @@
                                                         essence: Object.assign({}, message.payload.data.essence, {
                                                             data: Object.assign({}, message.payload.data.essence.data, {
                                                                 incoming: isReceiverAccount,
+                                                                internal: true
                                                             }),
                                                         }),
                                                     }),


### PR DESCRIPTION
# Description of change

When a new account is created any internal transfer you send is not marked as `internal` as the underlying response coming back from the wallet lib does not set the flag. If you logout/login then they are successfully marked as internal. This points to an underlying issue in wallet lib.

This PR will always flag internal transfer as true which overrides the value that comes back from wallet.rs.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/863

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
