### PR TITLE
fix: Hide the settings profile and export state entry until implemented

### DIFF
--- a/packages/shared/lib/typings/routes.ts
+++ b/packages/shared/lib/typings/routes.ts
@@ -60,7 +60,8 @@ export enum SettingsRoutesNoProfile {
 }
 
 export enum GeneralSettings {
-    Profile = 'profile',
+    // TODO: Implement and enable
+    // Profile = 'profile',
     Theme = 'theme',
     Language = 'language',
     Currency = 'currency',
@@ -90,7 +91,8 @@ export enum AdvancedSettings {
     HiddenAccounts = 'hiddenAccounts',
     ErrorLog = 'errorLog',
     Diagnostics = 'diagnostics',
-    StateExport = 'stateExport',
+    // TODO: Implement and enable
+    //StateExport = 'stateExport',
 }
 
 export enum AdvancedSettingsNoProfile {

--- a/packages/shared/routes/dashboard/settings/views/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Advanced.svelte
@@ -283,13 +283,13 @@
             {locale('views.settings.diagnostics.title')}
         </Button>
     </section>
-    {#if $loggedIn}
-        <HR classes="pb-5 mt-5 justify-center" />
-        <!-- TODO: Implement state export -->
-        <section id="stateExport" class="w-3/4 opacity-50">
-            <Text type="h4" classes="mb-3">{locale('views.settings.stateExport.title')}</Text>
-            <Text type="p" secondary classes="mb-5">{locale('views.settings.stateExport.description')}</Text>
-            <Button medium inlineStyle="min-width: 156px;" disabled onClick={() => {}}>{locale('actions.exportState')}</Button>
-        </section>
-    {/if}
+    <!-- TODO: Implement state export -->
+    <!-- {#if $loggedIn}
+    <HR classes="pb-5 mt-5 justify-center" />
+    <section id="stateExport" class="w-3/4 opacity-50">
+        <Text type="h4" classes="mb-3">{locale('views.settings.stateExport.title')}</Text>
+        <Text type="p" secondary classes="mb-5">{locale('views.settings.stateExport.description')}</Text>
+        <Button medium inlineStyle="min-width: 156px;" disabled onClick={() => {}}>{locale('actions.exportState')}</Button>
+    </section>
+    {/if} -->
 </div>


### PR DESCRIPTION
# Description of change

Hide the settings and navigation for General->Profile and Advanced Settings->State Export until they are implemented.

## Fixes

Fixes https://github.com/iotaledger/firefly/issues/830

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
