### PR TITLE
fix: Increase the padding for native About dialog

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -172,6 +172,9 @@
             @apply pr-2;
         }
     }
+    img {
+        -webkit-user-drag: none;
+    }
 </style>
 
 <TitleBar>

--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -391,8 +391,8 @@ export const openAboutWindow = () => {
     }
 
     windows.about = new BrowserWindow({
-        width: 300,
-        height: 180,
+        width: 380,
+        height: 230,
         useContentSize: true,
         titleBarStyle: 'hidden',
         show: false,

--- a/packages/desktop/public/about.html
+++ b/packages/desktop/public/about.html
@@ -32,6 +32,8 @@
         width: 100%;
         height: 100%;
         user-select: none;
+        -webkit-user-drag: none;
+        overflow: hidden;
       }
 
       body {
@@ -46,20 +48,24 @@
         font-family: 'Inter';
       }
 
-      .version {
+      #app-icon {
+        margin-top: 20px;
+        -webkit-user-drag: none;
+      }
+
+      #app-version {
         margin-bottom: 0.05rem;
       }
 
-      .title {
-        margin-top: 0.3rem;
-        margin-bottom: 0.05rem;
+      #footer {
+        margin-bottom: 30px;
       }
     </style>
   </head>
   <body>
     <img id="app-icon" alt="App icon" height="70" width="70" />
     <h2 id="title"></h2>
-    <p id="app-version" class="version"></p>
+    <p id="app-version"></p>
 
     <p id="footer"></p>
     <!-- https://github.com/electron/electron/issues/2863 -->


### PR DESCRIPTION
# Description of change

The padding top and bottom of the native about dialog is increased along with the height, the width is also increased to maintain the golden ratio.

This also disables image dragging for about and the main app.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/837

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
