### PR TITLE
fix: Larger initial gap limit for syncing when importing

### DIFF
--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -26,6 +26,7 @@ interface Profile {
     settings: UserSettings
     isDeveloperProfile: boolean
     hiddenAccounts?: string[]
+    gapLimit?: number
 }
 
 /**
@@ -98,6 +99,7 @@ export const createProfile = (profileName, isDeveloperProfile): Profile => {
         name: profileName,
         lastStrongholdBackupTime: null,
         isDeveloperProfile,
+        gapLimit: 10,
         settings: {
             currency: AvailableExchangeRates.USD,
             automaticNodeSelection: true,
@@ -187,7 +189,7 @@ export const removeProfile = (id: string): void => {
  * @returns {void}
  */
 export const updateProfile = (
-    path: string, value: string | string[] | boolean | Date | AvailableExchangeRates | Node | Node[] | ChartSelectors | HistoryDataProps) => {
+    path: string, value: string | string[] | boolean | Date | number | AvailableExchangeRates | Node | Node[] | ChartSelectors | HistoryDataProps) => {
     const _update = (_profile) => {
         const pathList = path.split('.')
 

--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -1,5 +1,5 @@
 import { cleanupSignup, login, strongholdPassword, walletPin } from 'shared/lib/app'
-import { profiles } from 'shared/lib/profile'
+import { profiles, updateProfile } from 'shared/lib/profile'
 import { selectedAccountId } from 'shared/lib/wallet'
 import { AccountRoutes, AppRoute, SettingsRoutes, SetupType, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
 import { get, readable, writable } from 'svelte/store'
@@ -179,6 +179,7 @@ export const routerNext = (event) => {
             nextRoute = AppRoute.Congratulations
             break
         case AppRoute.Congratulations:
+            updateProfile('gapLimit', get(walletSetupType) === SetupType.New ? 10 : 50)
             cleanupSignup()
             login()
             nextRoute = AppRoute.Dashboard

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -108,7 +108,9 @@
             onSuccess(accountsResponse) {
                 const _continue = () => {
                     accountsLoaded.set(true)
-                    syncAccounts(false)
+                    const gapLimit = $activeProfile?.gapLimit ?? 10
+                    syncAccounts(false, 0, gapLimit)
+                    updateProfile('gapLimit', 10)
                 }
 
                 if (accountsResponse.payload.length === 0) {

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -42,7 +42,7 @@
                     openPopup({ type: 'password', props: { onSuccess: () => syncAccounts(false, 0, 10) } })
                 } else {
                     const gapLimit = $activeProfile?.gapLimit
-                    syncAccounts(false, gapLimit ?? 0, gapLimit)
+                    syncAccounts(false, gapLimit === undefined ? undefined : 0, gapLimit)
                     updateProfile('gapLimit', undefined)
                 }
             },

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -1,10 +1,19 @@
 <script lang="typescript">
     import { ActivityRow, Icon, Text } from 'shared/components'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { openPopup } from 'shared/lib/popup';
+    import { openPopup } from 'shared/lib/popup'
+    import { activeProfile, updateProfile } from 'shared/lib/profile'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
-    import { api, AccountMessage, isSyncing, selectedAccountId, selectedMessage, syncAccounts, WalletAccount } from 'shared/lib/wallet'
+    import {
+        AccountMessage,
+        api,
+        isSyncing,
+        selectedAccountId,
+        selectedMessage,
+        syncAccounts,
+        WalletAccount,
+    } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import type { Readable, Writable } from 'svelte/store'
     import { get } from 'svelte/store'
@@ -32,7 +41,9 @@
                 if (strongholdStatusResponse.payload.snapshot.status === 'Locked') {
                     openPopup({ type: 'password', props: { onSuccess: () => syncAccounts(false, 0, 10) } })
                 } else {
-                    syncAccounts(false)
+                    const gapLimit = $activeProfile?.gapLimit
+                    syncAccounts(false, gapLimit ?? 0, gapLimit)
+                    updateProfile('gapLimit', undefined)
                 }
             },
             onError(err) {


### PR DESCRIPTION
# Description of change

When initially syncing an imported profile increase the gap limit parameter to read a larger number of addresses.
Also increase the gap limit for first manual sync in any session.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
