### PR TITLE
fix: Setup change password

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -264,6 +264,19 @@ export const asyncSetStrongholdPassword = (password) => {
     })
 }
 
+export const asyncChangeStrongholdPassword = (currentPassword, newPassword) => {
+    return new Promise<void>((resolve, reject) => {
+        api.changeStrongholdPassword(currentPassword, newPassword, {
+            onSuccess() {
+                resolve()
+            },
+            onError(err) {
+                reject(err)
+            },
+        })
+    })
+}
+
 export const asyncStoreMnemonic = (mnemonic) => {
     return new Promise<void>((resolve, reject) => {
         api.storeMnemonic(mnemonic, {

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -1,14 +1,16 @@
 <script lang="typescript">
-    import { showAppNotification } from 'shared/lib/notifications'
     import { Button, Illustration, OnboardingLayout, Password, Text } from 'shared/components'
+    import { strongholdPassword } from 'shared/lib/app'
+    import { showAppNotification } from 'shared/lib/notifications'
     import passwordInfo from 'shared/lib/password'
-    import { asyncSetStrongholdPassword, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
+    import { asyncChangeStrongholdPassword, asyncSetStrongholdPassword, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
     import { createEventDispatcher } from 'svelte'
     import zxcvbn from 'zxcvbn'
 
     export let locale
     export let mobile
 
+    let existingPassword = $strongholdPassword
     let password = ''
     let confirmedPassword = ''
     let error = ''
@@ -18,7 +20,7 @@
     const dispatch = createEventDispatcher()
 
     $: passwordStrength = zxcvbn(password)
-    $: password, confirmedPassword, (error = '', errorConfirm='')
+    $: password, confirmedPassword, ((error = ''), (errorConfirm = ''))
 
     async function handleContinueClick() {
         error = ''
@@ -41,7 +43,11 @@
         } else {
             try {
                 busy = true
-                await asyncSetStrongholdPassword(password)
+                if (existingPassword) {
+                    await asyncChangeStrongholdPassword(existingPassword, password)
+                } else {
+                    await asyncSetStrongholdPassword(password)
+                }
 
                 dispatch('next', { password })
             } catch (err) {


### PR DESCRIPTION
# Description of change

During setup if you navigate past the password stage and then click back you cannot change the password as the stronghold password has already been set.

With this change if a password has already been set in the stronghold `changePassword` is called instead of `setPassword`

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/878

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
