### PR TITLE
fix : Invalid balance calculation

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -862,7 +862,7 @@ export const updateAccounts = (syncedAccounts: SyncedAccount[]): void => {
             addresses: mergeProps(storedAccount.addresses, syncedAccount.addresses, 'address'),
             messages: mergeProps(storedAccount.messages, syncedAccount.messages, 'id'),
         })
-    }).sort((a, b) => a.index - b.index)
+    })
 
     if (newAccounts.length) {
         const totalBalance = {
@@ -872,8 +872,9 @@ export const updateAccounts = (syncedAccounts: SyncedAccount[]): void => {
         }
 
         const _accounts = []
+        let completeCount = 0
 
-        for (const [idx, newAccount] of newAccounts.entries()) {
+        for (const newAccount of newAccounts) {
             getAccountMeta(newAccount.id, (err, meta) => {
                 if (!err) {
                     totalBalance.balance += meta.balance
@@ -891,28 +892,30 @@ export const updateAccounts = (syncedAccounts: SyncedAccount[]): void => {
                     }), meta)
 
                     _accounts.push(account)
-
-                    if (idx === newAccounts.length - 1) {
-                        const { balanceOverview } = get(wallet);
-                        const overview = get(balanceOverview);
-
-                        accounts.update(() => {
-                            return [...updatedStoredAccounts, ..._accounts]
-                        })
-
-                        updateBalanceOverview(
-                            overview.balanceRaw + totalBalance.balance,
-                            overview.incomingRaw + totalBalance.incoming,
-                            overview.outgoingRaw + totalBalance.outgoing
-                        )
-                    }
                 } else {
                     console.error(err)
                 }
+
+                completeCount++
+                if (completeCount === newAccounts.length) {
+                    const { balanceOverview } = get(wallet);
+                    const overview = get(balanceOverview);
+
+                    accounts.update(() => {
+                        return [...updatedStoredAccounts, ..._accounts].sort((a, b) => a.index - b.index)
+                    })
+
+                    updateBalanceOverview(
+                        overview.balanceRaw + totalBalance.balance,
+                        overview.incomingRaw + totalBalance.incoming,
+                        overview.outgoingRaw + totalBalance.outgoing
+                    )
+                }
+
             })
         }
     } else {
-        accounts.update(() => updatedStoredAccounts);
+        accounts.update(() => updatedStoredAccounts.sort((a, b) => a.index - b.index));
     }
 };
 

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -32,7 +32,7 @@
         WalletAccount,
     } from 'shared/lib/wallet'
     import { onMount, setContext } from 'svelte'
-    import { derived, get, Readable, Writable } from 'svelte/store'
+    import { derived, Readable, Writable } from 'svelte/store'
     import { Account, CreateAccount, LineChart, Security, WalletActions, WalletBalance, WalletHistory } from './views/'
 
     export let locale

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -32,7 +32,7 @@
         WalletAccount,
     } from 'shared/lib/wallet'
     import { onMount, setContext } from 'svelte'
-    import { derived, Readable, Writable } from 'svelte/store'
+    import { derived, get, Readable, Writable } from 'svelte/store'
     import { Account, CreateAccount, LineChart, Security, WalletActions, WalletBalance, WalletHistory } from './views/'
 
     export let locale
@@ -120,22 +120,27 @@
                         outgoing: 0,
                     }
 
-                    for (const [idx, storedAccount] of accountsResponse.payload.entries()) {
-                        getAccountMeta(storedAccount.id, (err, meta) => {
+                    let completeCount = 0
+                    let newAccounts = []
+                    for (const payloadAccount of accountsResponse.payload) {
+                        getAccountMeta(payloadAccount.id, (err, meta) => {
                             if (!err) {
                                 totalBalance.balance += meta.balance
                                 totalBalance.incoming += meta.incoming
                                 totalBalance.outgoing += meta.outgoing
 
-                                const account = prepareAccountInfo(storedAccount, meta)
-                                accounts.update((accounts) => [...accounts, account])
-
-                                if (idx === accountsResponse.payload.length - 1) {
-                                    updateBalanceOverview(totalBalance.balance, totalBalance.incoming, totalBalance.outgoing)
-                                    _continue()
-                                }
+                                const account = prepareAccountInfo(payloadAccount, meta)
+                                newAccounts.push(account)
                             } else {
                                 console.error(err)
+                            }
+
+                            completeCount++
+
+                            if (completeCount === accountsResponse.payload.length) {
+                                accounts.update((accounts) => [...accounts, ...newAccounts].sort((a, b) => a.index - b.index))
+                                updateBalanceOverview(totalBalance.balance, totalBalance.incoming, totalBalance.outgoing)
+                                _continue()
                             }
                         })
                     }
@@ -160,7 +165,7 @@
                             if (account.id === accountId) {
                                 account.depositAddress = response.payload.address
 
-                                if (!account.addresses.some(a => a.address === response.payload.address)) {
+                                if (!account.addresses.some((a) => a.address === response.payload.address)) {
                                     account.addresses.push(response.payload)
                                 }
                             }
@@ -451,7 +456,7 @@
                                                         essence: Object.assign({}, message.payload.data.essence, {
                                                             data: Object.assign({}, message.payload.data.essence.data, {
                                                                 incoming: isReceiverAccount,
-                                                                internal: true
+                                                                internal: true,
                                                             }),
                                                         }),
                                                     }),


### PR DESCRIPTION
# Description of change

When account metadata was loaded the loop exited when it reached the account index which was the same as the number of accounts. The accounts sometimes do not come from the wallet in index order, so this loop aborted early.

This fix makes sure all values are taken into account, and sorts the accounts based on their index in other location to make sure similar situations do not occur.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with a stronghold backup which had unsorted accounts.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
