### PR TITLE
fix: Stronghold backup time in local time format

### DIFF
--- a/packages/shared/lib/utils.ts
+++ b/packages/shared/lib/utils.ts
@@ -217,7 +217,9 @@ export const setClipboard = (input: string): boolean => {
 export const getDefaultStrongholdName = (): string => {
     // Match https://github.com/iotaledger/wallet.rs/blob/ffbeaa3466b44f79dd5f87e14ed1bdc4846d9e85/src/account_manager.rs#L1428
     // Trim milliseconds and replace colons with dashes
-    const date = new Date().toISOString().slice(0, -5).replace(/:/g, "-")
+    const tzoffset = (new Date()).getTimezoneOffset() * 60000; // offset in milliseconds
+    const localISOTime = (new Date(Date.now() - tzoffset)).toISOString()
+    const date = localISOTime.slice(0, -5).replace(/:/g, "-")
     return `firefly-backup-${date}.stronghold`
 }
 


### PR DESCRIPTION
# Description of change

The time and date used in the stronghold backup filename does not take into account local time zone.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows from Africa timezone

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
