### PR TITLE
fix: Localization during onboarding, localize timeframe dropdown

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -36,7 +36,13 @@
     import { getLocalisedMenuItems } from './lib/helpers'
 
     $: $appSettings.darkMode ? document.body.classList.add('scheme-dark') : document.body.classList.remove('scheme-dark')
-    $: Electron.updateMenu('strings', getLocalisedMenuItems($_))
+    $: {
+        isLocaleLoaded.subscribe((loaded) => {
+            if (loaded) {
+                Electron.updateMenu('strings', getLocalisedMenuItems($_))
+            }
+        })
+    }
     $: Electron.updateMenu('loggedIn', $loggedIn)
 
     $: if (document.dir !== $dir) {

--- a/packages/shared/lib/marketData.ts
+++ b/packages/shared/lib/marketData.ts
@@ -26,10 +26,10 @@ export enum HistoryDataProps {
 }
 
 enum Timeframes {
-    ONE_HOUR = '1 hour',
-    TWENTY_FOUR_HOURS = '1 day',
-    SEVEN_DAYS = '1 week',
-    ONE_MONTH = '1 month',
+    ONE_HOUR = '1Hour',
+    TWENTY_FOUR_HOURS = '1Day',
+    SEVEN_DAYS = '1Week',
+    ONE_MONTH = '1Month',
 }
 
 enum Histories {

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -411,7 +411,11 @@
         "portoflio": "Portfolio",
         "token": "Token",
         "accountValue": "Account Value",
-        "accountActivity": "Account Activity"
+        "accountActivity": "Account Activity",
+        "timeframe1Hour": "1 hour",
+        "timeframe1Day": "1 day",
+        "timeframe1Week": "1 week",
+        "timeframe1Month": "1 month"
     },
     "actions": {
         "continue": "Continue",

--- a/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
@@ -127,8 +127,8 @@
             <span>
                 <Dropdown
                     small
-                    value={TIMEFRAME_MAP[$activeProfile?.settings.chartSelectors.timeframe]}
-                    items={Object.keys(TIMEFRAME_MAP).map((value) => ({ label: TIMEFRAME_MAP[value], value }))}
+                    value={locale(`charts.timeframe${TIMEFRAME_MAP[$activeProfile?.settings.chartSelectors.timeframe]}`)}
+                    items={Object.keys(TIMEFRAME_MAP).map((value) => ({ label: locale(`charts.timeframe${TIMEFRAME_MAP[value]}`), value }))}
                     onSelect={(newTimeframe) => updateProfile('settings.chartSelectors.timeframe', newTimeframe.value)}
                     contentWidth={true} />
             </span>


### PR DESCRIPTION
# Description of change

Localization was not applied everywhere during onboarding as the loading of the json was not waited to complete before applying.

In addition the market data timeframe drop down was not localized.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/890

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows with onboarding in German

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
