### PR TITLE
fix: Hover button tried wrapping when content had spaces

### DIFF
--- a/packages/shared/components/Button.svelte
+++ b/packages/shared/components/Button.svelte
@@ -151,6 +151,7 @@
                     @apply opacity-0;
                     @apply overflow-hidden;
                     @apply max-w-0;
+                    @apply whitespace-nowrap;
                 }
                 :global(svg.showHoverText) {
                     @apply text-blue-500;


### PR DESCRIPTION
# Description of change

The hover effect on the Create button uses the width to animate, this means that any content with spaces tries to wrap. See the video in https://github.com/iotaledger/firefly/issues/902

To fix we apply no wrap to the hover button style.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/902

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows in Korean

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
