### PR TITLE
fix(backend/bindings/node): Set min macOS version to 10.12

### DIFF
--- a/packages/backend/bindings/node/native/.cargo/config.toml
+++ b/packages/backend/bindings/node/native/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-mmacosx-version-min=10.12"]


### PR DESCRIPTION
# Description of change

The `-mmacosx-version-min=` flag needs to be passed to the compiler when building for macOS, otherwise the app will only run on the macOS version it was compiled for (and later). This is 10.15 (Catalina) and later in our case. This PR sets the minimum macOS version to 10.12 (Sierra). It's important to note that only macOS Mojave (10.14) and later still receive security updates from Apple.

## Links to any relevant issues

Fixes #897 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Before:
```
otool -l /Applications/Firefly\ Beta.app/Contents/Resources/app.asar.unpacked/public/build/index.node| grep LC_BUILD_VERSION -A7
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 10.15
      sdk 10.15.6
   ntools 1
     tool 3
  version 609.8
```
(minimum OS 10.15)

After:
```
otool -l index.node | grep LC_VERSION_MIN_MACOSX -A3
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.12
      sdk 11.1
```
(minimum OS 10.12)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code