### PR TITLE
fix: Make sure destroyed Idle component is not triggered from debounce

### DIFF
--- a/packages/shared/components/Idle.svelte
+++ b/packages/shared/components/Idle.svelte
@@ -6,13 +6,20 @@
     import { get } from 'svelte/store'
 
     let timeout
+    let isDestroyed = false
 
     function handleEvent() {
-        clearTimeout(timeout)
+        // The events are debounced so the component can get onDestroy
+        // called and be followed by a debounced handleEvent so
+        // make sure the idle doesn't get triggered again when its
+        // already destroyed
+        if (!isDestroyed) {
+            clearTimeout(timeout)
 
-        const ap = get(activeProfile)
-        if (ap) {
-            timeout = setTimeout(lock, ap.settings.lockScreenTimeout * 60 * 1000)
+            const ap = get(activeProfile)
+            if (ap) {
+                timeout = setTimeout(lock, ap.settings.lockScreenTimeout * 60 * 1000)
+            }
         }
     }
 
@@ -21,6 +28,7 @@
     }
 
     onDestroy(() => {
+        isDestroyed = true
         clearTimeout(timeout)
     })
 </script>


### PR DESCRIPTION
# Description of change

Although the idle timer was removed in `onDestroy` the events were debounced so they could still call the idle handler after destroy.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with slower debounce

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
