### PR TITLE
fix: Balance update did not record balances for missing addresses

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -623,6 +623,7 @@ export const updateAccountAfterBalanceChange = (
                 const activeCurrency = get(activeProfile)?.settings.currency ?? CurrencyTypes.USD;
 
                 let updatedAddress = false
+                let maxKeyIndex = 0
                 const updatedAccount = Object.assign<WalletAccount, Partial<WalletAccount>>(storedAccount, {
                     rawIotaBalance,
                     balance: formatUnit(rawIotaBalance, 2),
@@ -637,6 +638,8 @@ export const updateAccountAfterBalanceChange = (
                             updatedAddress = true
                         }
 
+                        maxKeyIndex = Math.max(maxKeyIndex, _address.keyIndex)
+
                         return _address
                     })
                 })
@@ -647,7 +650,7 @@ export const updateAccountAfterBalanceChange = (
                     updatedAccount.addresses.push({
                         address,
                         balance: spentBalance + receivedBalance,
-                        keyIndex: updatedAccount.addresses.length,
+                        keyIndex: maxKeyIndex + 1,
                         internal: false,
                         outputs: []
                     })


### PR DESCRIPTION
# Description of change

When a balance update was received if the address was not one that was recognised the balance was discarded. Instead the address is added to those for the account.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
