### PR TITLE
fix: Send to account locks and resets dropdown

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -43,20 +43,6 @@
     $: to, (toError = '')
     $: address, (addressError = '')
 
-    const updateFromSendParams = ((s) => {
-        selectedSendType = s.isInternal ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
-        unit =  s.amount === 0 ? Unit.Mi : Unit.i
-        amount = s.amount === 0 ? '' : formatUnitPrecision(s.amount, Unit.i, false)
-        address = s.address
-        if (from && accountsDropdownItems) {
-            to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : to
-        }
-    })
-
-    const sendSubscription = sendParams.subscribe((s) => {
-        updateFromSendParams(s)
-    })
-
     let transferSteps: {
         [key in TransferProgressEventType | 'Complete']: {
             label: string
@@ -93,31 +79,47 @@
         },
     }
 
-    $: accountsDropdownItems = $liveAccounts.map((acc) => format(acc))
-    $: from = $account ? format($account) : accountsDropdownItems[0]
+    let accountsDropdownItems
+    let from
+    $: {
+        accountsDropdownItems = $liveAccounts.map((acc) => format(acc))
+
+        if (from) {
+            from = accountsDropdownItems.find(a => a.id === from.id)
+        } else {
+            from = $account ? accountsDropdownItems.find(a => a.id === $account.id) : accountsDropdownItems[0]
+        }
+        if (to) {
+            to = accountsDropdownItems.find(a => a.id === to.id)
+        }
+    }
+
+    const clearErrors = () => {
+        amountError = ''
+        addressError = ''
+        toError = ''
+    }
 
     const handleSendTypeClick = (type) => {
         selectedSendType = type
-        amountError = ''
+        clearErrors()
     }
     const handleFromSelect = (item) => {
         from = item
         if (to === from) {
             to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : undefined
         }
-        amountError = ''
+        clearErrors()
     }
     const handleToSelect = (item) => {
         to = item
         if (from === to) {
             from = undefined
         }
-        amountError = ''
+        clearErrors()
     }
     const handleSendClick = () => {
-        amountError = ''
-        addressError = ''
-        toError = ''
+        clearErrors()
 
         if (selectedSendType === SEND_TYPE.EXTERNAL) {
             // Validate address length
@@ -216,6 +218,21 @@
     const handleMaxClick = () => {
         amount = formatUnitPrecision(from.balance, unit, false)
     }
+
+    const updateFromSendParams = ((s) => {
+        selectedSendType = s.isInternal ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
+        unit =  s.amount === 0 ? Unit.Mi : Unit.i
+        amount = s.amount === 0 ? '' : formatUnitPrecision(s.amount, Unit.i, false)
+        address = s.address
+        if (from && accountsDropdownItems) {
+            to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : to
+        }
+    })
+
+    const sendSubscription = sendParams.subscribe((s) => {
+        updateFromSendParams(s)
+    })
+
     onMount(() => {
         updateFromSendParams($sendParams)
     })

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -48,7 +48,9 @@
         unit =  s.amount === 0 ? Unit.Mi : Unit.i
         amount = s.amount === 0 ? '' : formatUnitPrecision(s.amount, Unit.i, false)
         address = s.address
-        to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : to
+        if (from && accountsDropdownItems) {
+            to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : to
+        }
     })
 
     const sendSubscription = sendParams.subscribe((s) => {

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -48,6 +48,7 @@
         unit =  s.amount === 0 ? Unit.Mi : Unit.i
         amount = s.amount === 0 ? '' : formatUnitPrecision(s.amount, Unit.i, false)
         address = s.address
+        to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : to
     })
 
     const sendSubscription = sendParams.subscribe((s) => {
@@ -215,7 +216,6 @@
     }
     onMount(() => {
         updateFromSendParams($sendParams)
-        to = $liveAccounts.length === 2 ? accountsDropdownItems[from.id === $liveAccounts[0].id ? 1 : 0] : to
     })
     onDestroy(() => {
         sendSubscription()


### PR DESCRIPTION
# Description of change

If you only have 2 accounts and your perform an internal transfer from account 2 to account 1, on completion the form gets reset and the second dropdown is disabled but is also set to account 1.

Also the account balances shown in the dropdown do not update after tx confirmation.

This PR improves the logic for selecting the accounts and the values in the dropdowns.

![image](https://user-images.githubusercontent.com/5030334/115246802-1c405100-a11e-11eb-8770-e026d339c979.png)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
