### PR TITLE
fix: The precision used in the token formatting was incorrect

### DIFF
--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -277,6 +277,13 @@ export const ensureZeros = (val: string, maxZeros: number): string => {
 
     const parts = val.split(decimalSeparator)
 
+    if (parts.length === 1) {
+        parts[1] = ''
+        if (maxZeros > 0) {
+            parts[1].padEnd(maxZeros, '0')
+        }
+    }
+
     // If there are more then decimal places and it is just 0s remove them
     if (parts[1].length > maxZeros) {
         parts[1] = `${parts[1].slice(0, maxZeros)}${parts[1].slice(maxZeros).replace(/0+$/, '')}`

--- a/packages/shared/lib/units.ts
+++ b/packages/shared/lib/units.ts
@@ -40,19 +40,20 @@ export const formatUnitBestMatch = (value: number, includeUnits: boolean = true)
  * @param grouped Group the thousands
  */
 export function formatUnitPrecision(valueRaw: number, unit: Unit, includeUnits: boolean = true, grouped: boolean = false): string {
+    // At the moment we have no symbol for IOTA so we always put the currency code
+    // at the end, in the future when we have a symbol this can be updated to position
+    // it correctly to the left when necessary
+    const currencyPosition = getCurrencyPosition()
+
     if (!valueRaw) {
-        return includeUnits ? `0 ${unit}` : '0'
+        return includeUnits ? (currencyPosition === `left` ? `0 ${unit}` : `0 ${unit}`) : '0'
     }
 
     const converted = changeUnits(valueRaw, Unit.i, unit)
 
-    const formatted = formatNumber(converted, undefined, undefined, unit === Unit.i ? 0 : 2, grouped)
+    const formatted = formatNumber(converted, UNIT_MAP[unit].dp, undefined, unit === Unit.i ? 0 : 2, grouped)
 
     if (includeUnits) {
-        // At the moment we have no symbol for IOTA so we always put the currency code
-        // at the end, in the future when we have a symbol this can be updated to position
-        // it correctly to the left when necessary
-        const currencyPosition = getCurrencyPosition()
         return currencyPosition === `left` ? `${formatted} ${unit}` : `${formatted} ${unit}`
     } else {
         return formatted


### PR DESCRIPTION
# Description of change

The precision used in token formatting was incorrect, instead of passing the dp for the unit type it rounded.

e.g. 55590605665 was converted to 55590.606 Mi instead of 55590.605665 Mi

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested with value with high `i` precision.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
