### PR TITLE
fix: Reduce gap limits now that we have wider account discovery

### DIFF
--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -8,7 +8,7 @@
     const { balanceOverview } = $wallet
 
     let addressIndex = 0
-    let gapIndex = 50
+    let gapIndex = 25
     let accountDiscoveryThreshold = 10
     let password
     let error = ''

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -112,7 +112,7 @@
                     accountsLoaded.set(true)
                     const gapLimit = $activeProfile?.gapLimit ?? 10
                     try {
-                        await asyncSyncAccounts(0, gapLimit, 5, false)
+                        await asyncSyncAccounts(0, gapLimit, 1, false)
                     } catch (err) {
                         console.error(err)
                     }

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -39,10 +39,10 @@
         api.getStrongholdStatus({
             onSuccess(strongholdStatusResponse) {
                 if (strongholdStatusResponse.payload.snapshot.status === 'Locked') {
-                    openPopup({ type: 'password', props: { onSuccess: async () => asyncSyncAccounts(0, 10, 5, false) } })
+                    openPopup({ type: 'password', props: { onSuccess: async () => asyncSyncAccounts(0, 10, 1, false) } })
                 } else {
                     const gapLimit = $activeProfile?.gapLimit
-                    asyncSyncAccounts(gapLimit === undefined ? undefined : 0, gapLimit, 5, false)
+                    asyncSyncAccounts(gapLimit === undefined ? undefined : 0, gapLimit, 1, false)
                     updateProfile('gapLimit', undefined)
                 }
             },


### PR DESCRIPTION
# Description of change

Now that we perform wider searches on the number of accounts reduce the gapLimit so that sync doesn't take as long.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
