### PR TITLE
Fix: Balance finder password

### DIFF
--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -59,7 +59,7 @@
     </div>
     <div class="flex flex-row flex-nowrap w-full space-x-4">
         <Button classes="w-full" secondary onClick={handleCancelClick} disabled={isBusy}>{locale('actions.cancel')}</Button>
-        <Button classes="w-full" onClick={handleFindBalances} disabled={$isStrongholdLocked && password.length === 0}>
+        <Button classes="w-full" onClick={handleFindBalances} disabled={($isStrongholdLocked && password.length === 0) || isBusy}>
             {#if isBusy}
                 <Spinner busy={true} message={locale(`actions.searching`)} classes="justify-center" />
             {:else}{locale(`actions.${addressIndex ? 'searchAgain' : 'searchBalances'}`)}{/if}

--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -1,8 +1,9 @@
 <script lang="typescript">
     import { Button, Password, Spinner, Text } from 'shared/components'
     import { closePopup } from 'shared/lib/popup'
-    import { asyncSetStrongholdPassword, asyncSyncAccounts, updateAccounts, wallet } from 'shared/lib/wallet'
-
+    import { asyncSetStrongholdPassword, asyncSyncAccounts, wallet } from 'shared/lib/wallet'
+    import { isStrongholdLocked } from 'shared/lib/profile'
+    
     export let locale
 
     const { balanceOverview } = $wallet
@@ -10,7 +11,7 @@
     let addressIndex = 0
     let gapIndex = 50
     let accountDiscoveryThreshold = 10
-    let password
+    let password = ''
     let error = ''
     let isBusy = false
 
@@ -18,7 +19,9 @@
         try {
             error = ''
             isBusy = true
-            await asyncSetStrongholdPassword(password)
+            if ($isStrongholdLocked) {
+                await asyncSetStrongholdPassword(password)
+            }
             await asyncSyncAccounts(addressIndex, gapIndex, accountDiscoveryThreshold, false)
             addressIndex += gapIndex
         } catch (err) {
@@ -40,21 +43,23 @@
         <Text type="p">{locale('popups.balanceFinder.totalWalletBalance')}</Text>
         <Text type="p" highlighted>{$balanceOverview.balance}</Text>
         <Text type="p" secondary classes="mb-6">{$balanceOverview.balanceFiat}</Text>
-        <Text type="p" secondary classes="mb-3">{locale('popups.balanceFinder.typePassword')}</Text>
-        <Password
-            {error}
-            classes="w-full mb-2"
-            bind:value={password}
-            showRevealToggle
-            {locale}
-            placeholder={locale('general.password')}
-            autofocus
-            submitHandler={() => handleFindBalances()}
-            disabled={isBusy} />
+        {#if $isStrongholdLocked}
+            <Text type="p" secondary classes="mb-3">{locale('popups.balanceFinder.typePassword')}</Text>
+            <Password
+                {error}
+                classes="w-full mb-2"
+                bind:value={password}
+                showRevealToggle
+                {locale}
+                placeholder={locale('general.password')}
+                autofocus
+                submitHandler={() => handleFindBalances()}
+                disabled={isBusy} />
+        {/if}
     </div>
     <div class="flex flex-row flex-nowrap w-full space-x-4">
         <Button classes="w-full" secondary onClick={handleCancelClick} disabled={isBusy}>{locale('actions.cancel')}</Button>
-        <Button classes="w-full" onClick={handleFindBalances} disabled={!password || isBusy}>
+        <Button classes="w-full" onClick={handleFindBalances} disabled={$isStrongholdLocked && password.length === 0}>
             {#if isBusy}
                 <Spinner busy={true} message={locale(`actions.searching`)} classes="justify-center" />
             {:else}{locale(`actions.${addressIndex ? 'searchAgain' : 'searchBalances'}`)}{/if}

--- a/packages/shared/routes/dashboard/settings/views/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Advanced.svelte
@@ -236,9 +236,9 @@
         <Text type="h4" classes="mb-3">{locale('views.settings.deepLinks.title')}</Text>
         <Text type="p" secondary classes="mb-5">{locale('views.settings.deepLinks.description')}</Text>
         <Checkbox label={locale('actions.enableDeepLinks')} bind:checked={deepLinkingChecked} />
+        <HR classes="pb-5 mt-5 justify-center" />
     </section> -->
     {#if $loggedIn}
-        <HR classes="pb-5 mt-5 justify-center" />
         <section id="balanceFinder" class="w-3/4">
             <Text type="h4" classes="mb-3">{locale('views.settings.balanceFinder.title')}</Text>
             <Text type="p" secondary classes="mb-5">{locale('views.settings.balanceFinder.description')}</Text>


### PR DESCRIPTION
# Description of change

Balance finder only requires password when stronghold is locked.
Removes double separator around balance finder in settings.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
