### PR TITLE
fix: Reset the send route if only one account

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -220,7 +220,7 @@
     }
 
     const updateFromSendParams = (s) => {
-        selectedSendType = s.isInternal ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
+        selectedSendType = s.isInternal && $liveAccounts.length > 1 ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
         unit = s.amount === 0 ? Unit.Mi : Unit.i
         amount = s.amount === 0 ? '' : formatUnitPrecision(s.amount, Unit.i, false)
         address = s.address


### PR DESCRIPTION
# Description of change

With two accounts if you internal transfer all tokens from account 1 to account 2, hide account 2, then go back into send it reied to set back to internal, which it cant with only one account.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
