### PR TITLE
fix: The number format group separator is not present until numbers are larger

### DIFF
--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -185,7 +185,7 @@ export const getDecimalSeparator = (currency: string | undefined = undefined) =>
     })
         .formatToParts(1.1)
         .find(part => part.type === 'decimal')
-        .value;
+        ?.value ?? '.';
 }
 
 export const getCurrencyPosition = (): "left" | "right" => {
@@ -210,9 +210,9 @@ export const getGroupSeparator = (currency: string | undefined = undefined) => {
         style: 'currency',
         currency: currency ?? 'USD',
     })
-        .formatToParts(1111)
+        .formatToParts(1111111)
         .find(part => part.type === 'group')
-        .value;
+        ?.value ?? ',';
 }
 
 


### PR DESCRIPTION
# Description of change

In some languages the group separator for currency is not found until the test number is larger
e.g in Polish 1111 does not yield the separator, with 1111111 it does

Also added fallbacks for group and decimal separators in case they still are not found.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Test on windows in polish

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
