### PR TITLE
fix: Missing auto lock localisation

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -245,7 +245,9 @@
             },
             "appLock": {
                 "title": "Automatic Lock",
-                "description": "Inactivity time before your wallets lock and you are logged out"
+                "description": "Inactivity time before your wallets lock and you are logged out",
+                "durationMinute": "{time, plural, one {1 minute} other {# minutes}}",
+                "durationHour": "{time, plural, one {1 hour} other {# hours}}"
             },
             "changePassword": {
                 "title": "Change password",

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -10,21 +10,17 @@
     import { get } from 'svelte/store'
     import zxcvbn from 'zxcvbn'
 
-    function assignTimeoutOptionLabel(timeInMinutes) {
-        let label = ''
+    export let locale
 
+    function assignTimeoutOptionLabel(timeInMinutes) {
         if (timeInMinutes >= 60) {
-            label = `${timeInMinutes / 60} hour`
+            return locale('views.settings.appLock.durationHour', { values: { time: timeInMinutes / 60 } })
         }
 
-        label = `${timeInMinutes} minute`
-
-        return label.includes('1') ? label : `${label}s`
+        return locale('views.settings.appLock.durationMinute', { values: { time: timeInMinutes } })
     }
 
     const lockScreenTimeoutOptions = [1, 5, 10, 30, 60].map((time) => ({ value: time, label: assignTimeoutOptionLabel(time) }))
-
-    export let locale
 
     let exportStrongholdChecked
     let currentPassword = ''


### PR DESCRIPTION
# Description of change

The autolock drop down values were not localised.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
