### PR TITLE
fix: Activity detail did not show full details when there was a remainder

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -10,6 +10,8 @@
     import {
         findAccountWithAddress,
         findAccountWithAnyAddress,
+        getIncomingFlag,
+        getInternalFlag,
         getMilestoneMessageValue,
         receiverAddressesFromTransactionPayload,
         sendAddressFromTransactionPayload,
@@ -81,7 +83,7 @@
         // For an incoming transaction there might be multiple receiver addresses
         // especially if there was a remainder, so if any account addresses match
         // we need to find the account details for our address match
-        if (txPayload && (txPayload.data.essence.data.internal || txPayload.data.essence.data.incoming)) {
+        if (getIncomingFlag(txPayload) || getInternalFlag(txPayload)) {
             return findAccountWithAnyAddress(receiverAddresses)
         }
 

--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -1,14 +1,15 @@
 <script lang="typescript">
-    import { Unit } from '@iota/unit-converter'
     import { Icon, Text } from 'shared/components'
     import { convertToFiat, currencies, CurrencyTypes, exchangeRates, formatCurrency } from 'shared/lib/currency'
     import { getInitials, truncateString } from 'shared/lib/helpers'
     import { formatDate } from 'shared/lib/i18n'
     import { activeProfile } from 'shared/lib/profile'
     import type { Milestone, Payload, Transaction } from 'shared/lib/typings/message'
-    import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
+    import { formatUnitBestMatch } from 'shared/lib/units'
     import { setClipboard } from 'shared/lib/utils'
     import {
+        findAccountWithAddress,
+        findAccountWithAnyAddress,
         getMilestoneMessageValue,
         receiverAddressesFromTransactionPayload,
         sendAddressFromTransactionPayload,
@@ -25,6 +26,7 @@
     export let onBackClick = () => {}
     export let balance // migration tx
 
+    let cachedMigrationTx = !payload
     let milestonePayload = payload?.type === 'Milestone' ? (payload as Milestone) : undefined
     let txPayload = payload?.type === 'Transaction' ? (payload as Transaction) : undefined
 
@@ -37,7 +39,7 @@
         if (txPayload) {
             return sendAddressFromTransactionPayload(txPayload)
         } else if (milestonePayload) {
-            return 'Legacy Network'
+            return locale('general.legacyNetwork')
         }
 
         return null
@@ -64,9 +66,8 @@
 
     const prepareSenderAccount = () => {
         if (txPayload) {
-            return txPayload.data.essence.data.internal
-                ? $accounts.find((acc) => acc.addresses.some((add) => senderAddress === add.address))
-                : null
+            // There can only be one sender address which either belongs to us or not
+            return findAccountWithAddress(senderAddress)
         }
 
         return null
@@ -77,10 +78,11 @@
             return $accounts.find((acc) => acc.index === 0)
         }
 
-        if (txPayload) {
-            return txPayload.data.essence.data.internal
-                ? $accounts.find((acc) => acc.addresses.some((add) => receiverAddresses.includes(add.address)))
-                : null
+        // For an incoming transaction there might be multiple receiver addresses
+        // especially if there was a remainder, so if any account addresses match
+        // we need to find the account details for our address match
+        if (txPayload && (txPayload.data.essence.data.internal || txPayload.data.essence.data.incoming)) {
+            return findAccountWithAnyAddress(receiverAddresses)
         }
 
         return null
@@ -88,19 +90,21 @@
 
     let senderAddress: string = prepareSenderAddress()
     let receiverAddresses: string[] = prepareReceiverAddresses()
+    let receiverAddressesYou: WalletAccount[] = receiverAddresses.map((a) => findAccountWithAddress(a))
 
     $: senderAccount = prepareSenderAccount()
     $: receiverAccount = prepareReceiverAccount()
-    $: value = milestonePayload
-        ? getMilestoneMessageValue(milestonePayload, $accounts)
-        : txPayload
-        ? txPayload.data.essence.data.value
-        : 0
-    $: currencyValue = convertToFiat(value, $currencies[CurrencyTypes.USD], $exchangeRates[$activeProfile?.settings.currency])
-
-    function isAccountYours(account) {
-        return account && $accounts.find((a) => a.id === account.id)
+    let value = 0
+    $: {
+        if (cachedMigrationTx) {
+            value = balance
+        } else if (milestonePayload) {
+            value = getMilestoneMessageValue(milestonePayload, $accounts)
+        } else if (txPayload) {
+            value = txPayload.data.essence.data.value
+        }
     }
+    $: currencyValue = convertToFiat(value, $currencies[CurrencyTypes.USD], $exchangeRates[$activeProfile?.settings.currency])
 </script>
 
 <style type="text/scss">
@@ -118,9 +122,7 @@
                     class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold text-center bg-{senderAccount?.color ?? 'blue'}-500 text-white">
                     {getInitials(senderAccount.alias, 2)}
                 </div>
-                {#if isAccountYours(senderAccount)}
-                    <Text smaller>{locale('general.you')}</Text>
-                {/if}
+                <Text smaller>{locale('general.you')}</Text>
             {:else}
                 <Text smaller>{truncateString(senderAddress, 3, 3, 3)}</Text>
             {/if}
@@ -134,8 +136,6 @@
                     class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold bg-{receiverAccount?.color ?? 'blue'}-500 text-white">
                     {getInitials(receiverAccount.alias, 2)}
                 </div>
-            {/if}
-            {#if isAccountYours(receiverAccount)}
                 <Text smaller>{locale('general.you')}</Text>
             {:else}
                 {#each receiverAddresses as address}
@@ -175,16 +175,22 @@
             <div class="mb-5">
                 <Text secondary>{locale('general.inputAddress')}</Text>
                 <button class="text-left" on:click={() => setClipboard(senderAddress.toLowerCase())}>
-                    <Text type="pre">{senderAddress}</Text>
+                    <Text type="pre">
+                        {senderAddress}
+                        {#if senderAccount}&nbsp;({senderAccount.alias}){/if}
+                    </Text>
                 </button>
             </div>
         {/if}
         {#if receiverAddresses.length > 0}
             <div class="mb-5">
                 <Text secondary>{locale('general.receiveAddress')}</Text>
-                {#each receiverAddresses as receiver}
+                {#each receiverAddresses as receiver, idx}
                     <button class="text-left" on:click={() => setClipboard(receiver.toLowerCase())}>
-                        <Text type="pre" classes="mb-2">{receiver}</Text>
+                        <Text type="pre" classes="mb-2">
+                            {receiver}
+                            {#if receiverAddressesYou[idx]}&nbsp;({receiverAddressesYou[idx].alias}){/if}
+                        </Text>
                     </button>
                 {/each}
             </div>

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -4,13 +4,15 @@
     import { formatDate } from 'shared/lib/i18n'
     import type { Milestone, Payload, Transaction } from 'shared/lib/typings/message'
     import { formatUnitBestMatch } from 'shared/lib/units'
-    import type { WalletAccount } from 'shared/lib/wallet'
     import {
         findAccountWithAddress,
         findAccountWithAnyAddress,
+        getIncomingFlag,
+        getInternalFlag,
         getMilestoneMessageValue,
         receiverAddressesFromTransactionPayload,
         sendAddressFromTransactionPayload,
+        WalletAccount,
     } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import type { Writable } from 'svelte/store'
@@ -57,9 +59,7 @@
     // especially if there was a remainder, so if any account addresses match
     // we need to find the account details for our address match
     $: receiverAccount =
-        txPayload.data.essence.data.internal || txPayload.data.essence.data.incoming
-            ? findAccountWithAnyAddress(receiverAddresses)
-            : null
+        getIncomingFlag(txPayload) || getInternalFlag(txPayload) ? findAccountWithAnyAddress(receiverAddresses) : null
 
     let initialsColor
     let accountAlias = ''

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -52,7 +52,7 @@
     $: senderAddress = sendAddressFromTransactionPayload(payload)
     $: receiverAddresses = receiverAddressesFromTransactionPayload(payload)
 
-    // There can only be one sender address which either belongs to use or not
+    // There can only be one sender address which either belongs to us or not
     $: senderAccount = findAccountWithAddress(senderAddress)
 
     // For an incoming transaction there might be multiple receiver addresses

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -1,10 +1,13 @@
 <script lang="typescript">
     import { Icon, Text } from 'shared/components'
+    import { truncateString } from 'shared/lib/helpers'
     import { formatDate } from 'shared/lib/i18n'
     import type { Milestone, Payload, Transaction } from 'shared/lib/typings/message'
     import { formatUnitBestMatch } from 'shared/lib/units'
     import type { WalletAccount } from 'shared/lib/wallet'
     import {
+        findAccountWithAddress,
+        findAccountWithAnyAddress,
         getMilestoneMessageValue,
         receiverAddressesFromTransactionPayload,
         sendAddressFromTransactionPayload,
@@ -47,13 +50,16 @@
     $: senderAddress = sendAddressFromTransactionPayload(payload)
     $: receiverAddresses = receiverAddressesFromTransactionPayload(payload)
 
-    $: senderAccount = senderAddress
-        ? $accounts?.find((acc) => acc.addresses.some((add) => senderAddress === add.address)) ?? null
-        : null
+    // There can only be one sender address which either belongs to use or not
+    $: senderAccount = findAccountWithAddress(senderAddress)
 
-    $: receiverAccount = receiverAddresses?.length
-        ? $accounts.find((acc) => acc.addresses.some((add) => receiverAddresses.includes(add.address))) ?? null
-        : null
+    // For an incoming transaction there might be multiple receiver addresses
+    // especially if there was a remainder, so if any account addresses match
+    // we need to find the account details for our address match
+    $: receiverAccount =
+        txPayload.data.essence.data.internal || txPayload.data.essence.data.incoming
+            ? findAccountWithAnyAddress(receiverAddresses)
+            : null
 
     let initialsColor
     let accountAlias = ''
@@ -62,12 +68,23 @@
         if (txPayload) {
             const acc = txPayload.data.essence.data.incoming ? receiverAccount : senderAccount
 
+            // The address in the payload was one of our accounts so grab
+            // the account alias to display
             if (acc) {
                 if (includeFullSender) {
                     accountAlias = acc.alias
                 }
                 if (txPayload.data.essence.data.internal) {
                     initialsColor = acc.color
+                }
+            } else {
+                // We can't find the address in our accounts so just display the abbreviated address
+                if (includeFullSender) {
+                    accountAlias = truncateString(
+                        txPayload.data.essence.data.incoming ? receiverAddresses[0] : senderAddress,
+                        3,
+                        3
+                    )
                 }
             }
         }

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -1591,3 +1591,28 @@ export const getMilestoneMessageValue = (payload: Payload, accounts) => {
     return undefined
 }
 
+/**
+ * Find an address in one of our accounts
+ * @param address The address to find
+ * @returns The wallet account matching the address or undefined if not found
+ */
+export const findAccountWithAddress = (address: string): WalletAccount | undefined => {
+    if (!address) {
+        return
+    }
+    const accounts = get(get(wallet).accounts)
+    return accounts.find((acc) => acc.addresses.some((add) => address === add.address))
+}
+
+/**
+ * Find an address in one of our accounts
+ * @param addresses The addresses to find
+ * @returns The wallet account matching the address or undefined if not found
+ */
+ export const findAccountWithAnyAddress = (addresses: string[]): WalletAccount | undefined => {
+    if (!addresses || addresses.length === 0) {
+        return
+    }
+    const accounts = get(get(wallet).accounts)
+    return accounts.find((acc) => acc.addresses.some((add) => addresses.includes(add.address)))
+}

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -697,7 +697,8 @@
         "receivedTo": "Received to {account}",
         "sentFrom": "Sent from {account}",
         "receiving": "Receiving",
-        "sending": "Sending"
+        "sending": "Sending",
+        "legacyNetwork": "Legacy Network"
     },
     "dates": {
         "today": "Today",


### PR DESCRIPTION
# Description of change

When a transaction has a remainder the lookups for the activity details did not produce the correct display.
Adds localisation to `Legacy Network`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with multiple internal, external transaction with and without remainders.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
