### PR TITLE
fix: css splash animation not keeping responsive aspect ratio

### DIFF
--- a/packages/shared/routes/Splash.svelte
+++ b/packages/shared/routes/Splash.svelte
@@ -4,6 +4,6 @@
 
 <div class="w-full h-full flex justify-center items-center bg-white dark:bg-gray-900">
     <div class="w-1/3">
-        <Animation classes="h-36 w-auto" animation="splashscreen-desktop" loop={false} renderer="canvas" />
+        <Animation classes="relative w-full h-auto" animation="splashscreen-desktop" loop={false} renderer="canvas" />  
     </div>
 </div>

--- a/packages/shared/routes/Splash.svelte
+++ b/packages/shared/routes/Splash.svelte
@@ -4,6 +4,6 @@
 
 <div class="w-full h-full flex justify-center items-center bg-white dark:bg-gray-900">
     <div class="w-1/3">
-        <Animation classes="relative w-full h-auto" animation="splashscreen-desktop" loop={false} renderer="canvas" />  
+        <Animation classes="w-full h-auto" animation="splashscreen-desktop" loop={false} renderer="canvas" />  
     </div>
 </div>


### PR DESCRIPTION
# Description of change

This PR aims to prevent the following screenshot from happening 

![image](https://user-images.githubusercontent.com/3624944/115532493-22f1d400-a296-11eb-8e36-94f4a5b64f3b.png)

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on Ubuntu 18.04

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
