### PR TITLE
feat: add seedvault error message when file is empty/corrupt

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -147,6 +147,7 @@
             "restoringWallet": "Restoring wallet...",
             "findingBalance": "Finding balance...",
             "incorrectSeedVaultPassword": "Incorrect SeedVault password.",
+            "noDataSeedVault": "No data could be found in the SeedVault.",
             "signingBundle": "Signing bundle",
             "broadcastingBundle": "Broadcasting bundle",
             "miningBundle": "Mining bundle",

--- a/packages/shared/routes/setup/import/Import.svelte
+++ b/packages/shared/routes/setup/import/Import.svelte
@@ -127,6 +127,8 @@
                     if (!err?.snapshot) {
                         if (err && err.name === 'KdbxError' && err.code === 'InvalidKey') {
                             error = locale('views.migrate.incorrectSeedVaultPassword')
+                        } else if (err && err.name === 'KdbxError' && err.code === 'FileCorrupt') {
+                            error = locale('views.migrate.noDataSeedVault')
                         } else {
                             error = locale(err.error)
                         }


### PR DESCRIPTION
# Description of change

Add error to seedvault import when file is empty/corrupted

![image](https://user-images.githubusercontent.com/3624944/115540859-c810aa80-a29e-11eb-93b4-a143d6106b0d.png)


## Links to any relevant issues

Fixes issue #967

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

1. Create an text file with a name `whatever.kdbx` or something similar.
2. Import/migrate new wallet using that file
3. Enter password and see the error

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
