### PR TITLE
fix: The order of addresses determined which account was displayed

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -84,7 +84,7 @@
         // especially if there was a remainder, so if any account addresses match
         // we need to find the account details for our address match
         if (getIncomingFlag(txPayload) || getInternalFlag(txPayload)) {
-            return findAccountWithAnyAddress(receiverAddresses)
+            return findAccountWithAnyAddress(receiverAddresses, senderAccount)
         }
 
         return null

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -59,7 +59,7 @@
     // especially if there was a remainder, so if any account addresses match
     // we need to find the account details for our address match
     $: receiverAccount =
-        getIncomingFlag(txPayload) || getInternalFlag(txPayload) ? findAccountWithAnyAddress(receiverAddresses) : null
+        getIncomingFlag(txPayload) || getInternalFlag(txPayload) ? findAccountWithAnyAddress(receiverAddresses, senderAccount) : null
 
     let initialsColor
     let accountAlias = ''

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -1608,12 +1608,30 @@ export const findAccountWithAddress = (address: string): WalletAccount | undefin
 /**
  * Find an address in one of our accounts
  * @param addresses The addresses to find
+ * @param excludeFirst A wallet to exclude on first pass
  * @returns The wallet account matching the address or undefined if not found
  */
- export const findAccountWithAnyAddress = (addresses: string[]): WalletAccount | undefined => {
+ export const findAccountWithAnyAddress = (addresses: string[], excludeFirst?: WalletAccount): WalletAccount | undefined => {
     if (!addresses || addresses.length === 0) {
         return
     }
-    const accounts = get(get(wallet).accounts)
-    return accounts.find((acc) => acc.addresses.some((add) => addresses.includes(add.address)))
+    let accounts = get(get(wallet).accounts)
+
+    let res = accounts.filter((acc) => acc.addresses.some((add) => addresses.includes(add.address)))
+
+    if (res.length > 0) {
+        if (excludeFirst) {
+            const initialLen = res.length
+            res = res.filter(a => a.id !== excludeFirst.id)
+            // If the length changed we removed it, so put it back
+            // at the end
+            if (res.length !== initialLen) {
+                res.push(excludeFirst)
+            }
+        }
+
+        if (res.length > 0) {
+            return res[0]
+        }
+    }
 }


### PR DESCRIPTION
# Description of change

For an internal transfer with a reminder the order of addresses meant that sometime the sender account was shown instead of the receiver account. The sender account is now excluded unless there is no other option.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
