### PR TITLE
feat: hide error notifications for chrysalis node dns issues

### DIFF
--- a/packages/shared/lib/shell/walletApi.ts
+++ b/packages/shared/lib/shell/walletApi.ts
@@ -223,6 +223,7 @@ const storeCallbacks = (__id: string, type: ResponseTypes, callbacks?: Callbacks
  */
 const handleError = (type: ErrorType | ValidatorErrorTypes, error: string): { type: ErrorType | ValidatorErrorTypes, error: string } => {
     const newError = { type, message: error, time: Date.now() };
+
     logError(newError)
 
     // TODO: Add full type list to remove this temporary fix
@@ -235,6 +236,9 @@ const handleError = (type: ErrorType | ValidatorErrorTypes, error: string): { ty
         }
         if (error.includes('No synced node')) {
             return ('error.node.noSynced')
+        }
+        if (error.includes('dns error')) {
+            return ('error.node.chrysalisNodeInactive')
         }
 
         return getErrorMessage(type)

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -1461,10 +1461,16 @@ export const updateAccountNetworkSettings = async (automaticNodeSelection, inclu
                 )
             },
             onError(err) {
-                showAppNotification({
-                    type: 'error',
-                    message: localize(err.error),
-                })
+                const shouldHideErrorNotification =
+                    err && err.type === 'ClientError' && err.error === 'error.node.chrysalisNodeInactive'
+
+                if (!shouldHideErrorNotification) {
+                    showAppNotification({
+                        type: 'error',
+                        message: localize(err.error),
+                    })
+                }
+
             },
         }
     )
@@ -1562,9 +1568,9 @@ export const getMilestoneMessageValue = (payload: Payload, accounts) => {
  * Get incoming flag from message
  * @returns 
  */
- export const getIncomingFlag = (payload: Payload) => {
+export const getIncomingFlag = (payload: Payload) => {
     if (payload?.type === "Transaction") {
-       return payload.data.essence.data.incoming
+        return payload.data.essence.data.incoming
     }
 
     return undefined
@@ -1574,19 +1580,19 @@ export const getMilestoneMessageValue = (payload: Payload, accounts) => {
  * Set incoming flag on the message
  * @returns 
  */
- export const setIncomingFlag = (payload: Payload, incoming: boolean) => {
+export const setIncomingFlag = (payload: Payload, incoming: boolean) => {
     if (payload?.type === "Transaction") {
-       payload.data.essence.data.incoming = incoming
+        payload.data.essence.data.incoming = incoming
     }
- }
+}
 
- /**
- * Get internal flag from message
- * @returns 
- */
-  export const getInternalFlag = (payload: Payload) => {
+/**
+* Get internal flag from message
+* @returns 
+*/
+export const getInternalFlag = (payload: Payload) => {
     if (payload?.type === "Transaction") {
-       return payload.data.essence.data.internal
+        return payload.data.essence.data.internal
     }
 
     return undefined
@@ -1610,7 +1616,7 @@ export const findAccountWithAddress = (address: string): WalletAccount | undefin
  * @param addresses The addresses to find
  * @returns The wallet account matching the address or undefined if not found
  */
- export const findAccountWithAnyAddress = (addresses: string[]): WalletAccount | undefined => {
+export const findAccountWithAnyAddress = (addresses: string[]): WalletAccount | undefined => {
     if (!addresses || addresses.length === 0) {
         return
     }

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -221,10 +221,15 @@
                 },
                 onError(err) {
                     isGeneratingAddress = false
-                    showAppNotification({
+
+                    const shouldHideErrorNotification = err && err.type === 'ClientError' && err.error === 'error.node.chrysalisNodeInactive'
+
+                    if (!shouldHideErrorNotification) {
+                        showAppNotification({
                         type: 'error',
                         message: locale(err.error),
-                    })
+                        })
+                    }
                 },
             })
         }

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -25,10 +25,16 @@
                 },
                 onError(err) {
                     $isSyncing = false
-                    showAppNotification({
-                        type: 'error',
-                        message: locale(err.error),
-                    })
+
+                    const shouldHideErrorNotification =
+                        err && err.type === 'ClientError' && err.error === 'error.node.chrysalisNodeInactive'
+
+                    if (!shouldHideErrorNotification) {
+                        showAppNotification({
+                            type: 'error',
+                            message: locale(err.error),
+                        })
+                    }
                 },
             })
         }


### PR DESCRIPTION
# Description of change

Do not show error notifications for chrysalis node DNS issues. Areas where this is done are address generation, individual account sync and node settings. 

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
