### PR TITLE
fix: Activity row dark more styling

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -121,7 +121,7 @@
         <div class="flex flex-col flex-wrap justify-center items-center text-center">
             {#if senderAccount}
                 <div
-                    class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold text-center bg-{senderAccount?.color ?? 'blue'}-500 text-white">
+                    class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold text-center bg-{senderAccount?.color ?? 'blue'}-500 text-white dark:text-gray-900">
                     {getInitials(senderAccount.alias, 2)}
                 </div>
                 <Text smaller>{locale('general.you')}</Text>
@@ -135,7 +135,7 @@
         <div class="flex flex-col flex-wrap justify-center items-center text-center">
             {#if receiverAccount}
                 <div
-                    class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold bg-{receiverAccount?.color ?? 'blue'}-500 text-white">
+                    class="flex items-center justify-center w-8 h-8 rounded-xl p-2 mb-2 text-12 leading-100 font-bold bg-{receiverAccount?.color ?? 'blue'}-500 text-white dark:text-gray-900">
                     {getInitials(receiverAccount.alias, 2)}
                 </div>
                 <Text smaller>{locale('general.you')}</Text>

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -74,9 +74,7 @@
                 if (includeFullSender) {
                     accountAlias = acc.alias
                 }
-                if (txPayload.data.essence.data.internal) {
-                    initialsColor = acc.color
-                }
+                initialsColor = acc.color
             } else {
                 // We can't find the address in our accounts so just display the abbreviated address
                 if (includeFullSender) {

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -127,7 +127,7 @@
         {:else}
             <Icon
                 boxed
-                classes="text-white dark:text-{txPayload.data.essence.data.internal ? 'gray-500' : `${color}-${txPayload.data.essence.data.incoming ? '500' : '600'}`}"
+                classes={`text-white dark:text-${initialsColor}-600`}
                 boxClasses="bg-{initialsColor ? `${initialsColor}-500` : txPayload.data.essence.data.internal ? 'gray-500' : `${color}-${txPayload.data.essence.data.internal ? '500' : '600'}`} dark:bg-gray-900"
                 icon={txPayload.data.essence.data.internal ? 'transfer' : txPayload.data.essence.data.incoming ? 'chevron-down' : 'chevron-up'} />
         {/if}


### PR DESCRIPTION
# Description of change

The styling for the activity rows in dark mode didn't use the account color.
In addition the dark mode transaction details used white on colored background for the account initials which was hard to read.

![image](https://user-images.githubusercontent.com/5030334/115576461-6dd21280-a2bb-11eb-97f3-cea7b04a4898.png)

![image](https://user-images.githubusercontent.com/5030334/115576748-b38edb00-a2bb-11eb-9e67-bc9c6c1ec29e.png)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows in dark mode

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
