### PR TITLE
fix: Currency with literal caused exception

### DIFF
--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -250,8 +250,10 @@ export const formatCurrency = (value: number, currency: string | undefined = und
     // the
     const curIndex = parts.findIndex(p => p.type === "currency")
     if (curIndex >= 0) {
-        if (curIndex === 0 && parts[curIndex + 1].type !== "literal") {
-            parts.splice(curIndex + 1, 0, { type: "literal", value: " " })
+        if (curIndex === 0) {
+            if (parts[curIndex + 1].type !== "literal") {
+                parts.splice(curIndex + 1, 0, { type: "literal", value: " " })
+            }
         } else if (parts[curIndex - 1].type !== "literal") {
             parts.splice(curIndex, 0, { type: "literal", value: " " })
         }


### PR DESCRIPTION
# Description of change

In languages where the currency formatting started with the currency part and then already included a literal it triggered an exception in the code to insert literals where there wasn't one.

e.g. Portugese Brazilian

## Links To Issues

Fixes https://github.com/iotaledger/firefly/issues/1005

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested with all languages

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
