### PR TITLE
fix: Windows replace use of non-ascii filename chars

### DIFF
--- a/packages/shared/lib/helpers.ts
+++ b/packages/shared/lib/helpers.ts
@@ -227,25 +227,36 @@ export const stripSpaces = (str) => {
  * @returns The copied object
  */
 export function deepCopy(obj) {
-    if(typeof obj !== 'object' || obj === null) {
+    if (typeof obj !== 'object' || obj === null) {
         return obj;
     }
 
-    if(obj instanceof Date) {
+    if (obj instanceof Date) {
         return new Date(obj.getTime());
     }
 
-    if(obj instanceof Array) {
+    if (obj instanceof Array) {
         return obj.reduce((arr, item, i) => {
             arr[i] = deepCopy(item);
             return arr;
         }, []);
     }
 
-    if(obj instanceof Object) {
+    if (obj instanceof Object) {
         return Object.keys(obj).reduce((newObj, key) => {
             newObj[key] = deepCopy(obj[key]);
             return newObj;
         }, {})
     }
+}
+
+/**
+ * Encode Non ASCII characters to escaped characters.
+ * @param value The value to encode.
+ * @returns The encoded value.
+ */
+export function encodeNonASCII(value: string): string | undefined {
+    return typeof value === "string"
+        ? value.replace(/[\u007F-\uFFFF]/g, chr => `${(`0000${chr.charCodeAt(0).toString(16)}`).slice(-4)}`)
+        : undefined;
 }

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -1,7 +1,7 @@
 import { AvailableExchangeRates } from 'shared/lib/currency'
 import { persistent } from 'shared/lib/helpers'
 import { generateRandomId } from 'shared/lib/utils'
-import { asyncRemoveStorage, destroyActor, getStoragePath } from 'shared/lib/wallet'
+import { destroyActor, getStoragePathParts } from 'shared/lib/wallet'
 import { derived, get, Readable, writable } from 'svelte/store'
 import type { ChartSelectors } from './chart'
 import { Electron } from './electron'
@@ -252,9 +252,8 @@ export const cleanupInProgressProfiles = async () => {
  */
 export const removeProfileFolder = async (profileName) => {
     try {
-        const userDataPath = await Electron.getUserDataPath()
-        const profileStoragePath = getStoragePath(userDataPath, profileName)
-        await Electron.removeProfileFolder(profileStoragePath)
+        const storagePathParts = await getStoragePathParts(profileName)
+        await Electron.removeProfileFolder(storagePathParts.path)
     } catch (err) {
         console.error(err)
     }

--- a/packages/shared/routes/setup/Congratulations.svelte
+++ b/packages/shared/routes/setup/Congratulations.svelte
@@ -12,7 +12,7 @@
     import { LOG_FILE_NAME, migration, resetMigrationState, totalMigratedBalance } from 'shared/lib/migration'
     import { activeProfile, newProfile, profileInProgress, saveProfile, setActiveProfile } from 'shared/lib/profile'
     import { formatUnitBestMatch } from 'shared/lib/units'
-    import { getStoragePath } from 'shared/lib/wallet'
+    import { getStoragePathParts } from 'shared/lib/wallet'
     import { createEventDispatcher, onDestroy, onMount } from 'svelte'
     import { get } from 'svelte/store'
 
@@ -50,11 +50,9 @@
 
     const handleContinueClick = () => {
         if (wasMigrated) {
-            Electron.getUserDataPath()
-                .then((path) => {
-                    const source = getStoragePath(path, $activeProfile.name)
-
-                    return Electron.exportMigrationLog(`${source}/${LOG_FILE_NAME}`, `${$activeProfile.name}-${LOG_FILE_NAME}`)
+            getStoragePathParts($activeProfile.name)
+                .then((storagePathParts) => {
+                    return Electron.exportMigrationLog(`${storagePathParts.path}${storagePathParts.sep}${LOG_FILE_NAME}`, `${$activeProfile.name}-${LOG_FILE_NAME}`)
                 })
                 .then((result) => {
                     if (result) {

--- a/packages/shared/routes/setup/Profile.svelte
+++ b/packages/shared/routes/setup/Profile.svelte
@@ -13,7 +13,7 @@
         profileInProgress,
         profiles,
     } from 'shared/lib/profile'
-    import { destroyActor, getStoragePath, initialise, MAX_PROFILE_NAME_LENGTH } from 'shared/lib/wallet'
+    import { destroyActor, getStoragePathParts, initialise, MAX_PROFILE_NAME_LENGTH } from 'shared/lib/wallet'
     import { createEventDispatcher } from 'svelte'
     import { get } from 'svelte/store'
 
@@ -72,8 +72,8 @@
                     profile = createProfile(trimmedProfileName, false)
                     profileInProgress.set(trimmedProfileName)
 
-                    const userDataPath = await Electron.getUserDataPath()
-                    initialise($newProfile.id, getStoragePath(userDataPath, $newProfile.name))
+                    const storagePathParts = await getStoragePathParts($newProfile.name)
+                    initialise($newProfile.id, storagePathParts.path)
 
                     initialiseMigrationListeners()
                 }


### PR DESCRIPTION
# Description of change

On windows profile names with non ascii characters caused an exception e.g. `userä`

This is because the windows version of RocksDB does not support the wider character set https://github.com/facebook/rocksdb/issues/3408 and so the profile storage folders which use the profile names were not accessible.

On windows the non ASCII characters will now be replaced with their sequence numbers instead for folder names e.g. `userä` = `user00e4`

An alternative fix is to do a custom build of the rust RocksDB using this flag https://github.com/facebook/rocksdb/pull/4469 which enables UTF8 support for windows filenames.

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/1015

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with profile names with non ascii characters.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
