### PR TITLE
feat: Display a caps lock indicator on password input

### DIFF
--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Error } from 'shared/components'
+    import { Error, Text } from 'shared/components'
     import { formatNumber, getAllDecimalSeparators, getDecimalSeparator, parseCurrency } from 'shared/lib/currency'
     import { onMount } from 'svelte'
 
@@ -19,13 +19,21 @@
     export let isFocused = false
     export let maxDecimals = undefined
     export let disableContextMenu = false
+    export let locale = undefined
+    export let capsLockWarning = false
 
     let inputElement
     let allDecimalSeparators = getAllDecimalSeparators()
     let decimalSeparator = getDecimalSeparator()
+    let capsLockOn = false
+    let hasFocus = false
 
     const handleInput = (e) => {
         value = e.target.value
+    }
+
+    const onKeyDown = (e) => {
+        capsLockOn = e.getModifierState('CapsLock')
     }
 
     const onKeyPress = (e) => {
@@ -186,8 +194,11 @@
             class:floating-active={value && label}
             on:input={handleInput}
             on:keypress={onKeyPress}
+            on:keydown={onKeyDown}
             on:paste={onPaste}
             on:contextmenu={handleContextMenu}
+            on:focus={() => hasFocus = true}
+            on:blur={() => hasFocus = false}
             {disabled}
             {...$$restProps}
             {placeholder}
@@ -197,6 +208,9 @@
             <floating-label class:floating-active={value && label}>{label}</floating-label>
         {/if}
     </div>
+    {#if capsLockWarning && hasFocus && capsLockOn}
+        <Text smaller overrideColor classes="mt-1 text-orange-500">{locale('general.capsLock')}</Text>
+    {/if}
     {#if error}
         <Error {error} />
     {/if}

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -32,7 +32,7 @@
         value = e.target.value
     }
 
-    const onKeyDown = (e) => {
+    const onKeyCaps = (e) => {
         capsLockOn = e.getModifierState('CapsLock')
     }
 
@@ -194,7 +194,8 @@
             class:floating-active={value && label}
             on:input={handleInput}
             on:keypress={onKeyPress}
-            on:keydown={onKeyDown}
+            on:keydown={onKeyCaps}
+            on:keyup={onKeyCaps}
             on:paste={onPaste}
             on:contextmenu={handleContextMenu}
             on:focus={() => hasFocus = true}

--- a/packages/shared/components/inputs/Password.svelte
+++ b/packages/shared/components/inputs/Password.svelte
@@ -58,7 +58,7 @@
             </div>
         </strength-meter>
     {/if}
-    <div class="flex w-full relative">
+    <div class="flex  w-full relative">
         <Input
             {error}
             {type}
@@ -70,7 +70,9 @@
             placeholder={placeholder || locale('general.password')}
             {submitHandler}
             disableContextMenu={true}
-            spellcheck="false" />
+            spellcheck="false"
+            {locale}
+            capsLockWarning={true} />
         {#if showRevealToggle === true && !disabled}
             <button type="button" on:click={() => revealToggle()} tabindex="-1" class="absolute top-3 right-3">
                 <Icon icon={revealed ? 'view' : 'hide'} classes="text-blue-500" />

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -701,7 +701,8 @@
         "sentFrom": "Sent from {account}",
         "receiving": "Receiving",
         "sending": "Sending",
-        "legacyNetwork": "Legacy Network"
+        "legacyNetwork": "Legacy Network",
+        "capsLock": "Caps Lock is on"
     },
     "dates": {
         "today": "Today",


### PR DESCRIPTION
# Description of change

Displays a caps lock indicator on password input to stop people incorrectly typing passwords in the wrong case.

![image](https://user-images.githubusercontent.com/5030334/115893913-9ccdbd00-a450-11eb-98a0-24c8bc839bf3.png)

## Links to any relevant issues

Fixes https://github.com/iotaledger/firefly/issues/996 https://github.com/iotaledger/firefly/issues/1021

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
