### PR TITLE
chore(desktop): Bump version to 1.1.1

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "productName": "Firefly",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "IOTA wallet desktop",
     "main": "public/build/main.js",
     "repository": "git@github.com:iotaledger/new-wallet.git",


### PR DESCRIPTION
### Changelog
- Improve display of error messages (#1041)
- Display macOS version instead of Darwin kernel version (#1041)
- Do not show error screen for uncaught errors in the renderer process (#1041)