### PR TITLE
fix: Balance finder with password layout is incorrect

### DIFF
--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -39,10 +39,12 @@
 <Text type="h4" classes="mb-6">{locale('popups.balanceFinder.title')}</Text>
 <Text type="p" secondary classes="mb-5">{locale('popups.balanceFinder.body')}</Text>
 <div class="flex w-full flex-row flex-wrap">
-    <div class="flex w-full flex-row flex-wrap mb-6 justify-between">
+    <div class="flex w-full flex-row flex-wrap mb-1 justify-between">
         <Text type="p">{locale('popups.balanceFinder.totalWalletBalance')}</Text>
         <Text type="p" highlighted>{$balanceOverview.balance}</Text>
-        <Text type="p" secondary classes="mb-6">{$balanceOverview.balanceFiat}</Text>
+        <Text type="p" secondary>{$balanceOverview.balanceFiat}</Text>
+    </div>
+    <div class="flex w-full flex-row flex-wrap mt-4 mb-6 justify-between">
         {#if $isStrongholdLocked}
             <Text type="p" secondary classes="mb-3">{locale('popups.balanceFinder.typePassword')}</Text>
             <Password


### PR DESCRIPTION
# Description of change

The layout of the balance finder popup is incorrect when a password is required.

![image1](https://user-images.githubusercontent.com/5030334/116514883-88137e00-a8c3-11eb-8419-7844e47a76f4.PNG)

Updated to

![image2](https://user-images.githubusercontent.com/5030334/116514901-8d70c880-a8c3-11eb-9fd6-eae25cf2580c.PNG)


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
