### PR TITLE
chore: rename entrypoint to index

### DIFF
--- a/packages/desktop/index.js
+++ b/packages/desktop/index.js
@@ -15,7 +15,7 @@ window.addEventListener('error', event => {
 })
 
 window.addEventListener('unhandledrejection', event => {
-    // Electron.unhandledException("Render Context Unhandled Rejection", event.reason)
+    Electron.unhandledException("Render Context Unhandled Rejection", event.reason)
     event.preventDefault();
     console.error(event.reason)
 });

--- a/packages/desktop/index.js
+++ b/packages/desktop/index.js
@@ -15,7 +15,7 @@ window.addEventListener('error', event => {
 })
 
 window.addEventListener('unhandledrejection', event => {
-    Electron.unhandledException("Render Context Unhandled Rejection", event.reason)
+    //Electron.unhandledException("Render Context Unhandled Rejection", event.reason)
     event.preventDefault();
     console.error(event.reason)
 });

--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -131,7 +131,7 @@ const rendererPlugins = [
 module.exports = [
     {
         entry: {
-            'build/index': ['./main.js'],
+            'build/index': ['./index.js'],
         },
         resolve,
         output,


### PR DESCRIPTION
# Description of change

Renames desktop root level main.js to index.js. The former is confusing given its use in Electron preload.

## Type of change

- Refactor

## How the change has been tested

Starts on Mac

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
