### PR TITLE
feat: Send fiat amounts

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -3,8 +3,8 @@
     import { Input, Text } from 'shared/components'
     import {
         AvailableExchangeRates,
-convertFromFiat,
-                convertToFiat,
+        convertFromFiat,
+        convertToFiat,
         currencies,
         CurrencyTypes,
         exchangeRates,
@@ -39,14 +39,11 @@ convertFromFiat,
     $: amountForLabel = getFormattedLabel(amount)
     $: {
         if (amount.length > 0) {
-            // TODO: Handle fiat here!
             if(!isFiatCurrency(unit)) {
                 const rawVal = changeUnits(parseCurrency(amount), unit, Unit.i)
                 if (rawVal > MAX_VALUE) {
                     amount = formatUnitPrecision(MAX_VALUE, unit, false)
                 }
-            } else {
-                // TODO: write case here
             }
         }
     }
@@ -61,9 +58,8 @@ convertFromFiat,
                 amount = amountToFiat(amount).slice(2)
             } else {
                 if(isFiatCurrency(unit)) {
-                    console.log("FIAT -> IOTA")
-
-                    amount = "1003"
+                    let inIotas = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+                    amount = formatUnitPrecision(inIotas, index).replace(index, '')
                 } else {
                     amount = formatUnitPrecision(changeUnits(parseCurrency(amount), unit, Unit.i), index, false)
                 }
@@ -136,7 +132,7 @@ convertFromFiat,
         } else {
             const amountAsI = changeUnits(amountAsFloat, unit, Unit.i)
             const amountasFiat = convertToFiat(amountAsI, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
-            
+
             return amountasFiat === 0 ? replaceCurrencyDecimal(`< 0.01`) : formatCurrency(amountasFiat)
         }
     }
@@ -147,7 +143,6 @@ convertFromFiat,
         if(!amount) return null
 
         const amountAsFloat = parseCurrency(_amount, unit)
-        console.log(amountAsFloat)
         if(amountAsFloat === 0 || Number.isNaN(amountAsFloat)) {
             return null
         } else {

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -28,6 +28,7 @@
 
     let profileCurrency: AvailableExchangeRates = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
 
+    // NOTE: Units is used for the dropdown, so it must contain both IOTA denominations and the user's selected fiat currency
     const Units = [profileCurrency as string].concat(Object.values(Unit).filter((x) => x !== 'Pi').map(x => x as string))
     const MAX_VALUE = 2779530283000000
 
@@ -122,7 +123,7 @@
         }
     }
 
-    const isFiatCurrency = (unitAsString): boolean => {
+    const isFiatCurrency = (unitAsString) => {
         return !Object.values(Unit).includes(unitAsString);
     }
 

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -44,6 +44,11 @@
                 if (rawVal > MAX_VALUE) {
                     amount = formatUnitPrecision(MAX_VALUE, unit, false)
                 }
+            } else {
+                const amountAsI = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+                if(amountAsI > MAX_VALUE) {
+                    amount = convertToFiat(MAX_VALUE, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency]).toString()
+                }
             }
         }
     }

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -42,7 +42,8 @@
     $: {
         if (amount.length > 0) {
             if(!isFiatCurrency(unit)) {
-                const rawVal = changeUnits(parseCurrency(amount), unit, Unit.i)
+                const amountParsed = parseCurrency(amount)
+                const rawVal = changeUnits(Number.isNaN(amountParsed) ? 0 : amountParsed, unit, Unit.i)
                 if (rawVal > MAX_VALUE) {
                     amount = formatUnitPrecision(MAX_VALUE, unit, false)
                 }

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -29,8 +29,8 @@
 
     let profileCurrency: AvailableExchangeRates = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
 
-    // NOTE: Units is used for the dropdown, so it must contain both IOTA denominations and the user's selected fiat currency
-    const Units = [profileCurrency as string].concat(Object.values(Unit).filter((x) => x !== 'Pi').map(x => x as string))
+    /** NOTE: Units is used for the dropdown, so it must contain both IOTA denominations and the user's selected fiat currency */
+    const Units = [profileCurrency as string].concat(Object.values(Unit).filter(x => x !== 'Pi').map(x => x as string))
     const MAX_VALUE = 2779530283000000
 
     let dropdown = false
@@ -62,6 +62,8 @@
     const onSelect = (index) => {
         if (amount.length > 0) {
             if(isFiatCurrency(index)) {
+                if(isFiatCurrency(unit)) return
+
                 amount = amountToFiat(amount).slice(2)
             } else {
                 if(isFiatCurrency(unit)) {

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -9,6 +9,7 @@
         CurrencyTypes,
         exchangeRates,
         formatCurrency,
+        isFiatCurrency,
         parseCurrency,
         replaceCurrencyDecimal,
     } from 'shared/lib/currency'
@@ -64,8 +65,8 @@
                 amount = amountToFiat(amount).slice(2)
             } else {
                 if(isFiatCurrency(unit)) {
-                    let inIotas = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
-                    amount = formatUnitPrecision(inIotas, index).replace(index, '')
+                    let amountAsI = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+                    amount = formatUnitPrecision(amountAsI, index).replace(index, '')
                 } else {
                     amount = formatUnitPrecision(changeUnits(parseCurrency(amount), unit, Unit.i), index, false)
                 }
@@ -123,14 +124,10 @@
         }
     }
 
-    const isFiatCurrency = (unitAsString) => {
-        return !Object.values(Unit).includes(unitAsString);
-    }
-
     const amountToFiat = (_amount) => {
-        if(isFiatCurrency(unit)) return _amount
-
         if (!amount) return null
+        
+        if(isFiatCurrency(unit)) return _amount
 
         const amountAsFloat = parseCurrency(_amount)
         if (amountAsFloat === 0 || Number.isNaN(amountAsFloat)) {
@@ -144,9 +141,9 @@
     }
 
     const amountFromFiat = (_amount) => {
-        if(!isFiatCurrency(unit)) return _amount
-
         if(!amount) return null
+        
+        if(!isFiatCurrency(unit)) return _amount
 
         const amountAsFloat = parseCurrency(_amount, unit)
         if(amountAsFloat === 0 || Number.isNaN(amountAsFloat)) {

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -61,23 +61,30 @@
     }
 
     const onSelect = (index) => {
-        if (amount.length > 0) {
-            if(isFiatCurrency(index)) {
-                if(isFiatCurrency(unit)) return
+        updateUnit(index)
+    }
 
-                amount = amountToFiat(amount).slice(2)
+    const updateUnit = (toUnit) => {
+        convertAmount(unit, toUnit)
+
+        unit = toUnit
+    }
+
+    const convertAmount = (fromUnit, toUnit) => {
+        if(amount.length <= 0 || fromUnit === toUnit) return
+
+        if(isFiatCurrency(toUnit)) {
+            amount = amountToFiat(amount).slice(2)
+        } else {
+            if(isFiatCurrency(fromUnit)) {
+                let amountAsI = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+                amount = formatUnitPrecision(amountAsI, toUnit).replace(toUnit, '')
             } else {
-                if(isFiatCurrency(unit)) {
-                    let amountAsI = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
-                    amount = formatUnitPrecision(amountAsI, index).replace(index, '')
-                } else {
-                    amount = formatUnitPrecision(changeUnits(parseCurrency(amount), unit, Unit.i), index, false)
-                }
+                amount = formatUnitPrecision(changeUnits(parseCurrency(amount), fromUnit, Unit.i), toUnit, false)
             }
         }
-
-        unit = index
     }
+
 
     const focusItem = (itemId) => {
         let elem = document.getElementById(itemId)

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -14,7 +14,7 @@
         replaceCurrencyDecimal,
     } from 'shared/lib/currency'
     import { activeProfile } from 'shared/lib/profile'
-    import { changeUnits, formatUnitPrecision, UNIT_MAP } from 'shared/lib/units'
+    import { changeUnits, formatUnitBestMatch, formatUnitPrecision, UNIT_MAP } from 'shared/lib/units'
 
     export let amount = undefined
     export let unit = Unit.Mi
@@ -142,7 +142,7 @@
 
     const amountFromFiat = (_amount) => {
         if(!amount) return null
-        
+
         if(!isFiatCurrency(unit)) return _amount
 
         const amountAsFloat = parseCurrency(_amount, unit)
@@ -150,9 +150,8 @@
             return null
         } else {
             const amountAsI = convertFromFiat(amountAsFloat, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
-            const amountAsMi = changeUnits(amountAsI, Unit.i, Unit.Mi)
 
-            return `${amountAsMi} Mi`
+            return formatUnitBestMatch(amountAsI)
         }
 
     }

--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -12,7 +12,7 @@
     } from 'shared/lib/currency'
     import { closePopup } from 'shared/lib/popup'
     import { activeProfile } from 'shared/lib/profile'
-    import { changeUnits, formatUnitPrecision } from 'shared/lib/units'
+    import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
     import { get } from 'svelte/store'
 
     export let locale
@@ -29,9 +29,9 @@
         const activeCurrency = get(activeProfile)?.settings.currency ?? AvailableExchangeRates.USD
 
         let valInFiat = formatCurrency(convertToFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[activeCurrency]), activeCurrency)
-        let valInIotas = isFiat ? changeUnits(amount, Unit.i, Unit.Mi) : formatUnitPrecision(amount, unit)
+        let valInIotas = isFiat ? formatUnitBestMatch(amount) : formatUnitPrecision(amount, unit)
         
-        return isFiat ? `${valInFiat} (${valInIotas} Mi)` : `${valInIotas} (${valInFiat})` 
+        return isFiat ? `${valInFiat} (${valInIotas})` : `${valInIotas} (${valInFiat})` 
     }
 
     function handleCancelClick() {

--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -8,10 +8,11 @@
         CurrencyTypes,
         exchangeRates,
         formatCurrency,
+        isFiatCurrency,
     } from 'shared/lib/currency'
     import { closePopup } from 'shared/lib/popup'
     import { activeProfile } from 'shared/lib/profile'
-    import { formatUnitPrecision } from 'shared/lib/units'
+    import { changeUnits, formatUnitPrecision } from 'shared/lib/units'
     import { get } from 'svelte/store'
 
     export let locale
@@ -21,11 +22,16 @@
     export let unit = Unit.i
     export let onConfirm = () => {}
 
-    let displayedAmount = `${formatUnitPrecision(amount, unit)} (${localConvertToFiat(amount)})`
-
-    function localConvertToFiat(amount) {
+    let displayedAmount = getDisplayAmount()
+    
+    function getDisplayAmount() {
+        const isFiat = isFiatCurrency(unit)
         const activeCurrency = get(activeProfile)?.settings.currency ?? AvailableExchangeRates.USD
-        return formatCurrency(convertToFiat(amount, get(currencies)[CurrencyTypes.USD], get(exchangeRates)[activeCurrency]))
+
+        let valInFiat = formatCurrency(convertToFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[activeCurrency]), activeCurrency)
+        let valInIotas = isFiat ? changeUnits(amount, Unit.i, Unit.Mi) : formatUnitPrecision(amount, unit)
+        
+        return isFiat ? `${valInFiat} (${valInIotas} Mi)` : `${valInIotas} (${valInFiat})` 
     }
 
     function handleCancelClick() {

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -140,7 +140,7 @@ export const currencies = writable<Currencies>({} as Currencies)
  *
  * @method convertToFiat
  *
- * @param {number} amount
+ * @param {number} amount 
  * @param {number} usdPrice
  * @param {number} conversionRate
  *
@@ -148,6 +148,19 @@ export const currencies = writable<Currencies>({} as Currencies)
  */
 export const convertToFiat = (amount: number, usdPrice: number, conversionRate: number): number => {
     return +(((amount * usdPrice) / 1000000) * conversionRate).toFixed(2)
+}
+
+/**
+ * Converts fiat to iotas equivalent
+ * 
+ * @param {number} amount 
+ * @param {number} usdPrice 
+ * @param {number} conversionRate 
+ * 
+ * @returns {number}
+ */
+export const convertFromFiat = (amount: number, usdPrice: number, conversionRate: number): number => {
+    return +(((amount * conversionRate) / usdPrice) * 1000000).toFixed(0)
 }
 
 /**

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -1,4 +1,3 @@
-import { Unit } from '@iota/unit-converter'
 import { get, writable } from 'svelte/store'
 import { appSettings } from './appSettings'
 import { activeProfile } from './profile'
@@ -167,16 +166,16 @@ export const convertFromFiat = (amount: number, usdPrice: number, conversionRate
 }
 
 /**
- * Determines if a unit is a fiat currency or not
+ * Determines if a currency is fiat or not
  * 
  * @method isFiatCurrency
  * 
- * @param {Unit | string} unit
+ * @param {string} currency
  * 
  * @returns {boolean}
  */
-export const isFiatCurrency = (unit: Unit | string): boolean => {
-    return !Object.values(Unit).map(x => x as string).includes(unit as string)
+export const isFiatCurrency = (currency: string): boolean => {
+    return Object.values(AvailableExchangeRates).map(x => x as string).includes(currency)
 }
 
 /**

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -166,7 +166,7 @@ export const convertFromFiat = (amount: number, usdPrice: number, conversionRate
 }
 
 /**
- * Determines if a currency is fiat or not
+ * Determines if a currency is fiat or not via its ISO 4217 code
  * 
  * @method isFiatCurrency
  * 

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -153,6 +153,8 @@ export const convertToFiat = (amount: number, usdPrice: number, conversionRate: 
 /**
  * Converts fiat to iotas equivalent
  * 
+ * @method convertFromFiat
+ * 
  * @param {number} amount 
  * @param {number} usdPrice 
  * @param {number} conversionRate 

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -1,3 +1,4 @@
+import { Unit } from '@iota/unit-converter'
 import { get, writable } from 'svelte/store'
 import { appSettings } from './appSettings'
 import { activeProfile } from './profile'
@@ -163,6 +164,19 @@ export const convertToFiat = (amount: number, usdPrice: number, conversionRate: 
  */
 export const convertFromFiat = (amount: number, usdPrice: number, conversionRate: number): number => {
     return +(((amount / conversionRate) / usdPrice) * 1000000).toFixed(0)
+}
+
+/**
+ * Determines if a unit is a fiat currency or not
+ * 
+ * @method isFiatCurrency
+ * 
+ * @param {Unit | string} unit
+ * 
+ * @returns {boolean}
+ */
+export const isFiatCurrency = (unit: Unit | string): boolean => {
+    return !Object.values(Unit).map(x => x as string).includes(unit as string)
 }
 
 /**

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -160,7 +160,7 @@ export const convertToFiat = (amount: number, usdPrice: number, conversionRate: 
  * @returns {number}
  */
 export const convertFromFiat = (amount: number, usdPrice: number, conversionRate: number): number => {
-    return +(((amount * conversionRate) / usdPrice) * 1000000).toFixed(0)
+    return +(((amount / conversionRate) / usdPrice) * 1000000).toFixed(0)
 }
 
 /**

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -216,7 +216,7 @@
         }
     }
     const handleMaxClick = () => {
-        const isFiat: boolean = !Object.values(Unit).includes(unit)
+        const isFiat = !Object.values(Unit).includes(unit)
         amount = isFiat ? convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]).toString() : formatUnitPrecision(from.balance, unit, false)
     }
 

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -240,7 +240,7 @@
     }
     const handleMaxClick = () => {
         amount = isFiatCurrency(unit) ? convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]).toString()
-                                             : formatUnitPrecision(from.balance, unit, false)
+                                      : formatUnitPrecision(from.balance, unit, false)
     }
 
     const updateFromSendParams = (s) => {

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -2,7 +2,7 @@
     import { Unit } from '@iota/unit-converter'
     import { Address, Amount, Button, Dropdown, Icon, ProgressBar, Text } from 'shared/components'
     import { clearSendParams, sendParams } from 'shared/lib/app'
-    import { parseCurrency } from 'shared/lib/currency'
+    import { convertToFiat, currencies, CurrencyTypes, exchangeRates, parseCurrency } from 'shared/lib/currency'
     import { closePopup, openPopup } from 'shared/lib/popup'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import type { TransferProgressEventType } from 'shared/lib/typings/events'
@@ -216,7 +216,8 @@
         }
     }
     const handleMaxClick = () => {
-        amount = formatUnitPrecision(from.balance, unit, false)
+        const isFiat: boolean = !Object.values(Unit).includes(unit)
+        amount = isFiat ? convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]).toString() : formatUnitPrecision(from.balance, unit, false)
     }
 
     const updateFromSendParams = (s) => {


### PR DESCRIPTION
# Description of change

Previously, the user was only able to enter values in the IOTA denominations (i, Ki, Mi, Gi, and Ti). This PR extends the functionality of the amount input to accommodate the user's selected fiat currency, meaning that the user can now specify a fiat amount when sending a transaction (internally and externally). 

## Links to any relevant issues

- #763
- #1168 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

This PR has been tested on MacOS (Catalina 10.15.7) and Linux (Ubuntu 20.04).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
