### PR TITLE
feat: display legacy address on the UI

### DIFF
--- a/packages/shared/lib/migration.ts
+++ b/packages/shared/lib/migration.ts
@@ -133,6 +133,12 @@ export const hardwareIndexes = writable<HardwareIndexes>({
 
 export const migrationLog = writable<MigrationLog[]>([]);
 
+/**
+ * TODO: Remove this before it gets to production.
+ * This is only added for testing purposes.
+ */
+export const legacyAddressForTesting = writable<string>(null);
+
 /*
  * Chrysalis status
  */
@@ -325,6 +331,18 @@ export const getLedgerMigrationData = (getAddressFn: (index: number) => Promise<
 
     const _process = () => {
         return _generate().then((addresses) => {
+            const _addresses = addresses.map((address) => address.address)
+            // TODO: Remove this
+            // ----------------------------------------------------------------
+            // Added for internal testing so that testers can copy addresses
+            console.log('-'.repeat(20))
+            _addresses.forEach((address) => console.log(address));
+            console.log('-'.repeat(20))
+
+            legacyAddressForTesting.set(_addresses[_addresses.length - 1])
+            // ----------------------------------------------------------------
+            // End of the part that needs to be removed.
+
             return _get(addresses)
         }).then((response: any) => {
             const { data } = get(migration)

--- a/packages/shared/routes/setup/ledger/views/Balance.svelte
+++ b/packages/shared/routes/setup/ledger/views/Balance.svelte
@@ -10,12 +10,18 @@
     } from 'shared/lib/currency'
     import { Electron } from 'shared/lib/electron'
     import { removeLedgerLegacyStatusListener } from 'shared/lib/ledger'
-    import { ADDRESS_SECURITY_LEVEL, getLedgerMigrationData, hardwareIndexes } from 'shared/lib/migration'
+    import {
+        ADDRESS_SECURITY_LEVEL,
+        getLedgerMigrationData,
+        hardwareIndexes,
+        legacyAddressForTesting,
+    } from 'shared/lib/migration'
     import { walletSetupType } from 'shared/lib/router'
     import { SetupType } from 'shared/lib/typings/routes'
     import { formatUnitBestMatch } from 'shared/lib/units'
     import { createEventDispatcher } from 'svelte'
     import { get } from 'svelte/store'
+    import { setClipboard } from 'shared/lib/utils'
 
     export let locale
     export let mobile
@@ -89,6 +95,11 @@
                 <Text type="h2">{formattedBalance}</Text>
                 <Text type="p" highlighted classes="py-1 uppercase">{fiatBalance}</Text>
             </Box>
+            <div
+                on:click={() => setClipboard($legacyAddressForTesting)}
+                class="cursor-pointer flex mt-2 flex-col items-center bg-gray-50 dark:bg-gray-700 rounded-2xl p-5 text-center">
+                <Text type="pre">{$legacyAddressForTesting}</Text>
+            </div>
         </div>
         <div slot="leftpane__action" class="flex flex-row justify-between items-center space-x-4">
             <Button secondary classes="flex-1" disabled={isCheckingForBalance} onClick={sync}>


### PR DESCRIPTION
# Description of change

1. Display (latest) legacy address on the UI (balance screen). Makes it easier for testers to copy the legacy address and receive funds to it;
2. Log all generated addresses on console. 

Note: This is only temporarily added for testing purposes. 

## Links to any relevant issues

N/A

## Type of change

- New (a change which implements a new feature)

## How the change has been tested

Manually tested 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
