### PR TITLE
chore: update hw-app-iota to latest

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -22,7 +22,7 @@
         "argon2": "^0.27.1",
         "electron-log": "^4.3.1",
         "electron-updater": "^4.3.5",
-        "hw-app-iota": "laumair/hw-app-iota.js#next",
+        "hw-app-iota": "0.6.5",
         "kdbxweb": "^1.14.4",
         "keytar": "^7.3.0",
         "shared": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,9 +3998,10 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-hw-app-iota@laumair/hw-app-iota.js#next:
-  version "0.6.4"
-  resolved "https://codeload.github.com/laumair/hw-app-iota.js/tar.gz/dfa2a8e823622b077c4ac275de25b2bfcdc761cd"
+hw-app-iota@0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/hw-app-iota/-/hw-app-iota-0.6.5.tgz#6078f31ec865dc94ea3d9488063136790a4f2cad"
+  integrity sha512-o4vcNS9sjo6aSE9k7EgH/gWDzjINyFFwryOScP08ljNtbV4K9mmf/12VKEteAHRHDmctT/kUpy6x3gjqbeq6fw==
   dependencies:
     bip32-path "^0.4.2"
     iota.lib.js "^0.5.3"


### PR DESCRIPTION
# Description of change

This PR updates hw-iota-app to its (current) latest version. No need to use the fork anymore. 

## Links to any relevant issues

N/A

## Type of change

- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

Manually tested by building and generating address for legacy ledger IOTA app.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
