### PR TITLE
fix: ensure js Ledger connection is closed and other fixes

### DIFF
--- a/packages/desktop/electron/lib/Ledger.js
+++ b/packages/desktop/electron/lib/Ledger.js
@@ -57,7 +57,7 @@ class Ledger {
 
         await this.awaitApplication(index, page, security);
 
-        return this.iota;
+        return { iota: this.iota, callback: () => this.transport.close() };
     }
 
     /**

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -1,9 +1,10 @@
 import { isSoftwareProfile } from 'shared/lib/profile'
 import { get, writable } from 'svelte/store'
 import { localize } from './i18n'
+import { stopPollingLedgerStatus } from './ledger'
 import { showAppNotification } from './notifications'
 import { closePopup } from './popup'
-import { activeProfile, clearActiveProfile, isStrongholdLocked } from './profile'
+import { activeProfile, clearActiveProfile, isLedgerProfile, isStrongholdLocked } from './profile'
 import { resetRouter } from './router'
 import { api, destroyActor, resetWallet } from './wallet'
 
@@ -75,6 +76,9 @@ export const logout = () => {
             }
             if (get(isSoftwareProfile)) {
                 isStrongholdLocked.set(true)
+            }
+            if (get(isLedgerProfile)) {
+                stopPollingLedgerStatus()
             }
             clearSendParams()
             closePopup()

--- a/packages/shared/lib/migration.ts
+++ b/packages/shared/lib/migration.ts
@@ -458,7 +458,8 @@ export const createMinedLedgerMigrationBundle = (
         inputs: Input[],
         remainder: undefined,
         now: () => number
-    ) => Promise<string[]>
+    ) => Promise<string[]>,
+    callback: () => void
 ) => {
     const { bundles } = get(migration);
 
@@ -496,6 +497,7 @@ export const createMinedLedgerMigrationBundle = (
 
     return prepareTransfersFn([transfer], inputs, undefined, () => txs[0].timestamp * 1000).then((trytes) => {
         updateLedgerBundleState(bundleIndex, trytes, false);
+        callback()
         return { trytes, bundleHash: asTransactionObject(trytes[0]).bundle }
     });
 };
@@ -515,7 +517,8 @@ export const createLedgerMigrationBundle = (
     prepareTransfersFn: (
         transfers: Transfer[],
         inputs: Input[],
-    ) => Promise<string[]>
+    ) => Promise<string[]>,
+    callback: () => void
 ): Promise<any> => {
     return new Promise((resolve, reject) => {
         api.getMigrationAddress(false, {
@@ -541,6 +544,7 @@ export const createLedgerMigrationBundle = (
 
         return prepareTransfersFn([transfer], bundle.inputs.map((input) => Object.assign({}, input, { keyIndex: input.index }))).then((trytes) => {
             updateLedgerBundleState(bundleIndex, trytes, false);
+            callback()
             return { trytes, bundleHash: asTransactionObject(trytes[0]).bundle }
         });
     });

--- a/packages/shared/lib/migration.ts
+++ b/packages/shared/lib/migration.ts
@@ -292,7 +292,7 @@ export const prepareMigrationLog = (bundleHash: string, trytes: string[], balanc
  * 
  * @returns {Promise<void>}
  */
-export const getLedgerMigrationData = (getAddressFn: (index: number) => Promise<string>): Promise<any> => {
+export const getLedgerMigrationData = (getAddressFn: (index: number) => Promise<string>, callback: () => void): Promise<any> => {
     const _get = (addresses: AddressInput[]): Promise<any> => {
         return new Promise((resolve, reject) => {
             api.getLedgerMigrationData(
@@ -362,7 +362,6 @@ export const getLedgerMigrationData = (getAddressFn: (index: number) => Promise<
             }
 
             prepareBundles()
-
             return get(data).inputs.length > 0;
         });
     }
@@ -371,9 +370,11 @@ export const getLedgerMigrationData = (getAddressFn: (index: number) => Promise<
         if (shouldGenerateMore) {
             return _process();
         }
-
         return Promise.resolve(true);
-    }).then(() => get(get(migration).data))
+    }).then(() => {
+        callback()
+        return get(get(migration).data)
+    })
 };
 
 /**

--- a/packages/shared/routes/dashboard/wallet/views/Security.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Security.svelte
@@ -1,21 +1,15 @@
 <script lang="typescript">
-    import {
-        getLedgerDeviceStatus,
-        getLedgerOpenedApp,
-        ledgerDeviceState,
-        pollLedgerDeviceStatus,
-        stopPollingLedgerStatus
-    } from 'shared/lib/ledger'
     import { SecurityTile, Text } from 'shared/components'
     import { versionDetails } from 'shared/lib/appUpdater'
     import { diffDates, getBackupWarningColor, isRecentDate } from 'shared/lib/helpers'
+    import { getLedgerDeviceStatus, getLedgerOpenedApp, ledgerDeviceState, pollLedgerDeviceStatus } from 'shared/lib/ledger'
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, isSoftwareProfile, isStrongholdLocked, profiles } from 'shared/lib/profile'
+    import { LedgerApp, LedgerDeviceState } from 'shared/lib/typings/ledger'
     import { api } from 'shared/lib/wallet'
     import { onDestroy, onMount } from 'svelte'
     import { get } from 'svelte/store'
-    import { LedgerApp, LedgerDeviceState } from 'shared/lib/typings/ledger'
 
     export let locale
 
@@ -29,7 +23,7 @@
 
     let hardwareDeviceColor = 'gray'
     $: {
-        switch($ledgerDeviceState) {
+        switch ($ledgerDeviceState) {
             default:
             case LedgerDeviceState.Connected:
                 hardwareDeviceColor = 'blue'
@@ -57,7 +51,7 @@
          * NOTE: The text for when another app (besides IOTA or IOTA Legacy) is open
          * requires an app name to be prepended or else the text won't make sense.
          */
-        if(state === LedgerDeviceState.OtherConnected) {
+        if (state === LedgerDeviceState.OtherConnected) {
             getLedgerOpenedApp()
                 .then((la: LedgerApp) => {
                     hardwareDeviceStatus = `${la.name} ${text}`
@@ -85,7 +79,6 @@
 
     onDestroy(() => {
         clearTimeout(ledgerSpinnerTimeout)
-        stopPollingLedgerStatus()
         unsubscribe()
     })
 

--- a/packages/shared/routes/dashboard/wallet/views/Security.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Security.svelte
@@ -79,7 +79,7 @@
         setup()
 
         if (!$isSoftwareProfile) {
-            pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL, getLedgerDeviceStatus)
+            pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL)
         }
     })
 

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -20,7 +20,7 @@
     import { getContext, onDestroy, onMount } from 'svelte'
     import type { Readable } from 'svelte/store'
     import { get } from 'svelte/store'
-    import { getLedgerDeviceStatus, ledgerDeviceState, pollLedgerDeviceStatus, stopPollingLedgerStatus } from 'shared/lib/ledger'
+    import { ledgerDeviceState, pollLedgerDeviceStatus, stopPollingLedgerStatus } from 'shared/lib/ledger'
     import { LedgerDeviceState } from 'shared/lib/typings/ledger'
     import { displayNotifications, isNewNotification, showAppNotification } from 'shared/lib/notifications'
     import type { NotificationType } from 'shared/lib/typings/notification'
@@ -422,7 +422,7 @@
     })
 
     onMount(() => {
-        pollLedgerDeviceStatus(false, 500, getLedgerDeviceStatus, getLedgerDeviceStatus, getLedgerDeviceStatus)
+        pollLedgerDeviceStatus(false, 500)
 
         updateFromSendParams($sendParams)
     })

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -3,8 +3,10 @@
     import { Address, Amount, Button, Dropdown, Icon, ProgressBar, Text } from 'shared/components'
     import { clearSendParams, sendParams } from 'shared/lib/app'
     import { parseCurrency } from 'shared/lib/currency'
+    import { ledgerDeviceState } from 'shared/lib/ledger'
+    import { displayNotifications, isNewNotification, showAppNotification } from 'shared/lib/notifications'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
-    import { isSoftwareProfile, isLedgerProfile } from 'shared/lib/profile'
+    import { isLedgerProfile, isSoftwareProfile } from 'shared/lib/profile'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import {
         GeneratingRemainderDepositAddressEvent,
@@ -13,6 +15,8 @@
         TransferProgressEventType,
         TransferState,
     } from 'shared/lib/typings/events'
+    import { LedgerDeviceState } from 'shared/lib/typings/ledger'
+    import type { NotificationType } from 'shared/lib/typings/notification'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
     import { changeUnits, formatUnitPrecision } from 'shared/lib/units'
     import { ADDRESS_LENGTH, validateBech32Address } from 'shared/lib/utils'
@@ -20,10 +24,6 @@
     import { getContext, onDestroy, onMount } from 'svelte'
     import type { Readable } from 'svelte/store'
     import { get } from 'svelte/store'
-    import { ledgerDeviceState, pollLedgerDeviceStatus, stopPollingLedgerStatus } from 'shared/lib/ledger'
-    import { LedgerDeviceState } from 'shared/lib/typings/ledger'
-    import { displayNotifications, isNewNotification, showAppNotification } from 'shared/lib/notifications'
-    import type { NotificationType } from 'shared/lib/typings/notification'
 
     export let locale
     export let send
@@ -422,16 +422,11 @@
     })
 
     onMount(() => {
-        pollLedgerDeviceStatus(false, 500)
-
         updateFromSendParams($sendParams)
     })
 
     onDestroy(() => {
         if (transactionTimeoutId) clearTimeout(transactionTimeoutId)
-
-        stopPollingLedgerStatus()
-
         sendSubscription()
     })
 </script>

--- a/packages/shared/routes/setup/Balance.svelte
+++ b/packages/shared/routes/setup/Balance.svelte
@@ -172,10 +172,10 @@
             const _onConnected = () => {
                 Electron.ledger
                     .selectSeed($hardwareIndexes.accountIndex, $hardwareIndexes.pageIndex, ADDRESS_SECURITY_LEVEL)
-                    .then((iota) => {
-                        return getLedgerMigrationData(iota.getAddress)
+                    .then(({ iota, callback }) => {
+                        return getLedgerMigrationData(iota.getAddress, callback)
                     })
-                    .then((data) => {
+                    .then(() => {
                         isCheckingForBalance = false
                     })
                     .catch((error) => {

--- a/packages/shared/routes/setup/ledger/views/AccountIndex.svelte
+++ b/packages/shared/routes/setup/ledger/views/AccountIndex.svelte
@@ -52,8 +52,8 @@
         const _onConnected = () => {
             Electron.ledger
                 .selectSeed(index, page, ADDRESS_SECURITY_LEVEL)
-                .then((iota) => {
-                    return getLedgerMigrationData(iota.getAddress)
+                .then(({ iota, callback }) => {
+                    return getLedgerMigrationData(iota.getAddress, callback)
                 })
                 .then((data) => {
                     busy = false

--- a/packages/shared/routes/setup/ledger/views/Connect.svelte
+++ b/packages/shared/routes/setup/ledger/views/Connect.svelte
@@ -1,7 +1,6 @@
 <script>
     import { Button, Icon, Illustration, OnboardingLayout, Spinner, Text } from 'shared/components'
     import {
-        getLedgerDeviceStatus,
         ledgerDeviceState,
         ledgerSimulator,
         pollLedgerDeviceStatus,
@@ -39,7 +38,7 @@
     const dispatch = createEventDispatcher()
 
     onMount(() => {
-        pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL, getLedgerDeviceStatus, getLedgerDeviceStatus)
+        pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL)
         polling = true
     })
 

--- a/packages/shared/routes/setup/migrate/views/Migrate.svelte
+++ b/packages/shared/routes/setup/migrate/views/Migrate.svelte
@@ -74,8 +74,8 @@
                 const _onConnected = () => {
                     Electron.ledger
                         .selectSeed($hardwareIndexes.accountIndex, $hardwareIndexes.pageIndex, ADDRESS_SECURITY_LEVEL)
-                        .then((iota) => {
-                            return createLedgerMigrationBundle(0, iota.prepareTransfers)
+                        .then(({ iota, callback }) => {
+                            return createLedgerMigrationBundle(0, iota.prepareTransfers, callback)
                         })
                         .then(({ trytes, bundleHash }) => {
                             closePopup() // close transaction popup

--- a/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
+++ b/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
@@ -136,8 +136,8 @@
                             if (transaction.trytes && transaction.trytes.length) {
                                 return Electron.ledger
                                     .selectSeed($hardwareIndexes.accountIndex, $hardwareIndexes.pageIndex, ADDRESS_SECURITY_LEVEL)
-                                    .then((iota) => {
-                                        return createMinedLedgerMigrationBundle(transaction.index, iota.prepareTransfers)
+                                    .then(({ iota, callback }) => {
+                                        return createMinedLedgerMigrationBundle(transaction.index, iota.prepareTransfers, callback)
                                     })
                                     .then(({ trytes, bundleHash }) => {
                                         closePopup() // close transaction popup
@@ -150,8 +150,8 @@
 
                             return Electron.ledger
                                 .selectSeed($hardwareIndexes.accountIndex, $hardwareIndexes.pageIndex, ADDRESS_SECURITY_LEVEL)
-                                .then((iota) => {
-                                    return createLedgerMigrationBundle(transaction.index, iota.prepareTransfers)
+                                .then(({ iota, callback }) => {
+                                    return createLedgerMigrationBundle(transaction.index, iota.prepareTransfers, callback)
                                 })
                                 .then(({ trytes, bundleHash }) => {
                                     closePopup() // close transaction popup
@@ -254,8 +254,8 @@
                             if (transaction.trytes && transaction.trytes.length) {
                                 return Electron.ledger
                                     .selectSeed($hardwareIndexes.accountIndex, $hardwareIndexes.pageIndex, ADDRESS_SECURITY_LEVEL)
-                                    .then((iota) => {
-                                        return createMinedLedgerMigrationBundle(transaction.index, iota.prepareTransfers)
+                                    .then(({ iota, callback }) => {
+                                        return createMinedLedgerMigrationBundle(transaction.index, iota.prepareTransfers, callback)
                                     })
                                     .then(({ trytes, bundleHash }) => {
                                         transactions = transactions.map((_transaction, i) => {
@@ -284,8 +284,8 @@
 
                             return Electron.ledger
                                 .selectSeed($hardwareIndexes.accountIndex, $hardwareIndexes.pageIndex, ADDRESS_SECURITY_LEVEL)
-                                .then((iota) => {
-                                    return createLedgerMigrationBundle(transaction.index, iota.prepareTransfers)
+                                .then(({ iota, callback }) => {
+                                    return createLedgerMigrationBundle(transaction.index, iota.prepareTransfers, callback)
                                 })
                                 .then(({ trytes, bundleHash }) => {
                                     closePopup() // close transaction popup


### PR DESCRIPTION
# Description of change

- Close Ledger connection on the js side after finishing getting migration data 
- Remove unnecessary ledger connection status calls
- Unify connection status polling to one global dashboard item in Security

## Links to any relevant issues

Fixes #1264 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on Mac

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
