### PR TITLE
Fix: Close tx legacy popup during bundle mining 

### DIFF
--- a/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
+++ b/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
@@ -258,6 +258,7 @@
                                         return createMinedLedgerMigrationBundle(transaction.index, iota.prepareTransfers)
                                     })
                                     .then(({ trytes, bundleHash }) => {
+                                        closePopup() // close transaction popup
                                         transactions = transactions.map((_transaction, i) => {
                                             if (_transaction.index === transaction.index) {
                                                 return { ..._transaction, bundleHash }
@@ -276,9 +277,6 @@
                                         }
 
                                         migratedAndUnconfirmedBundles = [...migratedAndUnconfirmedBundles, transaction.bundleHash]
-                                    })
-                                    .then(() => {
-                                        closePopup() // close transaction popup
                                     })
                             }
 


### PR DESCRIPTION
# Description of change

On bundle mining the legacy tx popup was closing too late

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Ubuntu 18.04, Ledger Nano S firmware 2.0.0

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
