### PR TITLE
reinitialize ledger route onMount

### DIFF
--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -58,7 +58,7 @@ export const dashboardRoute = writable<Tabs>(Tabs.Wallet)
 /**
  * Ledger setup route
  */
-export const ledgerRoute = writable<LedgerRoutes>(get(walletSetupType) === SetupType.New || get(walletSetupType) === SetupType.FireflyLedger ? LedgerRoutes.Connect : LedgerRoutes.LegacyIntro)
+export const ledgerRoute = writable<LedgerRoutes>(LedgerRoutes.LegacyIntro)
 
 /**
  * Ledger setup routing history

--- a/packages/shared/routes/setup/ledger/Ledger.svelte
+++ b/packages/shared/routes/setup/ledger/Ledger.svelte
@@ -3,7 +3,7 @@
     import { currentLedgerMigrationProgress, LedgerMigrationProgress } from 'shared/lib/migration'
     import { ledgerRoute, ledgerRouteHistory, walletSetupType } from 'shared/lib/router'
     import { LedgerRoutes, SetupType } from 'shared/lib/typings/routes'
-    import { createEventDispatcher } from 'svelte'
+    import { createEventDispatcher, onMount } from 'svelte'
     import { get } from 'svelte/store'
     import {
         AccountIndex,
@@ -21,6 +21,14 @@
     const dispatch = createEventDispatcher()
 
     $: $ledgerRoute, updateMigrationProgress()
+
+    onMount(() => {
+        if ($walletSetupType === SetupType.New || $walletSetupType === SetupType.FireflyLedger) {
+            ledgerRoute.set(LedgerRoutes.Connect)
+        } else {
+            ledgerRoute.set(LedgerRoutes.LegacyIntro)
+        }
+    })
 
     const updateMigrationProgress = () => {
         switch (get(ledgerRoute)) {


### PR DESCRIPTION
# Description of change

Fix ledger routing. Before, import from firefly ledger was using the legacy migration route

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Ubuntu 18.04. Ledger simulator

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
