### PR TITLE
Feat: check for new ledger app open after migration 

### DIFF
--- a/packages/shared/routes/setup/Congratulations.svelte
+++ b/packages/shared/routes/setup/Congratulations.svelte
@@ -69,6 +69,10 @@
         if (wasMigrated) {
             const _continue = () => {
                 if ($walletSetupType === SetupType.TrinityLedger) {
+                    /**
+                     * We check for the new Ledger IOTA app to be connected after migration
+                     * because the last app the user had open was the legacy one
+                     */
                     promptUserToConnectLedger(false, () => dispatch('next'))
                 } else {
                     dispatch('next')


### PR DESCRIPTION
# Description of change

Add ledger iota app connection check to ledger migration congrats view. This way, we make sure the user reaches the dashboard with the new ledger iota app open, since the last one it had open during migration was the legacy one

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Ubuntu 18.04. Ledger Simulators.
To test, run a ledger simulation and other profile creations to make sure the prompt is only added to ledger legacy migration. 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
