### PR TITLE
Feat: Remove chrysalis network upgrade checks and notification

### DIFF
--- a/packages/shared/lib/validator.ts
+++ b/packages/shared/lib/validator.ts
@@ -1,14 +1,14 @@
 import type { MarketDataValidationResponse } from 'shared/lib/marketData'
-import type { ChrysalisNodeDataValidationResponse, ChrysalisVariablesValidationResponse } from 'shared/lib/migration'
+import type { ChrysalisVariablesValidationResponse } from 'shared/lib/migration'
 import type { Account, SyncedAccount } from './typings/account'
 import type { Address } from './typings/address'
 import type { MessageResponse } from './typings/bridge'
 import { ResponseTypes } from './typings/bridge'
-import type { Message } from './typings/message'
 import type { LedgerStatus } from './typings/ledger'
-import type { StrongholdStatus } from './typings/wallet'
+import type { Message } from './typings/message'
+import type { MigrationData } from './typings/migration'
 import type { NodeInfo } from './typings/node'
-import type { MigrationData } from './typings/migration';
+import type { StrongholdStatus } from './typings/wallet'
 
 type Validators =
     | IdValidator
@@ -836,8 +836,6 @@ export default class ValidatorService {
             [ResponseTypes.MigrationProgress]: this.createBaseEventValidator().getFirst(),
             // Market data
             MarketData: new ValidatorChainBuilder().add(new TypeValidator()).getFirst(),
-            // Chrysalis node
-            ChrysalisNode: new ValidatorChainBuilder().add(new TypeValidator()).getFirst(),
             // Chrysalis github variables
             ChrysalisVariables: new ValidatorChainBuilder().add(new TypeValidator()).getFirst(),
         }
@@ -874,7 +872,7 @@ export default class ValidatorService {
      *
      * @returns {ValidationResponse}
      */
-    performValidation(response: MessageResponse | MarketDataValidationResponse | ChrysalisNodeDataValidationResponse | ChrysalisVariablesValidationResponse): ValidationResponse {
+    performValidation(response: MessageResponse | MarketDataValidationResponse | ChrysalisVariablesValidationResponse): ValidationResponse {
         return this.validators[response.type].isValid(response)
     }
 }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -869,8 +869,7 @@
         "minutesRemaining": "{minutes, plural, one {1 minute remaining} other {# minutes remaining}}",
         "copiedToClipboard": "Copied to clipboard",
         "accountsSynchronized": "Wallet synchronization complete",
-        "migratedAccountChrysalisDown": "Your funds will become available after Chrysalis on 28th April",
-        "migratedAccountChrysalisUp": "Your funds will become available shortly"
+        "fundsAvailableSoon": "Your funds will become available shortly"
     },
     "error": {
         "profile": {

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -176,7 +176,7 @@
      * but there is an active "funds available soon" notification,
      * then we close it
      */
-    $: if (!$activeProfile?.migratedTransactions?.length && fundsSoonNotificationId) {
+    $: if ($activeProfile && !$activeProfile?.migratedTransactions?.length && fundsSoonNotificationId) {
         removeDisplayNotification(fundsSoonNotificationId)
         fundsSoonNotificationId = null
     }

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -5,7 +5,7 @@
     import { ongoingSnapshot, openSnapshotPopup } from 'shared/lib/migration'
     import { NOTIFICATION_TIMEOUT_NEVER, removeDisplayNotification, showAppNotification } from 'shared/lib/notifications'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
-    import { activeProfile, isSoftwareProfile, updateProfile, isLedgerProfile } from 'shared/lib/profile'
+    import { activeProfile, isLedgerProfile, isSoftwareProfile, updateProfile } from 'shared/lib/profile'
     import { accountRoute, dashboardRoute, routerNext, walletRoute } from 'shared/lib/router'
     import { AccountRoutes, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
     import { api, selectedAccountId, STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS, wallet } from 'shared/lib/wallet'
@@ -158,11 +158,6 @@
                 timeout: NOTIFICATION_TIMEOUT_NEVER,
                 actions: [
                     {
-                        label: locale('actions.viewStatus'),
-                        isPrimary: true,
-                        callback: () => Electron.openUrl('https://chrysalis.iota.org'),
-                    },
-                    {
                         label: locale('actions.dismiss'),
                         callback: () => removeDisplayNotification(fundsSoonNotificationId),
                     },
@@ -172,14 +167,17 @@
     }
     $: if ($activeProfile) {
         const shouldDisplayMigrationPopup =
-        // Only display popup once the user successfully migrates the first account index
-            $isLedgerProfile && $activeProfile.ledgerMigrationCount === 1 && !$activeProfile.hasVisitedDashboard && !$popupState.active
+            // Only display popup once the user successfully migrates the first account index
+            $isLedgerProfile &&
+            $activeProfile.ledgerMigrationCount === 1 &&
+            !$activeProfile.hasVisitedDashboard &&
+            !$popupState.active
         if (shouldDisplayMigrationPopup) {
             updateProfile('hasVisitedDashboard', true)
 
             openPopup({
                 type: 'ledgerMigrateIndex',
-                preventClose: true
+                preventClose: true,
             })
         }
     }


### PR DESCRIPTION
# Description of change

The aim of this PR is to remove everything around checking when Chrysalis was finally upgraded. This made sense when we first released as Chrysalis was going to be bootstrapped one week after the Firefly release, but not anymore.  

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Ubuntu 18.04

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
