### PR TITLE
hotfix: only display transaction index pop up for migrated ledger profiles

### DIFF
--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -160,7 +160,8 @@
     }
     $: if ($activeProfile) {
         const shouldDisplayMigrationPopup =
-            $isLedgerProfile && !$activeProfile.hasVisitedDashboard && !$popupState.active
+        // Only display popup once the user successfully migrates the first account index
+            $isLedgerProfile && $activeProfile.ledgerMigrationCount === 1 && !$activeProfile.hasVisitedDashboard && !$popupState.active
         if (shouldDisplayMigrationPopup) {
             updateProfile('hasVisitedDashboard', true)
 


### PR DESCRIPTION
# Description of change

The index pop up was being shown for all ledger profiles. This PR ensures that it is only displayed (once) for migrated profiles. 

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
