### PR TITLE
feat: add tooltip in case of issues transferring fragmented funds

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -259,7 +259,9 @@
             "body1": "Firefly will now proceed to migrate your funds. This may take a while.",
             "migrate": "Migrate funds",
             "transaction": "Transaction {number}",
-            "rerun": "Try again"
+            "rerun": "Try again",
+            "nothingHappening": "If nothing seems to be happening for a long time...",
+            "reconnectDevice": "Try disconnecting and reconnecting your Ledger."
         },
         "migrateFailed": {
             "title": "To do",


### PR DESCRIPTION
# Description of change

- If a user disconnects their Ledger between validating and signing a transaction on device then migration will spin forever. This is solved by disconnecting and reconnecting the device.
- It may be possible to end up in this state for other reasons and reconnecting seems to fix it.
- There may be a better way to solve this so hold off on merging until discussed.

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on Mac

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
