### PR TITLE
fix: ensure correct address display for mined bundles

### DIFF
--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -19,6 +19,7 @@ import type { NotificationType } from './typings/notification'
 
 
 const LEDGER_STATUS_POLL_INTERVAL_ON_DISCONNECT = 1500
+const LEGACY_ADDRESS_WITH_CHECKSUM_LENGTH = 90
 
 let polling = false
 let intervalTimer
@@ -243,7 +244,7 @@ export function getLegacyErrorMessage(error: any, shouldLocalize: boolean = fals
 }
 
 export function formatAddressForLedger(address: string, removeChecksum: boolean = false): string {
-    if (removeChecksum) {
+    if (address.length === LEGACY_ADDRESS_WITH_CHECKSUM_LENGTH && removeChecksum) {
         address = removeAddressChecksum(address)
     }
     const len = address.length


### PR DESCRIPTION
# Description of change

- Bundle mining strips the checksum from the TRANSFER... address
- 9 further characters were being stripped again to leave an address length of 72 and yielding incorrect addresses and checksums displayed in ledger migration

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on Mac with mined and unmined bundles

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
