### PR TITLE
Fix: dashboard ledger prompt

### DIFF
--- a/packages/shared/components/popups/LedgerNotConnected.svelte
+++ b/packages/shared/components/popups/LedgerNotConnected.svelte
@@ -9,8 +9,16 @@
     export let handleClose
     export let locale
 
+    /**
+     * Used to avoid race condition with the reactive poll on dashboard
+     * as stopPollingLedgerStatus was running twice,
+     * stopping a newly created poll
+     */
+    let pollStopped = false
+
     function handleCancelClick() {
         stopPollingLedgerStatus()
+        pollStopped = true
         if ('function' === typeof handleClose) {
             handleClose()
         }
@@ -18,7 +26,9 @@
     }
 
     onDestroy(() => {
-        stopPollingLedgerStatus()
+        if (!pollStopped) {
+            stopPollingLedgerStatus()
+        }
     })
 </script>
 

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -309,7 +309,7 @@
                 },
             })
         } else {
-            promptUserToConnectLedger(false, () => _generate())
+            promptUserToConnectLedger(false, () => _generate(), undefined, true)
         }
     }
 

--- a/packages/shared/routes/dashboard/wallet/views/Security.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Security.svelte
@@ -2,7 +2,13 @@
     import { SecurityTile, Text } from 'shared/components'
     import { versionDetails } from 'shared/lib/appUpdater'
     import { diffDates, getBackupWarningColor, isRecentDate } from 'shared/lib/helpers'
-    import { getLedgerDeviceStatus, getLedgerOpenedApp, ledgerDeviceState, pollLedgerDeviceStatus } from 'shared/lib/ledger'
+    import {
+        getLedgerDeviceStatus,
+        getLedgerOpenedApp,
+        ledgerDeviceState,
+        pollLedgerDeviceStatus,
+        ledgerPollInterrupted,
+    } from 'shared/lib/ledger'
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, isLedgerProfile, isSoftwareProfile, isStrongholdLocked, profiles } from 'shared/lib/profile'
@@ -70,16 +76,20 @@
 
     onMount(() => {
         setup()
-
-        if ($isLedgerProfile) {
-            pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL)
-        }
     })
 
     onDestroy(() => {
         clearTimeout(ledgerSpinnerTimeout)
         unsubscribe()
     })
+
+    /**
+     * Reactive statement to resume ledger poll if it was interrupted
+     * when the one which interrupted has finished
+     */
+    $: if ($isLedgerProfile && !$ledgerPollInterrupted) {
+        pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL)
+    }
 
     function setup() {
         const ap = get(activeProfile)

--- a/packages/shared/routes/dashboard/wallet/views/Security.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Security.svelte
@@ -2,16 +2,10 @@
     import { SecurityTile, Text } from 'shared/components'
     import { versionDetails } from 'shared/lib/appUpdater'
     import { diffDates, getBackupWarningColor, isRecentDate } from 'shared/lib/helpers'
-    import {
-        getLedgerDeviceStatus,
-        getLedgerOpenedApp,
-        ledgerDeviceState,
-        pollLedgerDeviceStatus,
-        ledgerPollInterrupted,
-    } from 'shared/lib/ledger'
+    import { getLedgerDeviceStatus, getLedgerOpenedApp, ledgerDeviceState } from 'shared/lib/ledger'
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
-    import { activeProfile, isLedgerProfile, isSoftwareProfile, isStrongholdLocked, profiles } from 'shared/lib/profile'
+    import { activeProfile, isSoftwareProfile, isStrongholdLocked, profiles } from 'shared/lib/profile'
     import { LedgerApp, LedgerAppName, LedgerDeviceState } from 'shared/lib/typings/ledger'
     import { api } from 'shared/lib/wallet'
     import { onDestroy, onMount } from 'svelte'
@@ -25,7 +19,6 @@
     let color
     let isCheckingLedger
     let ledgerSpinnerTimeout
-    let LEDGER_STATUS_POLL_INTERVAL = 2000
 
     let hardwareDeviceColor = 'gray'
     $: {
@@ -82,14 +75,6 @@
         clearTimeout(ledgerSpinnerTimeout)
         unsubscribe()
     })
-
-    /**
-     * Reactive statement to resume ledger poll if it was interrupted
-     * when the one which interrupted has finished
-     */
-    $: if ($isLedgerProfile && !$ledgerPollInterrupted) {
-        pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL)
-    }
 
     function setup() {
         const ap = get(activeProfile)

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -379,7 +379,9 @@
          * prompt function (only for non-software profiles).
          */
         if ($isSoftwareProfile) onSuccess()
-        else promptUserToConnectLedger(false, onSuccess)
+        else {
+            promptUserToConnectLedger(false, onSuccess, undefined, true)
+        }
     }
 
     const handleBackClick = () => {


### PR DESCRIPTION
# Description of change

When trying to send funds or generate an address from the dashboard, if ledger was not connected, the ledger status poll was not working because it was colliding with the always running poll that comes from the Security view.

In this PR in introduce a way to interrupt an existing poll and also add a reactive declaration on the dashboard to resume the poll if it was interrupted (wallet poll had to be moved to Dashboard.svelte to ensure a new poll could resume even out of the security view)

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)

## How the change has been tested

Ubuntu 18.04. Ledger Simulator

Enter dashboard with ledger disconnected and send some funds or generate a new address. Connectin popups should work as expected and the dashboard poll should keep working as normal. 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
