### PR TITLE
fix: show account index tooltip immediately when checking for balance

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -194,8 +194,8 @@
             "accountPage": "Account Page",
             "standard": "Standard",
             "expert": "Expert",
-            "takingAWhile": "This seems to be taking a while...",
-            "reinstallLegacy": "If your Ledger is not generating addresses you may need to reinstall the {legacy} app and try again."
+            "notGeneratingAddresses": "Is your Ledger generating addresses?",
+            "reinstallLegacy": "If not, disconnect the device and try again. If the issue persists, you may need to reinstall the {legacy} app."
         },
         "importBackupPassword": {
             "body1": "Please enter your backup password.",


### PR DESCRIPTION
# Description of change

- Shows tooltip to make sure user's device is generating addresses and advises what to do if it isn't

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Tested tooltip appearance and disappearance in conjunction with disconnecting device etc.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
