### PR TITLE
fix: stop prevent close error on account index popup 

### DIFF
--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -37,10 +37,6 @@
     })
 
     onMount(async () => {
-        openPopup({
-            type: 'ledgerMigrateIndex',
-            preventClose: true,
-        })
         if ($isSoftwareProfile) {
             api.setStrongholdPasswordClearInterval({ secs: STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS, nanos: 0 })
         }

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -37,6 +37,10 @@
     })
 
     onMount(async () => {
+        openPopup({
+            type: 'ledgerMigrateIndex',
+            preventClose: true,
+        })
         if ($isSoftwareProfile) {
             api.setStrongholdPasswordClearInterval({ secs: STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS, nanos: 0 })
         }
@@ -126,23 +130,29 @@
     if ($walletRoute === WalletRoutes.Init && !$accountsLoaded && $loggedIn) {
         startInit = Date.now()
         busy = true
-        openPopup({
-            type: 'busy',
-            hideClose: true,
-            fullScreen: true,
-            transition: false,
-        })
+        if (!get(popupState).active) {
+            openPopup({
+                type: 'busy',
+                hideClose: true,
+                fullScreen: true,
+                transition: false,
+            })
+        }
     }
     $: {
         if ($accountsLoaded) {
             const minTimeElapsed = 3000 - (Date.now() - startInit)
-            if (minTimeElapsed < 0) {
+            const cancelBusyState = () => {
                 busy = false
-                closePopup()
+                if (get(popupState).type === 'busy') {
+                    closePopup()
+                }
+            }
+            if (minTimeElapsed < 0) {
+                cancelBusyState()
             } else {
                 setTimeout(() => {
-                    busy = false
-                    closePopup()
+                    cancelBusyState()
                 }, minTimeElapsed)
             }
         }


### PR DESCRIPTION
# Description of change

The busy state timeout was attempting to close the account index popup post-migration and eliciting a prevent close error.

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested by simulating busy and account index popup and closure

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
