### PR TITLE
Fix/dashboard poll

### DIFF
--- a/packages/shared/components/popups/LedgerNotConnected.svelte
+++ b/packages/shared/components/popups/LedgerNotConnected.svelte
@@ -1,35 +1,18 @@
 <script>
     import { Button, Icon, Text } from 'shared/components'
-    import { stopPollingLedgerStatus } from 'shared/lib/ledger'
     import { closePopup } from 'shared/lib/popup'
     import { LedgerAppName } from 'shared/lib/typings/ledger'
-    import { onDestroy } from 'svelte'
 
     export let legacy
     export let handleClose
     export let locale
 
-    /**
-     * Used to avoid race condition with the reactive poll on dashboard
-     * as stopPollingLedgerStatus was running twice,
-     * stopping a newly created poll
-     */
-    let pollStopped = false
-
     function handleCancelClick() {
-        stopPollingLedgerStatus()
-        pollStopped = true
         if ('function' === typeof handleClose) {
             handleClose()
         }
         closePopup()
     }
-
-    onDestroy(() => {
-        if (!pollStopped) {
-            stopPollingLedgerStatus()
-        }
-    })
 </script>
 
 <div class="p-8 flex flex-col w-full items-center justify-center text-center">

--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -120,7 +120,11 @@ export function promptUserToConnectLedger(
         onConnected()
     }
     const _onDisconnected = () => {
-        if (polling && forcePoll) {
+        /**
+         * if there is an ongoing poll and we force to interrupt it, 
+         * we need to make sure we didnt interrupt it already
+         */
+        if (forcePoll && !get(ledgerPollInterrupted)) {
             stopPollingLedgerStatus()
             ledgerPollInterrupted.set(true)
         }

--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -109,11 +109,27 @@ export function promptUserToConnectLedger(
     forcePoll: boolean = false // use forcePoll to initialize a new poll even though there is one running
 ) {
     const _onCancel = () => {
-        stopPollingLedgerStatus()
+        /**
+         * stop poll only on normal circumstances (!forcePoll) 
+         * or if there really was an interruption.
+         * Otherwhise we have the rist of stopping an ongoing poll 
+         * that should be kept alive
+         */
+        if (!forcePoll || forcePoll && get(ledgerPollInterrupted)) {
+            stopPollingLedgerStatus()
+        }
         onCancel()
     }
     const _onConnected = () => {
-        stopPollingLedgerStatus()
+        /**
+         * stop poll only on normal circumstances (!forcePoll) 
+         * or if there really was an interruption.
+         * Otherwhise we have the rist of stopping an ongoing poll 
+         * that should be kept alive
+         */
+        if (!forcePoll || forcePoll && get(ledgerPollInterrupted)) {
+            stopPollingLedgerStatus()
+        }
         if (get(popupState).active) {
             closePopup()
         }

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -2,7 +2,7 @@
     import { Idle, Sidebar } from 'shared/components'
     import { loggedIn, logout } from 'shared/lib/app'
     import { Electron } from 'shared/lib/electron'
-    import { ledgerPollInterrupted, pollLedgerDeviceStatus } from 'shared/lib/ledger'
+    import { ledgerPollInterrupted, pollLedgerDeviceStatus, stopPollingLedgerStatus } from 'shared/lib/ledger'
     import { ongoingSnapshot, openSnapshotPopup } from 'shared/lib/migration'
     import { NOTIFICATION_TIMEOUT_NEVER, removeDisplayNotification, showAppNotification } from 'shared/lib/notifications'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
@@ -86,6 +86,9 @@
     onDestroy(() => {
         if (fundsSoonNotificationId) {
             removeDisplayNotification(fundsSoonNotificationId)
+        }
+        if ($isLedgerProfile) {
+            stopPollingLedgerStatus()
         }
     })
 


### PR DESCRIPTION
# Description of change

This PR aims to fix:

- After sending or generating address from dashboard, the connection status item in the Security panel stops polling automatically: this was because the main poll was being interrupted for the sending or generating address polls and multiple stopPoll calls were being called, leading to the dashboard poll starting and stopping immediately (the extra stop poll was being called from ledger connection popup)
- Stop dashboard poll always when leaving the dashboard route (we werent stopping it for extra index migration)
- Interruption poll (sending/generating address) was being started and stopped all over again because there was a missing condition to check if it was already started

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Ubuntu 18.04. Ledger Nano S and Ledger simulators 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
