### PR TITLE
hotfix: reset migration listeners state when all event listeners are destroyed on the active actor

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -34,7 +34,7 @@ import type {
     AddressInput,
     MigrationBundle,
     MigrationData,
-    SendMigrationBundleResponse
+    SendMigrationBundleResponse,
 } from 'shared/lib/typings/migration'
 import { formatUnitBestMatch } from 'shared/lib/units'
 import { get, writable, Writable } from 'svelte/store'
@@ -47,6 +47,7 @@ import { SetupType } from './typings/routes'
 import type { Duration, StrongholdStatus } from './typings/wallet'
 import { displayNotificationForLedgerProfile } from './ledger'
 import { walletSetupType } from './router'
+import { didInitialiseMigrationListeners } from 'shared/lib/migration';
 
 const ACCOUNT_COLORS = ['turquoise', 'green', 'orange', 'yellow', 'purple', 'pink']
 
@@ -316,6 +317,7 @@ export const initialise = (id: string, storagePath: string): void => {
  * @returns {void}
  */
 export const removeEventListeners = (id: string): void => {
+    didInitialiseMigrationListeners.set(false);
     actors[id].removeEventListeners()
 };
 

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -41,22 +41,22 @@
             api.setStrongholdPasswordClearInterval({ secs: STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS, nanos: 0 })
         }
 
-        api.startBackgroundSync(
-            {
-                secs: 30,
-                nanos: 0,
-            },
-            true,
-            {
-                onSuccess() {},
-                onError(err) {
-                    showAppNotification({
-                        type: 'error',
-                        message: locale('error.account.syncing'),
-                    })
-                },
-            }
-        )
+        // api.startBackgroundSync(
+        //     {
+        //         secs: 30,
+        //         nanos: 0,
+        //     },
+        //     true,
+        //     {
+        //         onSuccess() {},
+        //         onError(err) {
+        //             showAppNotification({
+        //                 type: 'error',
+        //                 message: locale('error.account.syncing'),
+        //             })
+        //         },
+        //     }
+        // )
 
         // TODO: Re-enable deep links
         // Electron.DeepLinkManager.requestDeepLink()

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -41,22 +41,22 @@
             api.setStrongholdPasswordClearInterval({ secs: STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS, nanos: 0 })
         }
 
-        // api.startBackgroundSync(
-        //     {
-        //         secs: 30,
-        //         nanos: 0,
-        //     },
-        //     true,
-        //     {
-        //         onSuccess() {},
-        //         onError(err) {
-        //             showAppNotification({
-        //                 type: 'error',
-        //                 message: locale('error.account.syncing'),
-        //             })
-        //         },
-        //     }
-        // )
+        api.startBackgroundSync(
+            {
+                secs: 30,
+                nanos: 0,
+            },
+            true,
+            {
+                onSuccess() {},
+                onError(err) {
+                    showAppNotification({
+                        type: 'error',
+                        message: locale('error.account.syncing'),
+                    })
+                },
+            }
+        )
 
         // TODO: Re-enable deep links
         // Electron.DeepLinkManager.requestDeepLink()


### PR DESCRIPTION
# Description of change

Fixes the issue where the migration stays spinning forever despite the migration bundle being confirmed. 

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually tested with ledger device

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
