### PR TITLE
fix: simplify ledger status polling

### DIFF
--- a/packages/shared/components/popups/LedgerNotConnected.svelte
+++ b/packages/shared/components/popups/LedgerNotConnected.svelte
@@ -1,7 +1,9 @@
 <script>
     import { Button, Icon, Text } from 'shared/components'
+    import { stopPollingLedgerStatus } from 'shared/lib/ledger'
     import { closePopup } from 'shared/lib/popup'
     import { LedgerAppName } from 'shared/lib/typings/ledger'
+    import { onDestroy } from 'svelte'
 
     export let legacy
     export let handleClose
@@ -13,6 +15,10 @@
         }
         closePopup()
     }
+
+    onDestroy(() => {
+        stopPollingLedgerStatus()
+    })
 </script>
 
 <div class="p-8 flex flex-col w-full items-center justify-center text-center">

--- a/packages/shared/components/popups/LedgerNotConnected.svelte
+++ b/packages/shared/components/popups/LedgerNotConnected.svelte
@@ -3,11 +3,12 @@
     import { stopPollingLedgerStatus } from 'shared/lib/ledger'
     import { closePopup } from 'shared/lib/popup'
     import { LedgerAppName } from 'shared/lib/typings/ledger'
-    import { onDestroy } from 'svelte'
+    import { onDestroy, onMount } from 'svelte'
 
     export let legacy
     export let handleClose
     export let locale
+    export let poll
 
     function handleCancelClick() {
         if ('function' === typeof handleClose) {
@@ -15,6 +16,11 @@
         }
         closePopup()
     }
+
+    onMount(() => {
+        stopPollingLedgerStatus()
+        poll()
+    })
 
     onDestroy(() => {
         stopPollingLedgerStatus()

--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -21,19 +21,11 @@ import type { NotificationType } from './typings/notification'
 const LEDGER_STATUS_POLL_INTERVAL_ON_DISCONNECT = 1500
 const LEGACY_ADDRESS_WITH_CHECKSUM_LENGTH = 90
 
-let polling = false
 let intervalTimer
 
 export const ledgerSimulator = false
 export const ledgerDeviceState = writable<LedgerDeviceState>(LedgerDeviceState.NotDetected)
 export const isLedgerLegacyConnected = writable<boolean>(false)
-
-/**
- * On the dashboard we run a permanent ledger poll to get its status,
- * the intention of this variable is to know when the poll was interrupted
- * so we can resume it again later
- */
-export const ledgerPollInterrupted = writable<boolean>(false)
 
 export function getLedgerDeviceStatus(
     legacy: boolean = false,
@@ -49,6 +41,9 @@ export function getLedgerDeviceStatus(
             const isConnected = (legacy && state === LedgerDeviceState.LegacyConnected)
                 || (!legacy && state === LedgerDeviceState.Connected)
             if (isConnected) {
+                if (get(popupState).active && get(popupState).type === 'ledgerNotConnected') {
+                    closePopup()
+                }
                 onConnected()
             } else {
                 onDisconnected()
@@ -106,44 +101,14 @@ export function promptUserToConnectLedger(
     legacy: boolean = false,
     onConnected: () => void = () => { },
     onCancel: () => void = () => { },
-    forcePoll: boolean = false // use forcePoll to initialize a new poll even though there is one running
 ) {
     const _onCancel = () => {
-        /**
-         * stop poll only on normal circumstances (!forcePoll) 
-         * or if there really was an interruption.
-         * Otherwhise we have the rist of stopping an ongoing poll 
-         * that should be kept alive
-         */
-        if (!forcePoll || forcePoll && get(ledgerPollInterrupted)) {
-            stopPollingLedgerStatus()
-        }
         onCancel()
     }
     const _onConnected = () => {
-        /**
-         * stop poll only on normal circumstances (!forcePoll) 
-         * or if there really was an interruption.
-         * Otherwhise we have the rist of stopping an ongoing poll 
-         * that should be kept alive
-         */
-        if (!forcePoll || forcePoll && get(ledgerPollInterrupted)) {
-            stopPollingLedgerStatus()
-        }
-        if (get(popupState).active) {
-            closePopup()
-        }
         onConnected()
     }
     const _onDisconnected = () => {
-        /**
-         * if there is an ongoing poll and we force to interrupt it, 
-         * we need to make sure we didnt interrupt it already
-         */
-        if (forcePoll && !get(ledgerPollInterrupted)) {
-            stopPollingLedgerStatus()
-            ledgerPollInterrupted.set(true)
-        }
         pollLedgerDeviceStatus(legacy, LEDGER_STATUS_POLL_INTERVAL_ON_DISCONNECT, _onConnected, _onDisconnected, _onCancel)
         if (!get(popupState).active) {
             openLedgerNotConnectedPopup(legacy, onCancel)
@@ -214,6 +179,8 @@ export function isLedgerError(error: any): boolean {
     return errorType?.slice(0, 6) === "Ledger"
 }
 
+export const isPollingLedgerDeviceStatus = writable<boolean>(false)
+
 export function pollLedgerDeviceStatus(
     legacy: boolean = false,
     pollInterval: number = 1000,
@@ -221,13 +188,13 @@ export function pollLedgerDeviceStatus(
     _onDisconnected: () => void = () => { },
     _onCancel: () => void = () => { }
 ) {
-    if (!polling) {
+    if (!get(isPollingLedgerDeviceStatus)) {
         getLedgerDeviceStatus(legacy, _onConnected, _onDisconnected, _onCancel)
         intervalTimer = setInterval(async () => {
             getLedgerDeviceStatus(legacy, _onConnected, _onDisconnected, _onCancel)
         }, pollInterval)
+        isPollingLedgerDeviceStatus.set(true)
     }
-    polling = true
 }
 
 function openLedgerNotConnectedPopup(
@@ -247,11 +214,10 @@ function openLedgerNotConnectedPopup(
 }
 
 export function stopPollingLedgerStatus(): void {
-    if (intervalTimer) {
+    if (get(isPollingLedgerDeviceStatus)) {
         clearInterval(intervalTimer)
         intervalTimer = null
-        polling = false
-        ledgerPollInterrupted.set(false)
+        isPollingLedgerDeviceStatus.set(false)
     }
 }
 

--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -109,10 +109,11 @@ export function promptUserToConnectLedger(
         onConnected()
     }
     const _onDisconnected = () => {
-        pollLedgerDeviceStatus(legacy, LEDGER_STATUS_POLL_INTERVAL_ON_DISCONNECT, _onConnected, _onDisconnected, _onCancel)
         if (!get(popupState).active) {
-            openLedgerNotConnectedPopup(legacy, onCancel)
+            openLedgerNotConnectedPopup(legacy, onCancel, () => pollLedgerDeviceStatus(legacy, LEDGER_STATUS_POLL_INTERVAL_ON_DISCONNECT, _onConnected, _onDisconnected, _onCancel))
         }
+
+        
     }
     getLedgerDeviceStatus(legacy, _onConnected, _onDisconnected, _onCancel)
 }
@@ -199,7 +200,8 @@ export function pollLedgerDeviceStatus(
 
 function openLedgerNotConnectedPopup(
     legacy: boolean = false,
-    cancel: () => void = () => { }
+    cancel: () => void = () => { }, 
+    poll: () => void = () => { }
 ) {
     if (!get(popupState).active) {
         openPopup({
@@ -207,7 +209,8 @@ function openLedgerNotConnectedPopup(
             hideClose: true,
             props: {
                 legacy,
-                handleClose: () => cancel()
+                handleClose: () => cancel(),
+                poll
             },
         })
     }

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -2,7 +2,7 @@
     import { Idle, Sidebar } from 'shared/components'
     import { loggedIn, logout } from 'shared/lib/app'
     import { Electron } from 'shared/lib/electron'
-    import { ledgerPollInterrupted, pollLedgerDeviceStatus, stopPollingLedgerStatus } from 'shared/lib/ledger'
+    import { pollLedgerDeviceStatus, stopPollingLedgerStatus, isPollingLedgerDeviceStatus } from 'shared/lib/ledger'
     import { ongoingSnapshot, openSnapshotPopup } from 'shared/lib/migration'
     import { NOTIFICATION_TIMEOUT_NEVER, removeDisplayNotification, showAppNotification } from 'shared/lib/notifications'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
@@ -218,7 +218,7 @@
      * Reactive statement to resume ledger poll if it was interrupted
      * when the one which interrupted has finished
      */
-    $: if ($activeProfile && $isLedgerProfile && !$ledgerPollInterrupted) {
+    $: if ($activeProfile && $isLedgerProfile && !$isPollingLedgerDeviceStatus) {
         pollLedgerDeviceStatus(false, LEDGER_STATUS_POLL_INTERVAL)
     }
 </script>

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -2,7 +2,7 @@
     import { Idle, Sidebar } from 'shared/components'
     import { loggedIn, logout } from 'shared/lib/app'
     import { Electron } from 'shared/lib/electron'
-    import { pollLedgerDeviceStatus, stopPollingLedgerStatus, isPollingLedgerDeviceStatus } from 'shared/lib/ledger'
+    import { isPollingLedgerDeviceStatus, pollLedgerDeviceStatus, stopPollingLedgerStatus } from 'shared/lib/ledger'
     import { ongoingSnapshot, openSnapshotPopup } from 'shared/lib/migration'
     import { NOTIFICATION_TIMEOUT_NEVER, removeDisplayNotification, showAppNotification } from 'shared/lib/notifications'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
@@ -11,10 +11,10 @@
     import { AccountRoutes, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
     import {
         api,
+        isBackgroundSyncing,
         selectedAccountId,
         STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS,
         wallet,
-        isBackgroundSyncing,
     } from 'shared/lib/wallet'
     import { Settings, Wallet } from 'shared/routes'
     import { onDestroy, onMount } from 'svelte'

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -307,7 +307,7 @@
                 },
             })
         } else {
-            promptUserToConnectLedger(false, () => _generate(), undefined, true)
+            promptUserToConnectLedger(false, () => _generate(), undefined)
         }
     }
 

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -380,7 +380,7 @@
          */
         if ($isSoftwareProfile) onSuccess()
         else {
-            promptUserToConnectLedger(false, onSuccess, undefined, true)
+            promptUserToConnectLedger(false, onSuccess, undefined)
         }
     }
 


### PR DESCRIPTION
# Description of change

This PR simplifies the ledger connection status polling to ensure no more than one poll is ever active, and that the poll is started and stopped at the correct points.

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested with log statements and all scenarios involving ledger device polling.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
