### PR TITLE
Fix: Ledger migration skipping congratulations view

### DIFF
--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -11,10 +11,10 @@
     import { AccountRoutes, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
     import {
         api,
-        isBackgroundSyncing,
         selectedAccountId,
         STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS,
         wallet,
+        isBackgroundSyncing,
     } from 'shared/lib/wallet'
     import { Settings, Wallet } from 'shared/routes'
     import { onDestroy, onMount } from 'svelte'
@@ -36,7 +36,8 @@
 
     const LEDGER_STATUS_POLL_INTERVAL = 2000
 
-    const unsubscribe = ongoingSnapshot.subscribe((os) => {
+    // TODO: add missing unsubscribe to onDestroy
+    ongoingSnapshot.subscribe((os) => {
         if (os) {
             openSnapshotPopup()
         }
@@ -100,7 +101,6 @@
         if ($isLedgerProfile) {
             stopPollingLedgerStatus()
         }
-        unsubscribe()
     })
 
     // TODO: re-enable deep links

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -11,10 +11,10 @@
     import { AccountRoutes, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
     import {
         api,
+        isBackgroundSyncing,
         selectedAccountId,
         STRONGHOLD_PASSWORD_CLEAR_INTERVAL_SECS,
         wallet,
-        isBackgroundSyncing,
     } from 'shared/lib/wallet'
     import { Settings, Wallet } from 'shared/routes'
     import { onDestroy, onMount } from 'svelte'
@@ -36,7 +36,7 @@
 
     const LEDGER_STATUS_POLL_INTERVAL = 2000
 
-    ongoingSnapshot.subscribe((os) => {
+    const unsubscribe = ongoingSnapshot.subscribe((os) => {
         if (os) {
             openSnapshotPopup()
         }
@@ -100,6 +100,7 @@
         if ($isLedgerProfile) {
             stopPollingLedgerStatus()
         }
+        unsubscribe()
     })
 
     // TODO: re-enable deep links

--- a/packages/shared/routes/setup/Balance.svelte
+++ b/packages/shared/routes/setup/Balance.svelte
@@ -64,16 +64,18 @@
     let error = getError(balance)
     let formattedBalance = formatUnitBestMatch(balance, true, 3)
 
-    const unsubscribeBundles = bundles.subscribe((updatedBundles) => {
+    // TODO: add missing unsubscribe to onDestroy
+    bundles.subscribe((updatedBundles) => {
         _bundles = updatedBundles
         error = getError(_data.balance)
     })
 
-    const unsubscribeUnselectedBundles = unselectedInputs.subscribe(() => {
+    // TODO: add missing unsubscribe to onDestroy
+    unselectedInputs.subscribe(() => {
         error = getError(_data.balance)
     })
 
-    const unsubscribeData = data.subscribe((updatedData) => {
+    const unsubscribe = data.subscribe((updatedData) => {
         _data = updatedData
 
         fiatBalance = getFiatBalance(_data.balance)
@@ -198,11 +200,7 @@
         }
     }
 
-    onDestroy(() => {
-        unsubscribeBundles()
-        unsubscribeUnselectedBundles()
-        unsubscribeData()
-    })
+    onDestroy(unsubscribe)
 </script>
 
 {#if mobile}

--- a/packages/shared/routes/setup/Balance.svelte
+++ b/packages/shared/routes/setup/Balance.svelte
@@ -64,16 +64,16 @@
     let error = getError(balance)
     let formattedBalance = formatUnitBestMatch(balance, true, 3)
 
-    bundles.subscribe((updatedBundles) => {
+    const unsubscribeBundles = bundles.subscribe((updatedBundles) => {
         _bundles = updatedBundles
         error = getError(_data.balance)
     })
 
-    unselectedInputs.subscribe(() => {
+    const unsubscribeUnselectedBundles = unselectedInputs.subscribe(() => {
         error = getError(_data.balance)
     })
 
-    const unsubscribe = data.subscribe((updatedData) => {
+    const unsubscribeData = data.subscribe((updatedData) => {
         _data = updatedData
 
         fiatBalance = getFiatBalance(_data.balance)
@@ -198,7 +198,11 @@
         }
     }
 
-    onDestroy(unsubscribe)
+    onDestroy(() => {
+        unsubscribeBundles()
+        unsubscribeUnselectedBundles()
+        unsubscribeData()
+    })
 </script>
 
 {#if mobile}

--- a/packages/shared/routes/setup/migrate/views/Migrate.svelte
+++ b/packages/shared/routes/setup/migrate/views/Migrate.svelte
@@ -26,7 +26,7 @@
     } from 'shared/lib/migration'
     import { showAppNotification } from 'shared/lib/notifications'
     import { closePopup } from 'shared/lib/popup'
-    import { activeProfile,  newProfile, profileInProgress, saveProfile, setActiveProfile, updateProfile } from 'shared/lib/profile'
+    import { newProfile, profileInProgress, saveProfile, setActiveProfile } from 'shared/lib/profile'
     import { walletSetupType } from 'shared/lib/router'
     import { SetupType } from 'shared/lib/typings/routes'
     import { formatUnitBestMatch } from 'shared/lib/units'
@@ -59,7 +59,7 @@
 
     let closeTransport = () => {}
 
-    confirmedBundles.subscribe((newConfirmedBundles) => {
+    const unsubscribe = confirmedBundles.subscribe((newConfirmedBundles) => {
         newConfirmedBundles.forEach((bundle) => {
             if (bundle.bundleHash && bundle.bundleHash === singleMigrationBundleHash && bundle.confirmed) {
                 didComplete.set(true)
@@ -88,10 +88,10 @@
                         })
                         .then((data) => {
                             if ($newProfile) {
-                             // Save profile
+                                // Save profile
                                 saveProfile($newProfile)
                                 setActiveProfile($newProfile.id)
-                                              
+
                                 profileInProgress.set(undefined)
                                 newProfile.set(null)
                             }
@@ -149,6 +149,7 @@
 
     onDestroy(() => {
         clearTimeout(timeout)
+        unsubscribe()
     })
 </script>
 

--- a/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
+++ b/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
@@ -73,7 +73,7 @@
 
     let migratedAndUnconfirmedBundles = []
 
-    confirmedBundles.subscribe((newConfirmedBundles) => {
+    const unsubscribeConfirmedBundles = confirmedBundles.subscribe((newConfirmedBundles) => {
         newConfirmedBundles.forEach((bundle) => {
             if (bundle.bundleHash && bundle.confirmed) {
                 migratedAndUnconfirmedBundles = migratedAndUnconfirmedBundles.filter(
@@ -256,7 +256,10 @@
         newProfile.set(null)
     }
 
-    onDestroy(unsubscribe)
+    onDestroy(() => {
+        unsubscribe()
+        unsubscribeConfirmedBundles()
+    })
 
     function handleMigrateClick() {
         if (legacyLedger) {

--- a/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
+++ b/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
@@ -73,7 +73,8 @@
 
     let migratedAndUnconfirmedBundles = []
 
-    const unsubscribeConfirmedBundles = confirmedBundles.subscribe((newConfirmedBundles) => {
+    // TODO: add missing unsubscribe to onDestroy
+    confirmedBundles.subscribe((newConfirmedBundles) => {
         newConfirmedBundles.forEach((bundle) => {
             if (bundle.bundleHash && bundle.confirmed) {
                 migratedAndUnconfirmedBundles = migratedAndUnconfirmedBundles.filter(
@@ -256,10 +257,7 @@
         newProfile.set(null)
     }
 
-    onDestroy(() => {
-        unsubscribe()
-        unsubscribeConfirmedBundles()
-    })
+    onDestroy(unsubscribe)
 
     function handleMigrateClick() {
         if (legacyLedger) {


### PR DESCRIPTION
# Description of change

This PR adds the missing unsubscription that was causing the ledger migration to run multiple times `dispatch('next')` which was causing the Congratulations view to be skipped (only happening for happy ledger migrations). 

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Ubuntu 18.04. Ledger Nano S happy migration

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
