### PR TITLE
Fix: remove MigrateLedgerIndex from non ledger profiles

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { SettingsMenu, Text } from 'shared/components'
     import { loggedIn } from 'shared/lib/app'
-    import { isSoftwareProfile } from 'shared/lib/profile'
+    import { isLedgerProfile, isSoftwareProfile } from 'shared/lib/profile'
     import { settingsChildRoute, settingsRoute } from 'shared/lib/router'
     import { SettingsIcons } from 'shared/lib/typings/icons'
     import {
@@ -18,11 +18,15 @@
     export let mobile
 
     const securitySettings = Object.assign({}, SecuritySettings)
+    const advancedSettings = Object.assign({}, AdvancedSettings)
 
     // TODO: ledger, The operand of a 'delete' operator cannot be a read-only property
     $: if (!$isSoftwareProfile) {
         delete securitySettings.ExportStronghold
         delete securitySettings.ChangePassword
+    }
+    $: if (!$isLedgerProfile) {
+        delete advancedSettings.MigrateLedgerIndex
     }
 </script>
 
@@ -62,8 +66,8 @@
                 icon="tools"
                 iconColor="bg-green-600"
                 icons={SettingsIcons}
-                settings={AdvancedSettings}
-                activeSettings={$loggedIn ? AdvancedSettings : AdvancedSettingsNoProfile}
+                settings={advancedSettings}
+                activeSettings={$loggedIn ? advancedSettings : AdvancedSettingsNoProfile}
                 title={locale('views.settings.advancedSettings.title')}
                 description={locale('views.settings.advancedSettings.description')}
                 onClick={(setting) => {

--- a/packages/shared/routes/dashboard/settings/views/SettingsViewer.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsViewer.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { Icon, Scroller, SettingsNavigator, Text } from 'shared/components'
     import { loggedIn } from 'shared/lib/app'
-    import { isSoftwareProfile } from 'shared/lib/profile'
+    import { isLedgerProfile, isSoftwareProfile } from 'shared/lib/profile'
     import { settingsChildRoute, settingsRoute } from 'shared/lib/router'
     import { SettingsIcons } from 'shared/lib/typings/icons'
     import {
@@ -30,18 +30,22 @@
     let settings
 
     const securitySettings = Object.assign({}, SecuritySettings)
+    const advancedSettings = Object.assign({}, AdvancedSettings)
 
     // TODO: ledger, The operand of a 'delete' operator cannot be a read-only property
     $: if (!$isSoftwareProfile) {
         delete securitySettings.ExportStronghold
         delete securitySettings.ChangePassword
     }
+    $: if (!$isLedgerProfile) {
+        delete advancedSettings.MigrateLedgerIndex
+    }
 
     if ($loggedIn) {
         settings = {
             generalSettings: GeneralSettings,
             security: securitySettings,
-            advancedSettings: AdvancedSettings,
+            advancedSettings: advancedSettings,
             helpAndInfo: HelpAndInfo,
         }
     } else {


### PR DESCRIPTION
# Description of change

Remove Migrate Ledger Index setting from non ledger profiles: 

![image](https://user-images.githubusercontent.com/3624944/127888194-2604378f-5234-4fed-a42d-5530598a83e6.png)

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Login into a ledger profile and a software profile

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
