### PR TITLE
Fix: force close popups on logout

### DIFF
--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -81,7 +81,7 @@ export const logout = () => {
                 stopPollingLedgerStatus()
             }
             clearSendParams()
-            closePopup()
+            closePopup(true)
             clearActiveProfile()
             resetWallet()
             resetRouter()


### PR DESCRIPTION
# Description of change

This PRs adds the force flag to logout close popups to prevent scenarios like the following 
![image](https://user-images.githubusercontent.com/3624944/127897783-9240cab2-227f-45c9-b735-27d1431bc016.png)

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)

## How the change has been tested

Ubuntu 18.04. Logout with a freshly migrated profile which shows the index popup. Do not close it and wait for the Idle component to reach inactivity timeout and logout. The popup should be closed (like all)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
