### PR TITLE
fix: New profile transaction history 

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -79,6 +79,15 @@
     }
 
     function shouldShowFirstSync() {
+        /**
+         * NOTE: The following conditions must be satisfied
+         * for the "syncing history, ..." message to show:
+         *
+         *      1. It must be the first sync of the user's session
+         *      2. The wallet setup type must exist (a null value indicates an existing profile)
+         *      3. The wallet setup type cannot be new (if it's new then there's no tx history to sync)
+         *      4. Account must have no transactions (the length of $transactions must be zero)
+         */
         return $isFirstSessionSync &&
             $walletSetupType &&
             $walletSetupType !== SetupType.New &&

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -79,7 +79,10 @@
     }
 
     function shouldShowFirstSync() {
-        return $isFirstSessionSync && $walletSetupType && $walletSetupType !== SetupType.New
+        return $isFirstSessionSync &&
+            $walletSetupType &&
+            $walletSetupType !== SetupType.New &&
+            $transactions.length === 0
     }
 </script>
 


### PR DESCRIPTION
# Description of change

This PR fixes a bug where once transactions have been synced on restored profiles, the initial sync message pops up every subsequent time the user manually syncs the wallet history.

## Links to any relevant issues

None

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on (w/ Ledger Nano S):

- Ubuntu (20.04)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas