### PR TITLE
fix: multi-mined ledger bundles

### DIFF
--- a/packages/shared/lib/migration.ts
+++ b/packages/shared/lib/migration.ts
@@ -759,7 +759,7 @@ export const updateLedgerBundleState = (bundleIndex: number, trytes: string[], d
                     const isNewCrackabilityScoreLowerThanPrevious = bundle.bundleHash && bundle.crackability && migrationBundleCrackability < bundle.crackability
 
                     return Object.assign({}, bundle, {
-                        trytes,
+                        trytes: isNewCrackabilityScoreLowerThanPrevious ? trytes : bundle.trytes,
                         miningRuns: didMine ? bundle.miningRuns + 1 : bundle.miningRuns,
                         bundleHash: isNewCrackabilityScoreLowerThanPrevious ? newBundleHash : bundle.bundleHash,
                         crackability: isNewCrackabilityScoreLowerThanPrevious ? migrationBundleCrackability : bundle.crackability


### PR DESCRIPTION
# Description of change

- If a spent Ledger bundle was mined more than once and the old mined bundle was more secure than the new one, the old one was selected for send
- This caused an `cannot read inputs of undefined` error in the `prepareMigrationLog` function due to the state mismatch

## Links to any relevant issues

Fixes issue #1309

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested with multiple mined bundles

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
