### PR TITLE
hotfix: correctly set busy state during migration

### DIFF
--- a/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
+++ b/packages/shared/routes/setup/migrate/views/TransferFragmentedFunds.svelte
@@ -190,6 +190,8 @@
                         }
 
                         if (transaction.bundleHash) {
+                            setMigratingTransaction(transaction, 1)
+
                             return sendMigrationBundle(transaction.bundleHash).then(() => {
                                 migratedAndUnconfirmedBundles = [...migratedAndUnconfirmedBundles, transaction.bundleHash]
                             })
@@ -342,6 +344,7 @@
                         }
 
                         if (transaction.bundleHash) {
+                            setMigratingTransaction(transaction, 1)
                             return sendMigrationBundle(transaction.bundleHash).then(() => {
                                 if (!hasBroadcastAnyBundle) {
                                     hasBroadcastAnyBundle = true


### PR DESCRIPTION
# Description of change

If you disconnect from internet while migration multiple bundles (software account), the busy state isn't properly set. This PR fixes the issue. 

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
