### PR TITLE
feat: Send fiat amounts

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -3,64 +3,139 @@
     import { Input, Text } from 'shared/components'
     import {
         AvailableExchangeRates,
+        convertFromFiat,
         convertToFiat,
         currencies,
         CurrencyTypes,
         exchangeRates,
         formatCurrency,
+        isFiatCurrency,
         parseCurrency,
         replaceCurrencyDecimal,
     } from 'shared/lib/currency'
     import { activeProfile } from 'shared/lib/profile'
-    import { changeUnits, formatUnitPrecision, UNIT_MAP } from 'shared/lib/units'
+    import { changeUnits, formatUnitBestMatch, formatUnitPrecision, UNIT_MAP } from 'shared/lib/units'
+
+    type AmountUnit = Unit | string
+
+    export let locale = undefined
 
     export let amount = undefined
-    export let unit = Unit.Mi
+    export let unit: AmountUnit = Unit.Mi
     export let label = undefined
     export let placeholder = undefined
-    export let locale = undefined
+
     export let classes = ''
-    export let maxClick = () => {}
-    export let error = ''
     export let disabled = false
     export let autofocus = false
+    export let error = ''
+    export let maxClick = () => {}
 
-    const Units = Object.values(Unit).filter((x) => x !== 'Pi')
-    const MAX_VALUE = 2779530283000000
+    let profileCurrency: AvailableExchangeRates = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
 
-    let dropdown = false
+    const Units: AmountUnit[]
+        = [profileCurrency as string].concat(Object.values(Unit).filter(x => x !== 'Pi').map(x => x as string))
+
+    const MAX_VALUE = 2_779_530_283_000_000
+
+    let showDropdown = false
     let navContainer
     let unitsButton
     let focusedItem
 
-    let profileCurrency: AvailableExchangeRates = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
-    $: fiatAmount = amountToFiat(amount)
+    const amountToFiat = (_amount) => {
+        if (!amount) return null
+
+        if(isFiatCurrency(unit)) return _amount
+
+        const amountAsFloat = parseCurrency(_amount)
+        if (amountAsFloat === 0 || Number.isNaN(amountAsFloat)) {
+            return null
+        } else {
+            const rawAmount = changeUnits(amountAsFloat, unit as Unit, Unit.i)
+            const fiatAmount = convertToFiat(rawAmount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+
+            return fiatAmount === 0 ? replaceCurrencyDecimal(`< 0.01`) : formatCurrency(fiatAmount)
+        }
+    }
+
+    const amountFromFiat = (_amount) => {
+        if(!amount) return null
+
+        if(!isFiatCurrency(unit)) return _amount
+
+        const amountAsFloat = parseCurrency(_amount, unit)
+        if (amountAsFloat === 0 || Number.isNaN(amountAsFloat)) {
+            return null
+        } else {
+            const rawAmount = convertFromFiat(amountAsFloat, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+
+            return formatUnitBestMatch(rawAmount)
+        }
+    }
+
+    const getFormattedLabel = (_amount) => {
+        return isFiatCurrency(unit) ? amountFromFiat(_amount) : amountToFiat(_amount)
+    }
+
+    $: amountForLabel = getFormattedLabel(amount)
     $: {
         if (amount.length > 0) {
-            const rawVal = changeUnits(parseCurrency(amount), unit, Unit.i)
-            if (rawVal > MAX_VALUE) {
-                amount = formatUnitPrecision(MAX_VALUE, unit, false)
+            // const rawVal = changeUnits(parseCurrency(amount), unit, Unit.i)
+            // if (rawVal > MAX_VALUE) {
+            //     amount = formatUnitPrecision(MAX_VALUE, unit, false)
+            // }
+            if(!isFiatCurrency(unit)) {
+                const amountAsFloat = parseCurrency(amount)
+                const rawAmount = changeUnits(
+                    Number.isNaN(amountAsFloat) ? 0 : amountAsFloat,
+                    unit as Unit,
+                    Unit.i
+                )
+                if(rawAmount > MAX_VALUE) {
+                    amount = formatUnitPrecision(MAX_VALUE, unit as Unit, false)
+                }
+            } else {
+                const rawAmount = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+                if(rawAmount > MAX_VALUE) {
+                    amount = convertToFiat(MAX_VALUE, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+                }
             }
         }
     }
 
-    const clickOutside = () => {
-        dropdown = false
+    const onOutsideClick = () => {
+        showDropdown = false
     }
-    const onSelect = (index) => {
-        if (amount.length > 0) {
-            amount = formatUnitPrecision(changeUnits(parseCurrency(amount), unit, Unit.i), index, false)
+
+    const onUnitSelect = (toUnit: AmountUnit) => {
+        updateAmount(unit, toUnit)
+
+        unit = toUnit
+    }
+
+    const updateAmount = (fromUnit: AmountUnit, toUnit: AmountUnit) => {
+        if(amount.length <= 0 || fromUnit === toUnit) return
+
+        if(isFiatCurrency(toUnit)) { // IOTA -> FIAT
+            amount = amountToFiat(amount).slice(2)
+        } else {
+            let rawAmount
+            if(isFiatCurrency(fromUnit)) // FIAT -> IOTA
+                rawAmount = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
+            else // IOTA -> IOTA
+                rawAmount = changeUnits(parseCurrency(amount), fromUnit as Unit, Unit.i)
+
+            amount = formatUnitPrecision(rawAmount, toUnit as Unit, false)
         }
-        unit = index
     }
 
-    const focusItem = (itemId) => {
-        let elem = document.getElementById(itemId)
-        focusedItem = elem
+    const onFocus = (itemId) => {
+        focusedItem = document.getElementById(itemId)
     }
 
-    const handleKey = (e) => {
-        if (dropdown) {
+    const onKey = (e) => {
+        if (showDropdown) {
             if (e.key === 'Escape') {
                 toggleDropDown()
                 e.preventDefault()
@@ -82,13 +157,18 @@
                         e.preventDefault()
                     }
                 }
+            } else if (e.key === 'Enter') {
+                if(focusedItem) {
+                    const idx = [...navContainer.children].indexOf(focusedItem)
+                    onUnitSelect(Units[idx])
+                }
             }
         }
     }
 
     const toggleDropDown = () => {
-        dropdown = !dropdown
-        if (dropdown) {
+        showDropdown = !showDropdown
+        if (showDropdown) {
             let elem = document.getElementById(unit)
             if (!elem) {
                 elem = navContainer.firstChild
@@ -102,23 +182,15 @@
         }
     }
 
-    const amountToFiat = (_amount) => {
-        if (!amount) return null
-        const amountAsFloat = parseCurrency(_amount)
-        if (amountAsFloat === 0 || Number.isNaN(amountAsFloat)) {
-            return null
-        } else {
-            const amountAsI = changeUnits(amountAsFloat, unit, Unit.i)
-            const amountasFiat = convertToFiat(amountAsI, $currencies[CurrencyTypes.USD], $exchangeRates[profileCurrency])
-            return amountasFiat === 0 ? replaceCurrencyDecimal(`< 0.01`) : formatCurrency(amountasFiat)
-        }
+    const getMaxDecimals = (_unit: AmountUnit) => {
+        return isFiatCurrency(_unit) ? 2 : UNIT_MAP[_unit].dp
     }
 </script>
 
 <style type="text/scss">
     amount-input {
         nav {
-            &.dropdown {
+            &.showDropdown {
                 @apply opacity-100;
                 @apply pointer-events-auto;
             }
@@ -133,21 +205,21 @@
     }
 </style>
 
-<svelte:window on:click={clickOutside} />
-<amount-input class:disabled class="relative block {classes}" on:keydown={handleKey}>
+<svelte:window on:click={onOutsideClick} />
+<amount-input class:disabled class="relative block {classes}" on:keydown={onKey}>
     <Input
         {error}
-        label={fiatAmount ?? (label || locale('general.amount'))}
+        label={amountForLabel ?? (label || locale('general.amount'))}
         placeholder={placeholder || locale('general.amount')}
         bind:value={amount}
         maxlength={17}
         {disabled}
         {autofocus}
-        maxDecimals={UNIT_MAP[unit].dp}
+        maxDecimals={getMaxDecimals(unit)}
         integer={unit === Unit.i}
         float={unit !== Unit.i}
-        style={dropdown ? 'border-bottom-right-radius: 0' : ''}
-        isFocused={dropdown} />
+        style={showDropdown ? 'border-bottom-right-radius: 0' : ''}
+        isFocused={showDropdown} />
     <actions class="absolute right-0 top-2.5 h-8 flex flex-row items-center text-12 text-gray-500 dark:text-white">
         <button
             on:click={maxClick}
@@ -165,7 +237,7 @@
             {unit}
             <nav
                 class="absolute w-10 overflow-y-auto pointer-events-none opacity-0 z-10 text-left top-10 right-0 rounded-b-lg bg-white dark:bg-gray-800 border border-solid border-blue-500"
-                class:dropdown
+                class:showDropdown
                 bind:this={navContainer}>
                 {#each Units as _unit}
                     <button
@@ -173,10 +245,10 @@
                         class="text-center w-full py-2 {unit === _unit && 'bg-gray-100 dark:bg-gray-700 dark:bg-opacity-20'} 
                         hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20
                         focus:bg-gray-200 dark:focus:bg-gray-800 dark:focus:bg-opacity-20"
-                        on:click={() => onSelect(_unit)}
-                        on:focus={() => focusItem(_unit)}
+                        on:click={() => onUnitSelect(_unit)}
+                        on:focus={() => onFocus(_unit)}
                         class:active={unit === _unit}
-                        tabindex={dropdown ? 0 : -1}>
+                        tabindex={showDropdown ? 0 : -1}>
                         <Text type="p" smaller>{_unit}</Text>
                     </button>
                 {/each}

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -85,7 +85,7 @@
                 if (Number.isNaN(val)) {
                     e.preventDefault()
                 } else if (maxDecimals !== undefined) {
-                    value = formatNumber(val, maxDecimals, undefined, 0)
+                    value = formatNumber(val, undefined, maxDecimals, 0)
                     e.preventDefault()
                 }
             } else if (integer) {

--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -8,11 +8,11 @@
         CurrencyTypes,
         exchangeRates,
         formatCurrency,
+        isFiatCurrency,
     } from 'shared/lib/currency'
     import { closePopup } from 'shared/lib/popup'
     import { activeProfile } from 'shared/lib/profile'
-    import { formatUnitPrecision } from 'shared/lib/units'
-    import { get } from 'svelte/store'
+    import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
 
     export let locale
     export let internal = false
@@ -21,11 +21,19 @@
     export let unit = Unit.i
     export let onConfirm = () => {}
 
-    let displayedAmount = `${formatUnitPrecision(amount, unit)} (${localConvertToFiat(amount)})`
+    let displayAmount = getFormattedAmount()
 
-    function localConvertToFiat(amount) {
-        const activeCurrency = get(activeProfile)?.settings.currency ?? AvailableExchangeRates.USD
-        return formatCurrency(convertToFiat(amount, get(currencies)[CurrencyTypes.USD], get(exchangeRates)[activeCurrency]))
+    function getFormattedAmount() {
+        const isFiat = isFiatCurrency(unit)
+        const currency = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
+
+        let iotaDisplayAmount = isFiat ? formatUnitBestMatch(amount) : formatUnitPrecision(amount, unit)
+        let fiatDisplayAmount = formatCurrency(
+            convertToFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[currency]),
+            currency
+        )
+
+        return isFiat ? `${fiatDisplayAmount} (${iotaDisplayAmount})` : `${iotaDisplayAmount} (${fiatDisplayAmount})`
     }
 
     function handleCancelClick() {
@@ -51,7 +59,7 @@
     </div>
     <div class="w-full text-center my-9 px-10">
         <Text type="h4" highlighted classes="mb-3">
-            {locale('popups.transaction.body', { values: { amount: displayedAmount } })}
+            {locale('popups.transaction.body', { values: { amount: displayAmount } })}
         </Text>
         <Text type={internal ? 'p' : 'pre'} secondary bigger>{to}</Text>
     </div>

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -136,7 +136,7 @@ export const exchangeRates = writable<ExchangeRates>(DEFAULT_EXCHANGE_RATES)
 export const currencies = writable<Currencies>({} as Currencies)
 
 /**
- * Converts iotas to fiat equivalent
+ * Converts an amount in IOTAs to its fiat equivalent
  *
  * @method convertToFiat
  *
@@ -147,7 +147,35 @@ export const currencies = writable<Currencies>({} as Currencies)
  * @returns {number}
  */
 export const convertToFiat = (amount: number, usdPrice: number, conversionRate: number): number => {
-    return +(((amount * usdPrice) / 1000000) * conversionRate).toFixed(2)
+    return +(((amount * usdPrice) / 1_000_000) * conversionRate).toFixed(2)
+}
+
+/**
+ * Converts a fiat amount to its equivalent in IOTAs
+ *
+ * @method convertFromFiat
+ *
+ * @param {number} amount
+ * @param {number} usdPrice
+ * @param {number} conversionRate
+ *
+ * @returns {number}
+ */
+export const convertFromFiat = (amount: number, usdPrice: number, conversionRate: number): number => {
+    return +(((amount / conversionRate) / usdPrice) * 1_000_000).toFixed(0)
+}
+
+/**
+ * Determines if a currency is fiat or not via its ISO 4217 code
+ *
+ * @method isFiatCurrency
+ *
+ * @param {string} currency
+ *
+ * @returns {boolean}
+ */
+export const isFiatCurrency = (currency: string): boolean => {
+    return Object.values(AvailableExchangeRates).map(x => x as string).includes(currency)
 }
 
 /**


### PR DESCRIPTION
# Description of change

This PR adds functionality for a user to select between IOTA denominations (i, Ki, Mi, Gi, and Ti) and his or her selected fiat currency when sending a transaction (internally or externally).

_NOTE: This PR will remain drafted until after the first release for Ledger integration._

## Links to any relevant issues

- #763
- #1168 

## Type of change

- New (a change which implements a new feature)
- Update (a change which updates existing functionality)

## How the change has been tested

Tested on (w/ Ledger Nano S):

- Ubuntu (20.04)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas