### PR TITLE
hotfix: ensure error notification is displayed on account creation

### DIFF
--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -153,9 +153,9 @@ export function displayNotificationForLedgerProfile(
     if (checkDeviceStatus) {
         getLedgerDeviceStatus(
             false,
-            () => { },
-            () => _notify(),
-            () => _notify()
+            _notify,
+            _notify,
+            _notify
         )
     } else {
         _notify()


### PR DESCRIPTION
# Description of change

For ledger accounts, if you try to add a new account (provided that the previous account has no history), it fails silently. This PR fixes the issue by making sure that error notification is displayed. 

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
