### PR TITLE
chore(desktop): Allow notarization to be skipped with env var

### DIFF
--- a/packages/desktop/scripts/notarize.macos.js
+++ b/packages/desktop/scripts/notarize.macos.js
@@ -2,7 +2,7 @@ const { notarize } = require('electron-notarize')
 const path = require('path')
 
 exports.default = async () => {
-    if (process.platform !== 'darwin') {
+    if (process.platform !== 'darwin' || process.env.MACOS_SKIP_NOTARIZATION) {
         return true
     }
 


### PR DESCRIPTION
# Description of change

Notarization can now be skipped on macOS by setting an environment variable (`MACOS_SKIP_NOTARIZATION=true`)

## Links to any relevant issues

N/A

## Type of change

- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

