### PR TITLE
fix(desktop): Handle missing profile storage path on first start

### DIFF
--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -67,6 +67,10 @@ try {
                         // Get a list of all the profile folders in storage
                         return fs.readdirSync(profileStoragePath)
                     } catch (err) {
+                        if (err.code === 'ENOENT') {
+                            // The __storage__ directory doesn't exist
+                            return []
+                        }
                         console.log(err)
                     }
                 }


### PR DESCRIPTION
# Description of change

When listing the profiles, we call `readdirSync` on the `__storage__` directory. On the first startup, this directory does not exist, so an error is thrown:

![image](https://user-images.githubusercontent.com/19519564/129975389-20b17bd3-fdb0-410d-95d5-7f986fa8b688.png)

For our purposes of listing the profiles, we can simply return an empty array.

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
