### PR TITLE
fix: Ledger mnemonic error

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -83,15 +83,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arc-swap"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
+checksum = "34a23efe54373080cf871532e2d01076be41c4c896d32ef63af1b2dded924b03"
 
 [[package]]
 name = "arrayref"
@@ -130,7 +130,7 @@ checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -252,20 +252,20 @@ dependencies = [
  "chrono",
  "fern",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
 [[package]]
 name = "bee-common"
 version = "0.4.1"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "autocfg",
  "chrono",
  "fern",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -276,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f96e90b3678de0ef73b7260538706ee195a13480cf601a0bf1542fa27e3abb"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "bee-crypto"
 version = "0.2.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "byteorder",
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 name = "bee-ledger"
 version = "0.4.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -339,14 +339,14 @@ dependencies = [
  "digest 0.9.0",
  "hex",
  "iota-crypto 0.4.2",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
 [[package]]
 name = "bee-message"
 version = "0.1.5"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bech32 0.8.1",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -355,8 +355,8 @@ dependencies = [
  "bytemuck",
  "digest 0.9.0",
  "hex",
- "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.127",
+ "iota-crypto 0.7.0",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "bee-network"
 version = "0.2.1"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "async-trait",
  "bee-runtime",
@@ -383,7 +383,7 @@ dependencies = [
  "log",
  "once_cell",
  "rand 0.8.4",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -404,11 +404,11 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-crypto 0.2.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iota-crypto 0.7.0",
  "thiserror",
 ]
 
@@ -443,7 +443,7 @@ dependencies = [
  "bee-protocol 0.1.0-alpha",
  "hex",
  "multiaddr 0.12.0",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
 ]
@@ -458,7 +458,7 @@ dependencies = [
  "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-protocol 0.1.0",
  "hex",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
 ]
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bee-runtime"
 version = "0.1.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "async-trait",
  "bee-storage",
@@ -478,10 +478,10 @@ dependencies = [
 [[package]]
 name = "bee-storage"
 version = "0.9.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -493,17 +493,17 @@ checksum = "6ec0259535d34f1bfd0c41bf5a6f0e3e33268dc9433e2ac3707e66715b51ce05"
 dependencies = [
  "autocfg",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
 name = "bee-ternary"
 version = "0.4.2-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "autocfg",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ source = "git+https://github.com/Alex6323/bee-p.git?rev=cf47287dbb37861668d378ea
 dependencies = [
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "iota-crypto 0.5.1",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -523,7 +523,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -614,7 +614,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
  "time",
  "winapi",
 ]
@@ -803,7 +803,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -859,7 +859,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -1049,7 +1049,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -1167,7 +1167,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "zeroize",
 ]
@@ -1209,7 +1209,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1229,7 +1229,7 @@ checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1256,7 +1256,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "synstructure",
 ]
 
@@ -1357,7 +1357,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1451,7 +1451,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1478,9 +1478,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1631,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -1761,7 +1761,7 @@ dependencies = [
  "criterion",
  "futures",
  "iota-crypto 0.5.1",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1786,7 +1786,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rumqttc",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1815,7 +1815,7 @@ dependencies = [
  "iota-model",
  "num_cpus",
  "once_cell",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "slip10",
  "tokio",
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "1.0.1"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#5d261b1202765f4e2e8d5bd8f9a649527f0d5f3f"
+source = "git+https://github.com/iotaledger/iota.rs?branch=dev#34bfa88d4cc286b73c4c51ed5b3cd4219154ba40"
 dependencies = [
  "async-trait",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -1834,12 +1834,12 @@ dependencies = [
  "bee-rest-api 0.1.0-alpha",
  "futures",
  "hex",
- "iota-crypto 0.6.0 (git+https://github.com/iotaledger/crypto.rs?rev=e42be4d)",
+ "iota-crypto 0.6.0",
  "log",
  "num_cpus",
  "regex",
  "reqwest",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1934,24 +1934,13 @@ dependencies = [
  "lazy_static",
  "pbkdf2",
  "rand 0.8.4",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "sha3",
  "tiny-keccak",
  "unicode-normalization",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "iota-crypto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a563712b1857f24cd194eb799ddee2c9f5fdb9f8cadc8cae333da5c7d2a9213"
-dependencies = [
- "blake2",
- "digest 0.9.0",
- "ed25519-zebra",
 ]
 
 [[package]]
@@ -1965,9 +1954,20 @@ dependencies = [
  "getrandom 0.2.3",
  "hmac 0.11.0",
  "pbkdf2",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "unicode-normalization",
+]
+
+[[package]]
+name = "iota-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c13594128939830ac9d9b8b44f9d073349cc6e10c30eb76c18ec89f0602ebe6"
+dependencies = [
+ "blake2",
+ "digest 0.9.0",
+ "ed25519-zebra",
 ]
 
 [[package]]
@@ -1984,7 +1984,7 @@ dependencies = [
  "ledger-transport-hid",
  "ledger-transport-tcp",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
  "trait-async",
 ]
@@ -1998,14 +1998,14 @@ dependencies = [
  "iota-constants 0.2.1 (git+https://github.com/iotaledger/iota.rs?rev=0aa7e11b075bea17ae52b1f7dff51f3a13c9d914)",
  "iota-conversion 0.3.0",
  "iota-crypto 0.3.0",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
 ]
 
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?branch=firefly-testing#ef2a2fe254c409533242916177ac21e94d262b9d"
+source = "git+https://github.com/iotaledger/wallet.rs?branch=fix/ledger-error-variant#d0069939ad13847622f87aa2720b457cadc51b9c"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2025,7 +2025,7 @@ dependencies = [
  "rand 0.8.4",
  "riker",
  "rocksdb",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "serde_repr",
  "slog",
@@ -2046,7 +2046,7 @@ dependencies = [
  "futures",
  "iota-crypto 0.5.1",
  "riker",
- "serde 1.0.127",
+ "serde 1.0.129",
  "stronghold-utils",
  "stronghold_engine",
  "thiserror",
@@ -2092,24 +2092,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2149,7 +2149,7 @@ dependencies = [
  "ledger-apdu",
  "ledger-transport-hid",
  "ledger-transport-tcp",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
  "trait-async",
  "wasm-bindgen",
@@ -2181,7 +2181,7 @@ dependencies = [
  "hex",
  "ledger-apdu",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libloading"
@@ -2436,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -2446,7 +2446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -2520,7 +2520,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "typenum",
 ]
@@ -2598,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -2618,9 +2618,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -2630,9 +2630,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -2711,7 +2711,7 @@ dependencies = [
  "data-encoding",
  "multihash 0.13.2",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
  "static_assertions",
  "unsigned-varint 0.7.0",
  "url",
@@ -2729,7 +2729,7 @@ dependencies = [
  "data-encoding",
  "multihash 0.14.0",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
  "static_assertions",
  "unsigned-varint 0.7.0",
  "url",
@@ -2771,7 +2771,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "synstructure",
 ]
 
@@ -2874,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
 dependencies = [
  "memchr",
 ]
@@ -2917,7 +2917,7 @@ dependencies = [
  "data-encoding",
  "multihash 0.13.2",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
  "static_assertions",
  "unsigned-varint 0.7.0",
  "url",
@@ -3030,7 +3030,7 @@ checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3041,7 +3041,7 @@ checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3144,7 +3144,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "version_check",
 ]
 
@@ -3255,7 +3255,7 @@ dependencies = [
  "itertools 0.9.0",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3268,7 +3268,7 @@ dependencies = [
  "itertools 0.10.1",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3423,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -3495,7 +3495,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3717,9 +3717,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -3739,23 +3739,23 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3766,7 +3766,7 @@ checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -3777,7 +3777,7 @@ checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3798,7 +3798,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -3874,9 +3874,9 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "slip10"
@@ -3982,7 +3982,7 @@ checksum = "1eec7338a29758185dc796de8847e078b9bc2f5880c02f7a7b34b13f04d31a23"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3992,7 +3992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c63b02bd4c6909552fa6fb76e3384411d49ee1aa148393c44edfc82f8d14d041"
 dependencies = [
  "libsodium-sys",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4019,7 +4019,7 @@ dependencies = [
  "iota-crypto 0.5.1",
  "once_cell",
  "paste",
- "serde 1.0.127",
+ "serde 1.0.129",
  "stronghold-runtime",
  "thiserror",
 ]
@@ -4049,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -4066,7 +4066,7 @@ checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "unicode-xid 0.2.2",
 ]
 
@@ -4110,7 +4110,7 @@ checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4138,7 +4138,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
 ]
 
@@ -4159,9 +4159,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -4185,7 +4185,7 @@ checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4230,7 +4230,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4252,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -4267,7 +4267,7 @@ checksum = "dfe8c654712ee594c93b7222d98b4e61c7e003aec49e73877edac607a213699d"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4354,12 +4354,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -4428,16 +4425,16 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+checksum = "3131cd6cb18488da91da1d10ed31e966f453c06b65bf010d35638456976a3fd7"
 dependencies = [
  "base64 0.13.0",
  "chunked_transfer",
  "log",
  "once_cell",
  "rustls",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "url",
  "webpki",
@@ -4454,7 +4451,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4505,7 +4502,7 @@ dependencies = [
  "log",
  "once_cell",
  "riker",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "tokio",
 ]
@@ -4534,36 +4531,36 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4573,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -4583,22 +4580,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "wasm-timer"
@@ -4617,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4789,6 +4786,6 @@ checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "synstructure",
 ]

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["/bindings", "/api-wrapper"]
 [dependencies]
 tokio = { version = "1.3", features = ["full"] }
 once_cell = "1.5.0"
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", branch = "firefly-testing", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator"] }
+iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", branch = "dev", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator"] }
 serde_json = "1.0"
 riker = "0.4"
 serde = "1.0"

--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -83,15 +83,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arc-swap"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
+checksum = "34a23efe54373080cf871532e2d01076be41c4c896d32ef63af1b2dded924b03"
 
 [[package]]
 name = "arrayref"
@@ -130,7 +130,7 @@ checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -252,20 +252,20 @@ dependencies = [
  "chrono",
  "fern",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
 [[package]]
 name = "bee-common"
 version = "0.4.1"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "autocfg",
  "chrono",
  "fern",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -276,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f96e90b3678de0ef73b7260538706ee195a13480cf601a0bf1542fa27e3abb"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "bee-crypto"
 version = "0.2.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "byteorder",
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 name = "bee-ledger"
 version = "0.4.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -339,14 +339,14 @@ dependencies = [
  "digest 0.9.0",
  "hex",
  "iota-crypto 0.4.2",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
 [[package]]
 name = "bee-message"
 version = "0.1.5"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bech32 0.8.1",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -355,8 +355,8 @@ dependencies = [
  "bytemuck",
  "digest 0.9.0",
  "hex",
- "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.127",
+ "iota-crypto 0.7.0",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "bee-network"
 version = "0.2.1"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "async-trait",
  "bee-runtime",
@@ -383,7 +383,7 @@ dependencies = [
  "log",
  "once_cell",
  "rand 0.8.4",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -404,11 +404,11 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-crypto 0.2.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iota-crypto 0.7.0",
  "thiserror",
 ]
 
@@ -443,7 +443,7 @@ dependencies = [
  "bee-protocol 0.1.0-alpha",
  "hex",
  "multiaddr 0.12.0",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
 ]
@@ -458,7 +458,7 @@ dependencies = [
  "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-protocol 0.1.0",
  "hex",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
 ]
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bee-runtime"
 version = "0.1.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "async-trait",
  "bee-storage",
@@ -478,10 +478,10 @@ dependencies = [
 [[package]]
 name = "bee-storage"
 version = "0.9.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -493,17 +493,17 @@ checksum = "6ec0259535d34f1bfd0c41bf5a6f0e3e33268dc9433e2ac3707e66715b51ce05"
 dependencies = [
  "autocfg",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
 name = "bee-ternary"
 version = "0.4.2-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#22d50c461bc87036cacf4fae65ef964194c8d213"
 dependencies = [
  "autocfg",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ source = "git+https://github.com/Alex6323/bee-p.git?rev=cf47287dbb37861668d378ea
 dependencies = [
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "iota-crypto 0.5.1",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -523,7 +523,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -614,7 +614,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
  "time",
  "winapi",
 ]
@@ -803,7 +803,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -875,7 +875,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -1071,7 +1071,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "zeroize",
 ]
@@ -1231,7 +1231,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1278,7 +1278,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "synstructure",
 ]
 
@@ -1394,7 +1394,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1488,7 +1488,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -1515,9 +1515,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -1798,7 +1798,7 @@ dependencies = [
  "criterion",
  "futures",
  "iota-crypto 0.5.1",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1823,7 +1823,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rumqttc",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1852,17 +1852,17 @@ dependencies = [
  "iota-model",
  "num_cpus",
  "once_cell",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "slip10",
  "tokio",
- "ureq 2.1.1",
+ "ureq 2.2.0",
 ]
 
 [[package]]
 name = "iota-client"
 version = "1.0.1"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#5d261b1202765f4e2e8d5bd8f9a649527f0d5f3f"
+source = "git+https://github.com/iotaledger/iota.rs?branch=dev#34bfa88d4cc286b73c4c51ed5b3cd4219154ba40"
 dependencies = [
  "async-trait",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -1871,12 +1871,12 @@ dependencies = [
  "bee-rest-api 0.1.0-alpha",
  "futures",
  "hex",
- "iota-crypto 0.6.0 (git+https://github.com/iotaledger/crypto.rs?rev=e42be4d)",
+ "iota-crypto 0.6.0",
  "log",
  "num_cpus",
  "regex",
  "reqwest",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1971,24 +1971,13 @@ dependencies = [
  "lazy_static",
  "pbkdf2",
  "rand 0.8.4",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "sha3",
  "tiny-keccak",
  "unicode-normalization",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "iota-crypto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a563712b1857f24cd194eb799ddee2c9f5fdb9f8cadc8cae333da5c7d2a9213"
-dependencies = [
- "blake2",
- "digest 0.9.0",
- "ed25519-zebra",
 ]
 
 [[package]]
@@ -2002,9 +1991,20 @@ dependencies = [
  "getrandom 0.2.3",
  "hmac 0.11.0",
  "pbkdf2",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "unicode-normalization",
+]
+
+[[package]]
+name = "iota-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c13594128939830ac9d9b8b44f9d073349cc6e10c30eb76c18ec89f0602ebe6"
+dependencies = [
+ "blake2",
+ "digest 0.9.0",
+ "ed25519-zebra",
 ]
 
 [[package]]
@@ -2021,7 +2021,7 @@ dependencies = [
  "ledger-transport-hid",
  "ledger-transport-tcp",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
  "trait-async",
 ]
@@ -2035,14 +2035,14 @@ dependencies = [
  "iota-constants 0.2.1 (git+https://github.com/iotaledger/iota.rs?rev=0aa7e11b075bea17ae52b1f7dff51f3a13c9d914)",
  "iota-conversion 0.3.0",
  "iota-crypto 0.3.0",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
 ]
 
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?branch=firefly-testing#ef2a2fe254c409533242916177ac21e94d262b9d"
+source = "git+https://github.com/iotaledger/wallet.rs?branch=fix/ledger-error-variant#d0069939ad13847622f87aa2720b457cadc51b9c"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2062,7 +2062,7 @@ dependencies = [
  "rand 0.8.4",
  "riker",
  "rocksdb",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "serde_repr",
  "slog",
@@ -2083,7 +2083,7 @@ dependencies = [
  "futures",
  "iota-crypto 0.5.1",
  "riker",
- "serde 1.0.127",
+ "serde 1.0.129",
  "stronghold-utils",
  "stronghold_engine",
  "thiserror",
@@ -2129,24 +2129,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2186,7 +2186,7 @@ dependencies = [
  "ledger-apdu",
  "ledger-transport-hid",
  "ledger-transport-tcp",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
  "trait-async",
  "wasm-bindgen",
@@ -2218,7 +2218,7 @@ dependencies = [
  "hex",
  "ledger-apdu",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
 ]
 
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libloading"
@@ -2473,7 +2473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -2483,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -2557,7 +2557,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "typenum",
 ]
@@ -2635,7 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -2655,9 +2655,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -2667,9 +2667,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -2748,7 +2748,7 @@ dependencies = [
  "data-encoding",
  "multihash 0.13.2",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
  "static_assertions",
  "unsigned-varint 0.7.0",
  "url",
@@ -2766,7 +2766,7 @@ dependencies = [
  "data-encoding",
  "multihash 0.14.0",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
  "static_assertions",
  "unsigned-varint 0.7.0",
  "url",
@@ -2808,7 +2808,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "synstructure",
 ]
 
@@ -2834,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2988,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
 dependencies = [
  "memchr",
 ]
@@ -3021,9 +3021,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3041,9 +3041,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",
@@ -3064,7 +3064,7 @@ dependencies = [
  "data-encoding",
  "multihash 0.13.2",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
  "static_assertions",
  "unsigned-varint 0.7.0",
  "url",
@@ -3177,7 +3177,7 @@ checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3188,7 +3188,7 @@ checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3291,7 +3291,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "version_check",
 ]
 
@@ -3402,7 +3402,7 @@ dependencies = [
  "itertools 0.9.0",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3415,7 +3415,7 @@ dependencies = [
  "itertools 0.10.1",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3579,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -3651,7 +3651,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3921,9 +3921,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -3943,23 +3943,23 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -3970,7 +3970,7 @@ checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -3981,7 +3981,7 @@ checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4002,7 +4002,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4078,9 +4078,9 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "slip10"
@@ -4186,7 +4186,7 @@ checksum = "1eec7338a29758185dc796de8847e078b9bc2f5880c02f7a7b34b13f04d31a23"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4196,7 +4196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c63b02bd4c6909552fa6fb76e3384411d49ee1aa148393c44edfc82f8d14d041"
 dependencies = [
  "libsodium-sys",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4223,7 +4223,7 @@ dependencies = [
  "iota-crypto 0.5.1",
  "once_cell",
  "paste",
- "serde 1.0.127",
+ "serde 1.0.129",
  "stronghold-runtime",
  "thiserror",
 ]
@@ -4253,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -4270,7 +4270,7 @@ checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "unicode-xid 0.2.2",
 ]
 
@@ -4314,7 +4314,7 @@ checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4342,7 +4342,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
 ]
 
@@ -4363,9 +4363,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -4389,7 +4389,7 @@ checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4434,7 +4434,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4456,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -4471,7 +4471,7 @@ checksum = "dfe8c654712ee594c93b7222d98b4e61c7e003aec49e73877edac607a213699d"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
 ]
 
 [[package]]
@@ -4558,12 +4558,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -4647,16 +4644,16 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+checksum = "3131cd6cb18488da91da1d10ed31e966f453c06b65bf010d35638456976a3fd7"
 dependencies = [
  "base64 0.13.0",
  "chunked_transfer",
  "log",
  "once_cell",
  "rustls",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "url",
  "webpki",
@@ -4673,7 +4670,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -4729,7 +4726,7 @@ dependencies = [
  "log",
  "once_cell",
  "riker",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "tokio",
 ]
@@ -4758,36 +4755,36 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4797,9 +4794,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -4807,22 +4804,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "wasm-timer"
@@ -4841,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5013,6 +5010,6 @@ checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.74",
+ "syn 1.0.75",
  "synstructure",
 ]

--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -40,7 +40,7 @@
             error = locale(err.error)
 
             if($isLedgerProfile) {
-                displayNotificationForLedgerProfile('error', true, true, false, false, err)
+                displayNotificationForLedgerProfile('error', true, false, false, false, error)
             } else {
                 showAppNotification({
                     type: 'error',

--- a/packages/shared/lib/ledger.ts
+++ b/packages/shared/lib/ledger.ts
@@ -139,10 +139,11 @@ export function displayNotificationForLedgerProfile(
         const shouldNotify = (!isConnected && !isLegacyConnected) || error
 
         if (canNotify && shouldNotify) {
-            const stateErrorMessage = localize(`error.ledger.${state}`)
+            const stateMessage = localize(`error.ledger.${state}`)
             const errorMessage = legacy ? getLegacyErrorMessage(error, true) : error?.error ? localize(error.error) : error
-
-            const message = error ? isLedgerError(error) ? stateErrorMessage : errorMessage : stateErrorMessage
+            
+            const shouldShowStateMessage = (!isConnected && !isLegacyConnected) && !error
+            const message = error ? (isLedgerError(error) && shouldShowStateMessage) ? stateMessage : errorMessage : stateMessage
             notificationId = showAppNotification({
                 type: notificationType,
                 message

--- a/packages/shared/lib/shell/walletErrors.ts
+++ b/packages/shared/lib/shell/walletErrors.ts
@@ -49,7 +49,7 @@ const errorMessages: {
     'NodesNotSynced': 'error.node.unsynced',
     // Ledger
     'LedgerMiscError': 'error.ledger.generic',
-    'WrongLedgerSeedError': 'error.ledger.mnemonicMismatch',
+    'LedgerMnemonicMismatch': 'error.ledger.mnemonicMismatch',
     'LedgerDongleLocked': 'error.ledger.locked',
     'LedgerDeniedByUser': 'error.send.cancelled',
     'LedgerDeviceNotFound': 'error.ledger.notFound',

--- a/packages/shared/lib/typings/events.ts
+++ b/packages/shared/lib/typings/events.ts
@@ -64,7 +64,7 @@ export enum ErrorType {
     LedgerDeniedByUser = 'LedgerDeniedByUser',
     LedgerDeviceNotFound = 'LedgerDeviceNotFound',
     LedgerEssenceTooLarge = 'LedgerEssenceTooLarge',
-    WrongLedgerSeedError = 'WrongLedgerSeedError',
+    LedgerMnemonicMismatch = 'LedgerMnemonicMismatch',
 
     // Dust output
     DustError = 'DustError',

--- a/packages/shared/routes/dashboard/wallet/views/CreateAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/CreateAccount.svelte
@@ -46,7 +46,7 @@
                     isBusy = false
 
                     if(err) {
-                        console.error(err?.error || err)
+                        console.error(err)
 
                         if($isLedgerProfile) {
                             displayNotificationForLedgerProfile('error', true, false, false, false, err)


### PR DESCRIPTION
# Description of change

- Changes Firefly backend to use the branch `dev` instead of `firefly-testing` on wallet.rs 
- Changes API error mapping to correct error result for when the Ledger device has a mismatched mnemonic
    - depends on branch `fix/ledger-error-variant` in wallet.rs ([#732](https://github.com/iotaledger/wallet.rs/pull/732))
- Changes some logic in displaying notifications for Ledger profiles

## Links to any relevant issues

None

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on:

- MacOS (Catalina 10.15.7)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas