### PR TITLE
fix: Transaction details

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -28,6 +28,8 @@
     export let onBackClick = () => {}
     export let balance // migration tx
 
+    console.log('THIS IS ME!')
+
     let cachedMigrationTx = !payload
     let milestonePayload = payload?.type === 'Milestone' ? (payload as Milestone) : undefined
     let txPayload = payload?.type === 'Transaction' ? (payload as Transaction) : undefined
@@ -126,7 +128,7 @@
                 </div>
                 <Text smaller>{locale('general.you')}</Text>
             {:else}
-                <Text smaller>{truncateString(senderAddress, 3, 3, 3)}</Text>
+                <Text smaller>{truncateString(senderAddress, 3, 3, 3) || locale('general.unknown')}</Text>
             {/if}
         </div>
         <Icon icon="small-chevron-right" classes="mx-4 text-gray-500 dark:text-white" />
@@ -141,7 +143,7 @@
                 <Text smaller>{locale('general.you')}</Text>
             {:else}
                 {#each receiverAddresses as address}
-                    <Text smaller>{truncateString(address, 3, 3, 3)}</Text>
+                    <Text smaller>{truncateString(address, 3, 3, 3) || locale('general.unknown')}</Text>
                 {/each}
             {/if}
         </div>

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -859,7 +859,8 @@
         "sending": "Sending",
         "legacyNetwork": "Legacy Network",
         "capsLock": "Caps Lock is on",
-        "version": "Version {version}"
+        "version": "Version {version}",
+        "unknown": "Unknown"
     },
     "dates": {
         "today": "Today",


### PR DESCRIPTION
# Description of change

- Adds fallback to display the text "Unknown" if for some reason the receiver or sender account is `null`

## Links to any relevant issues

- #1265 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on:

- MacOS (Catalina 10.15.7)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas