### PR TITLE
hotfix: `wallet.rs` branch

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -35,7 +35,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ dependencies = [
  "cipher",
  "ctr",
  "ghash",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -282,19 +282,6 @@ dependencies = [
 [[package]]
 name = "bee-crypto"
 version = "0.2.1-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9be03c91825c26fa8c93613362341df1136da233c8462ec2c59fe1be81c237"
-dependencies = [
- "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder",
- "lazy_static",
- "thiserror",
- "tiny-keccak",
-]
-
-[[package]]
-name = "bee-crypto"
-version = "0.2.1-alpha"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
 dependencies = [
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -302,17 +289,6 @@ dependencies = [
  "lazy_static",
  "thiserror",
  "tiny-keccak",
-]
-
-[[package]]
-name = "bee-ledger"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8645ed0a1e1e22952351b12cd0147553bd1e3507c71383a60d19bef9ac18b12"
-dependencies = [
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
 ]
 
 [[package]]
@@ -321,25 +297,7 @@ version = "0.4.0"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
 dependencies = [
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "thiserror",
-]
-
-[[package]]
-name = "bee-message"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34340c856750db4c2c0bed1e709503c0fee94a82c984fa024bf9490be4ae18cd"
-dependencies = [
- "bech32 0.8.1",
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-pow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "bytemuck",
- "digest 0.9.0",
- "hex",
- "iota-crypto 0.4.2",
- "serde 1.0.127",
+ "bee-message",
  "thiserror",
 ]
 
@@ -350,23 +308,14 @@ source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea
 dependencies = [
  "bech32 0.8.1",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
+ "bee-pow",
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bytemuck",
- "digest 0.9.0",
+ "digest",
  "hex",
  "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.127",
  "thiserror",
-]
-
-[[package]]
-name = "bee-network"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73a7e1695d5b1ae4ae8355dbbf5635cc4b97a37e49c8ec8355328da212a5bee"
-dependencies = [
- "libp2p 0.37.1",
 ]
 
 [[package]]
@@ -378,8 +327,8 @@ dependencies = [
  "bee-runtime",
  "futures",
  "hashbrown",
- "libp2p 0.39.1",
- "libp2p-core 0.29.0",
+ "libp2p",
+ "libp2p-core",
  "log",
  "once_cell",
  "rand 0.8.4",
@@ -392,21 +341,9 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612452ebcbc440512f0131a7058db63470b13828f1dc9c9b2024302673c767de"
-dependencies = [
- "bee-crypto 0.2.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "iota-crypto 0.4.2",
- "thiserror",
-]
-
-[[package]]
-name = "bee-pow"
-version = "0.1.0"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
 dependencies = [
- "bee-crypto 0.2.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
+ "bee-crypto",
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
@@ -417,19 +354,9 @@ name = "bee-protocol"
 version = "0.1.0-alpha"
 source = "git+https://github.com/iotaledger/bee?rev=c5b44f0a2867bb1655960e9418a87599e6565418#c5b44f0a2867bb1655960e9418a87599e6565418"
 dependencies = [
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-network 0.2.1",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
-]
-
-[[package]]
-name = "bee-protocol"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b135df2f2aa58952bf229909ba1d3638fe0522f0b60cb828f3c118e56608bf"
-dependencies = [
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-network 0.1.0",
+ "bee-message",
+ "bee-network",
+ "bee-pow",
 ]
 
 [[package]]
@@ -437,27 +364,12 @@ name = "bee-rest-api"
 version = "0.1.0-alpha"
 source = "git+https://github.com/iotaledger/bee?rev=c5b44f0a2867bb1655960e9418a87599e6565418#c5b44f0a2867bb1655960e9418a87599e6565418"
 dependencies = [
- "bee-ledger 0.4.0",
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-protocol 0.1.0-alpha",
+ "bee-ledger",
+ "bee-message",
+ "bee-pow",
+ "bee-protocol",
  "hex",
  "multiaddr 0.12.0",
- "serde 1.0.127",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "bee-rest-api"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2deddccfe0540d6d98598055015117b2df7d81c393b32eec7cfe9595725384de"
-dependencies = [
- "bee-ledger 0.1.0",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-protocol 0.1.0",
- "hex",
  "serde 1.0.127",
  "serde_json",
  "thiserror",
@@ -558,20 +470,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -580,17 +480,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -622,12 +513,6 @@ name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
@@ -749,7 +634,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -852,7 +737,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "num-traits 0.2.14",
  "oorandom",
@@ -874,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.1",
+ "itertools",
 ]
 
 [[package]]
@@ -1001,22 +886,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1025,8 +900,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1035,8 +910,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1077,9 +952,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1112,20 +987,11 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -1168,7 +1034,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "zeroize",
 ]
 
@@ -1181,7 +1047,7 @@ dependencies = [
  "curve25519-dalek",
  "hex",
  "rand_core 0.5.1",
- "sha2 0.9.5",
+ "sha2",
  "thiserror",
 ]
 
@@ -1259,12 +1125,6 @@ dependencies = [
  "syn 1.0.74",
  "synstructure",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fern"
@@ -1401,15 +1261,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1460,7 +1311,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval",
 ]
 
@@ -1547,22 +1398,12 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1572,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
  "crypto-mac 0.9.1",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1582,18 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
+ "digest",
 ]
 
 [[package]]
@@ -1602,8 +1432,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "digest",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
@@ -1754,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "iota-bundle-miner"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00#e57e297417ca6846117535b985b2bd6990db1f00"
+source = "git+https://github.com/iotaledger/iota.rs?rev=67193796e20841eaccc4cafb6fb442b064f8599f#67193796e20841eaccc4cafb6fb442b064f8599f"
 dependencies = [
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-transaction",
@@ -1770,38 +1600,11 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=57c5a33d83be4b8286a54156e9f0d2ac4345e9b9#57c5a33d83be4b8286a54156e9f0d2ac4345e9b9"
+source = "git+https://github.com/iotaledger/iota.rs?rev=67193796e20841eaccc4cafb6fb442b064f8599f#67193796e20841eaccc4cafb6fb442b064f8599f"
 dependencies = [
- "async-trait",
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-pow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-rest-api 0.1.0",
- "futures",
- "hex",
- "iota-crypto 0.5.1",
- "log",
- "num_cpus",
- "once_cell",
- "regex",
- "reqwest",
- "rumqttc",
- "serde 1.0.127",
- "serde_json",
- "thiserror",
- "tokio",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "iota-client"
-version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00#e57e297417ca6846117535b985b2bd6990db1f00"
-dependencies = [
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bee-common-derive",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-message",
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-transaction",
  "blake2",
@@ -1825,20 +1628,22 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "1.0.1"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#5d261b1202765f4e2e8d5bd8f9a649527f0d5f3f"
+source = "git+https://github.com/iotaledger/iota.rs?rev=5f8fd262526aa09e2f548b3711964ea8fc18bc0b#5f8fd262526aa09e2f548b3711964ea8fc18bc0b"
 dependencies = [
  "async-trait",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-rest-api 0.1.0-alpha",
+ "bee-message",
+ "bee-pow",
+ "bee-rest-api",
  "futures",
  "hex",
  "iota-crypto 0.6.0 (git+https://github.com/iotaledger/crypto.rs?rev=e42be4d)",
  "log",
  "num_cpus",
+ "once_cell",
  "regex",
  "reqwest",
+ "rumqttc",
  "serde 1.0.127",
  "serde_json",
  "thiserror",
@@ -1882,12 +1687,12 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00#e57e297417ca6846117535b985b2bd6990db1f00"
+source = "git+https://github.com/iotaledger/iota.rs?rev=67193796e20841eaccc4cafb6fb442b064f8599f#67193796e20841eaccc4cafb6fb442b064f8599f"
 dependencies = [
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-transaction",
  "iota-bundle-miner",
- "iota-client 0.5.0-alpha.3 (git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00)",
+ "iota-client 0.5.0-alpha.3",
  "iota-crypto 0.5.1",
 ]
 
@@ -1905,17 +1710,6 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558466ca403e13e2b849f6b1aa0ec98a602dd21a49421a24d69aa265261c2290"
-dependencies = [
- "blake2",
- "digest 0.9.0",
- "ed25519-zebra",
-]
-
-[[package]]
-name = "iota-crypto"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccb8160eb8a88434fb3a0a3fc852e625aceab6c0272f0f03cc3f47c125bceab"
@@ -1926,16 +1720,16 @@ dependencies = [
  "blake2",
  "byteorder",
  "chacha20poly1305",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
- "generic-array 0.14.4",
+ "generic-array",
  "getrandom 0.2.3",
  "hmac 0.11.0",
  "lazy_static",
  "pbkdf2",
  "rand 0.8.4",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "sha3",
  "tiny-keccak",
  "unicode-normalization",
@@ -1950,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a563712b1857f24cd194eb799ddee2c9f5fdb9f8cadc8cae333da5c7d2a9213"
 dependencies = [
  "blake2",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
 ]
 
@@ -1960,13 +1754,13 @@ version = "0.6.0"
 source = "git+https://github.com/iotaledger/crypto.rs?rev=e42be4d#e42be4d028edc520a3d71b5f37bf37f5a128dc32"
 dependencies = [
  "blake2",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
  "getrandom 0.2.3",
  "hmac 0.11.0",
  "pbkdf2",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "unicode-normalization",
 ]
 
@@ -2005,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?branch=firefly-testing#ef2a2fe254c409533242916177ac21e94d262b9d"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=8c1af4496cfecc6e17abc188ecc1a6b08e0b27b5#8c1af4496cfecc6e17abc188ecc1a6b08e0b27b5"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2015,7 +1809,7 @@ dependencies = [
  "futures",
  "getset",
  "hex",
- "iota-client 0.5.0-alpha.3 (git+https://github.com/iotaledger/iota.rs?rev=57c5a33d83be4b8286a54156e9f0d2ac4345e9b9)",
+ "iota-client 1.0.1",
  "iota-core",
  "iota-crypto 0.5.1",
  "iota-ledger",
@@ -2071,15 +1865,6 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2216,26 +2001,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08053fbef67cd777049ef7a95ebaca2ece370b4ed7712c3fa404d69a88cb741b"
-dependencies = [
- "atomic",
- "bytes 1.0.1",
- "futures",
- "lazy_static",
- "libp2p-core 0.28.3",
- "libp2p-swarm 0.29.0",
- "libp2p-swarm-derive 0.23.0",
- "parity-multiaddr",
- "parking_lot",
- "pin-project 1.0.8",
- "smallvec",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
@@ -2244,13 +2009,13 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "lazy_static",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-mplex",
  "libp2p-noise",
- "libp2p-swarm 0.30.0",
- "libp2p-swarm-derive 0.24.0",
+ "libp2p-swarm",
+ "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-yamux",
  "multiaddr 0.13.0",
@@ -2258,40 +2023,6 @@ dependencies = [
  "pin-project 1.0.8",
  "smallvec",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "lazy_static",
- "libsecp256k1 0.3.5",
- "log",
- "multihash 0.13.2",
- "multistream-select",
- "parity-multiaddr",
- "parking_lot",
- "pin-project 1.0.8",
- "prost 0.7.0",
- "prost-build 0.7.0",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.9.5",
- "smallvec",
- "thiserror",
- "unsigned-varint 0.7.0",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -2308,19 +2039,19 @@ dependencies = [
  "futures",
  "futures-timer",
  "lazy_static",
- "libsecp256k1 0.5.0",
+ "libsecp256k1",
  "log",
  "multiaddr 0.13.0",
  "multihash 0.14.0",
  "multistream-select",
  "parking_lot",
  "pin-project 1.0.8",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.5",
+ "sha2",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -2335,7 +2066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "smallvec",
  "trust-dns-resolver",
@@ -2348,11 +2079,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
  "futures",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "smallvec",
  "wasm-timer",
 ]
@@ -2366,7 +2097,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot",
@@ -2385,32 +2116,16 @@ dependencies = [
  "curve25519-dalek",
  "futures",
  "lazy_static",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.8.4",
- "sha2 0.9.5",
+ "sha2",
  "snow",
  "static_assertions",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
-dependencies = [
- "either",
- "futures",
- "libp2p-core 0.28.3",
- "log",
- "rand 0.7.3",
- "smallvec",
- "void",
- "wasm-timer",
 ]
 
 [[package]]
@@ -2421,22 +2136,12 @@ checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "rand 0.7.3",
  "smallvec",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
-dependencies = [
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -2460,7 +2165,7 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "libc",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "socket2 0.4.1",
  "tokio",
@@ -2473,7 +2178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "parking_lot",
  "thiserror",
  "yamux",
@@ -2492,36 +2197,20 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "digest",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "typenum",
 ]
 
@@ -2532,8 +2221,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
- "digest 0.9.0",
- "subtle 2.4.1",
+ "digest",
+ "subtle",
 ]
 
 [[package]]
@@ -2741,10 +2430,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array",
  "multihash-derive",
- "sha2 0.9.5",
  "unsigned-varint 0.5.1",
 ]
 
@@ -2754,10 +2441,10 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "digest",
+ "generic-array",
  "multihash-derive",
- "sha2 0.9.5",
+ "sha2",
  "unsigned-varint 0.7.0",
 ]
 
@@ -2895,33 +2582,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash 0.13.2",
- "percent-encoding",
- "serde 1.0.127",
- "static_assertions",
- "unsigned-varint 0.7.0",
- "url",
-]
 
 [[package]]
 name = "parking_lot"
@@ -3103,7 +2766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3115,7 +2778,7 @@ checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3191,40 +2854,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
-dependencies = [
- "bytes 1.0.1",
- "heck",
- "itertools 0.9.0",
- "log",
- "multimap",
- "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3235,27 +2870,14 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -3265,20 +2887,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "syn 1.0.74",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes 1.0.1",
- "prost 0.7.0",
 ]
 
 [[package]]
@@ -3288,7 +2900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -3807,23 +3419,11 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3832,11 +3432,11 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3845,10 +3445,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3886,7 +3486,7 @@ checksum = "28724a6e6f70b0cb115c580891483da6f3aa99e6a353598303a57f89d23aa6bc"
 dependencies = [
  "ed25519-dalek",
  "hmac 0.9.0",
- "sha2 0.9.5",
+ "sha2",
 ]
 
 [[package]]
@@ -3936,8 +3536,8 @@ dependencies = [
  "rand_core 0.6.3",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.5",
- "subtle 2.4.1",
+ "sha2",
+ "subtle",
  "x25519-dalek",
 ]
 
@@ -4023,12 +3623,6 @@ dependencies = [
  "stronghold-runtime",
  "thiserror",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -4400,8 +3994,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -8,11 +8,11 @@ exclude = ["/bindings", "/api-wrapper"]
 [dependencies]
 tokio = { version = "1.3", features = ["full"] }
 once_cell = "1.5.0"
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", branch = "firefly-testing", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator"] }
+iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "8c1af4496cfecc6e17abc188ecc1a6b08e0b27b5", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator"] }
 serde_json = "1.0"
 riker = "0.4"
 serde = "1.0"
-iota-client = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "5f8fd262526aa09e2f548b3711964ea8fc18bc0b" }
 log = "0.4"
 
 [dev-dependencies]

--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -60,7 +60,7 @@ import { ClientOptions } from '../../../shared/lib/typings/client'
 import { NodeAuth } from '../../../shared/lib/typings/node'
 
 // @ts-ignore
-import addon = require('./index.node')
+import addon = require('../index.node')
 
 const mailbox = []
 const onMessageListeners: ((payload: MessageResponse) => void)[] = []

--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -35,7 +35,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ dependencies = [
  "cipher",
  "ctr",
  "ghash",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -282,19 +282,6 @@ dependencies = [
 [[package]]
 name = "bee-crypto"
 version = "0.2.1-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9be03c91825c26fa8c93613362341df1136da233c8462ec2c59fe1be81c237"
-dependencies = [
- "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder",
- "lazy_static",
- "thiserror",
- "tiny-keccak",
-]
-
-[[package]]
-name = "bee-crypto"
-version = "0.2.1-alpha"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
 dependencies = [
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -302,17 +289,6 @@ dependencies = [
  "lazy_static",
  "thiserror",
  "tiny-keccak",
-]
-
-[[package]]
-name = "bee-ledger"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8645ed0a1e1e22952351b12cd0147553bd1e3507c71383a60d19bef9ac18b12"
-dependencies = [
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
 ]
 
 [[package]]
@@ -321,25 +297,7 @@ version = "0.4.0"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
 dependencies = [
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "thiserror",
-]
-
-[[package]]
-name = "bee-message"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34340c856750db4c2c0bed1e709503c0fee94a82c984fa024bf9490be4ae18cd"
-dependencies = [
- "bech32 0.8.1",
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-pow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "bytemuck",
- "digest 0.9.0",
- "hex",
- "iota-crypto 0.4.2",
- "serde 1.0.127",
+ "bee-message",
  "thiserror",
 ]
 
@@ -350,23 +308,14 @@ source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea
 dependencies = [
  "bech32 0.8.1",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
+ "bee-pow",
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bytemuck",
- "digest 0.9.0",
+ "digest",
  "hex",
  "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.127",
  "thiserror",
-]
-
-[[package]]
-name = "bee-network"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73a7e1695d5b1ae4ae8355dbbf5635cc4b97a37e49c8ec8355328da212a5bee"
-dependencies = [
- "libp2p 0.37.1",
 ]
 
 [[package]]
@@ -378,8 +327,8 @@ dependencies = [
  "bee-runtime",
  "futures",
  "hashbrown",
- "libp2p 0.39.1",
- "libp2p-core 0.29.0",
+ "libp2p",
+ "libp2p-core",
  "log",
  "once_cell",
  "rand 0.8.4",
@@ -392,21 +341,9 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612452ebcbc440512f0131a7058db63470b13828f1dc9c9b2024302673c767de"
-dependencies = [
- "bee-crypto 0.2.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "iota-crypto 0.4.2",
- "thiserror",
-]
-
-[[package]]
-name = "bee-pow"
-version = "0.1.0"
 source = "git+https://github.com/iotaledger/bee.git?branch=dev#b08ecba716a69b8ea25b3b1fb6e47f28ba5f4a65"
 dependencies = [
- "bee-crypto 0.2.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
+ "bee-crypto",
  "bee-ternary 0.4.2-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "iota-crypto 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
@@ -417,19 +354,9 @@ name = "bee-protocol"
 version = "0.1.0-alpha"
 source = "git+https://github.com/iotaledger/bee?rev=c5b44f0a2867bb1655960e9418a87599e6565418#c5b44f0a2867bb1655960e9418a87599e6565418"
 dependencies = [
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-network 0.2.1",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
-]
-
-[[package]]
-name = "bee-protocol"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b135df2f2aa58952bf229909ba1d3638fe0522f0b60cb828f3c118e56608bf"
-dependencies = [
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-network 0.1.0",
+ "bee-message",
+ "bee-network",
+ "bee-pow",
 ]
 
 [[package]]
@@ -437,27 +364,12 @@ name = "bee-rest-api"
 version = "0.1.0-alpha"
 source = "git+https://github.com/iotaledger/bee?rev=c5b44f0a2867bb1655960e9418a87599e6565418#c5b44f0a2867bb1655960e9418a87599e6565418"
 dependencies = [
- "bee-ledger 0.4.0",
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-protocol 0.1.0-alpha",
+ "bee-ledger",
+ "bee-message",
+ "bee-pow",
+ "bee-protocol",
  "hex",
  "multiaddr 0.12.0",
- "serde 1.0.127",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "bee-rest-api"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2deddccfe0540d6d98598055015117b2df7d81c393b32eec7cfe9595725384de"
-dependencies = [
- "bee-ledger 0.1.0",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-protocol 0.1.0",
- "hex",
  "serde 1.0.127",
  "serde_json",
  "thiserror",
@@ -558,20 +470,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -580,17 +480,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -622,12 +513,6 @@ name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
@@ -749,7 +634,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -868,7 +753,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "num-traits 0.2.14",
  "oorandom",
@@ -890,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.1",
+ "itertools",
 ]
 
 [[package]]
@@ -1017,22 +902,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1041,8 +916,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1051,8 +926,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1099,9 +974,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1134,20 +1009,11 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -1190,7 +1056,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "zeroize",
 ]
 
@@ -1203,7 +1069,7 @@ dependencies = [
  "curve25519-dalek",
  "hex",
  "rand_core 0.5.1",
- "sha2 0.9.5",
+ "sha2",
  "thiserror",
 ]
 
@@ -1281,12 +1147,6 @@ dependencies = [
  "syn 1.0.74",
  "synstructure",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fern"
@@ -1438,15 +1298,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1497,7 +1348,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval",
 ]
 
@@ -1584,22 +1435,12 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1609,7 +1450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
  "crypto-mac 0.9.1",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1619,18 +1460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
+ "digest",
 ]
 
 [[package]]
@@ -1639,8 +1469,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "digest",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
@@ -1791,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "iota-bundle-miner"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00#e57e297417ca6846117535b985b2bd6990db1f00"
+source = "git+https://github.com/iotaledger/iota.rs?rev=67193796e20841eaccc4cafb6fb442b064f8599f#67193796e20841eaccc4cafb6fb442b064f8599f"
 dependencies = [
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-transaction",
@@ -1807,38 +1637,11 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=57c5a33d83be4b8286a54156e9f0d2ac4345e9b9#57c5a33d83be4b8286a54156e9f0d2ac4345e9b9"
+source = "git+https://github.com/iotaledger/iota.rs?rev=67193796e20841eaccc4cafb6fb442b064f8599f#67193796e20841eaccc4cafb6fb442b064f8599f"
 dependencies = [
- "async-trait",
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-pow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bee-rest-api 0.1.0",
- "futures",
- "hex",
- "iota-crypto 0.5.1",
- "log",
- "num_cpus",
- "once_cell",
- "regex",
- "reqwest",
- "rumqttc",
- "serde 1.0.127",
- "serde_json",
- "thiserror",
- "tokio",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "iota-client"
-version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00#e57e297417ca6846117535b985b2bd6990db1f00"
-dependencies = [
- "bee-common 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
  "bee-common-derive",
- "bee-message 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-message",
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-transaction",
  "blake2",
@@ -1862,20 +1665,22 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "1.0.1"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#5d261b1202765f4e2e8d5bd8f9a649527f0d5f3f"
+source = "git+https://github.com/iotaledger/iota.rs?rev=5f8fd262526aa09e2f548b3711964ea8fc18bc0b#5f8fd262526aa09e2f548b3711964ea8fc18bc0b"
 dependencies = [
  "async-trait",
  "bee-common 0.4.1 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-message 0.1.5 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-pow 0.1.0 (git+https://github.com/iotaledger/bee.git?branch=dev)",
- "bee-rest-api 0.1.0-alpha",
+ "bee-message",
+ "bee-pow",
+ "bee-rest-api",
  "futures",
  "hex",
  "iota-crypto 0.6.0 (git+https://github.com/iotaledger/crypto.rs?rev=e42be4d)",
  "log",
  "num_cpus",
+ "once_cell",
  "regex",
  "reqwest",
+ "rumqttc",
  "serde 1.0.127",
  "serde_json",
  "thiserror",
@@ -1919,12 +1724,12 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00#e57e297417ca6846117535b985b2bd6990db1f00"
+source = "git+https://github.com/iotaledger/iota.rs?rev=67193796e20841eaccc4cafb6fb442b064f8599f#67193796e20841eaccc4cafb6fb442b064f8599f"
 dependencies = [
  "bee-ternary 0.4.2-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-transaction",
  "iota-bundle-miner",
- "iota-client 0.5.0-alpha.3 (git+https://github.com/iotaledger/iota.rs?rev=e57e297417ca6846117535b985b2bd6990db1f00)",
+ "iota-client 0.5.0-alpha.3",
  "iota-crypto 0.5.1",
 ]
 
@@ -1942,17 +1747,6 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558466ca403e13e2b849f6b1aa0ec98a602dd21a49421a24d69aa265261c2290"
-dependencies = [
- "blake2",
- "digest 0.9.0",
- "ed25519-zebra",
-]
-
-[[package]]
-name = "iota-crypto"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccb8160eb8a88434fb3a0a3fc852e625aceab6c0272f0f03cc3f47c125bceab"
@@ -1963,16 +1757,16 @@ dependencies = [
  "blake2",
  "byteorder",
  "chacha20poly1305",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
- "generic-array 0.14.4",
+ "generic-array",
  "getrandom 0.2.3",
  "hmac 0.11.0",
  "lazy_static",
  "pbkdf2",
  "rand 0.8.4",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "sha3",
  "tiny-keccak",
  "unicode-normalization",
@@ -1987,7 +1781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a563712b1857f24cd194eb799ddee2c9f5fdb9f8cadc8cae333da5c7d2a9213"
 dependencies = [
  "blake2",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
 ]
 
@@ -1997,13 +1791,13 @@ version = "0.6.0"
 source = "git+https://github.com/iotaledger/crypto.rs?rev=e42be4d#e42be4d028edc520a3d71b5f37bf37f5a128dc32"
 dependencies = [
  "blake2",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
  "getrandom 0.2.3",
  "hmac 0.11.0",
  "pbkdf2",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "unicode-normalization",
 ]
 
@@ -2042,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?branch=firefly-testing#ef2a2fe254c409533242916177ac21e94d262b9d"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=8c1af4496cfecc6e17abc188ecc1a6b08e0b27b5#8c1af4496cfecc6e17abc188ecc1a6b08e0b27b5"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2052,7 +1846,7 @@ dependencies = [
  "futures",
  "getset",
  "hex",
- "iota-client 0.5.0-alpha.3 (git+https://github.com/iotaledger/iota.rs?rev=57c5a33d83be4b8286a54156e9f0d2ac4345e9b9)",
+ "iota-client 1.0.1",
  "iota-core",
  "iota-crypto 0.5.1",
  "iota-ledger",
@@ -2108,15 +1902,6 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2253,26 +2038,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08053fbef67cd777049ef7a95ebaca2ece370b4ed7712c3fa404d69a88cb741b"
-dependencies = [
- "atomic",
- "bytes 1.0.1",
- "futures",
- "lazy_static",
- "libp2p-core 0.28.3",
- "libp2p-swarm 0.29.0",
- "libp2p-swarm-derive 0.23.0",
- "parity-multiaddr",
- "parking_lot",
- "pin-project 1.0.8",
- "smallvec",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
@@ -2281,13 +2046,13 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "lazy_static",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-mplex",
  "libp2p-noise",
- "libp2p-swarm 0.30.0",
- "libp2p-swarm-derive 0.24.0",
+ "libp2p-swarm",
+ "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-yamux",
  "multiaddr 0.13.0",
@@ -2295,40 +2060,6 @@ dependencies = [
  "pin-project 1.0.8",
  "smallvec",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "lazy_static",
- "libsecp256k1 0.3.5",
- "log",
- "multihash 0.13.2",
- "multistream-select",
- "parity-multiaddr",
- "parking_lot",
- "pin-project 1.0.8",
- "prost 0.7.0",
- "prost-build 0.7.0",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.9.5",
- "smallvec",
- "thiserror",
- "unsigned-varint 0.7.0",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -2345,19 +2076,19 @@ dependencies = [
  "futures",
  "futures-timer",
  "lazy_static",
- "libsecp256k1 0.5.0",
+ "libsecp256k1",
  "log",
  "multiaddr 0.13.0",
  "multihash 0.14.0",
  "multistream-select",
  "parking_lot",
  "pin-project 1.0.8",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.5",
+ "sha2",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -2372,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "smallvec",
  "trust-dns-resolver",
@@ -2385,11 +2116,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
  "futures",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "smallvec",
  "wasm-timer",
 ]
@@ -2403,7 +2134,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot",
@@ -2422,32 +2153,16 @@ dependencies = [
  "curve25519-dalek",
  "futures",
  "lazy_static",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.8.4",
- "sha2 0.9.5",
+ "sha2",
  "snow",
  "static_assertions",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
-dependencies = [
- "either",
- "futures",
- "libp2p-core 0.28.3",
- "log",
- "rand 0.7.3",
- "smallvec",
- "void",
- "wasm-timer",
 ]
 
 [[package]]
@@ -2458,22 +2173,12 @@ checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "rand 0.7.3",
  "smallvec",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
-dependencies = [
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -2497,7 +2202,7 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "libc",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log",
  "socket2 0.4.1",
  "tokio",
@@ -2510,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
  "futures",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "parking_lot",
  "thiserror",
  "yamux",
@@ -2529,36 +2234,20 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "digest",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "typenum",
 ]
 
@@ -2569,8 +2258,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
- "digest 0.9.0",
- "subtle 2.4.1",
+ "digest",
+ "subtle",
 ]
 
 [[package]]
@@ -2778,10 +2467,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array",
  "multihash-derive",
- "sha2 0.9.5",
  "unsigned-varint 0.5.1",
 ]
 
@@ -2791,10 +2478,10 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "digest",
+ "generic-array",
  "multihash-derive",
- "sha2 0.9.5",
+ "sha2",
  "unsigned-varint 0.7.0",
 ]
 
@@ -3009,12 +2696,6 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -3050,24 +2731,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash 0.13.2",
- "percent-encoding",
- "serde 1.0.127",
- "static_assertions",
- "unsigned-varint 0.7.0",
- "url",
 ]
 
 [[package]]
@@ -3250,7 +2913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3262,7 +2925,7 @@ checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3338,40 +3001,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
-dependencies = [
- "bytes 1.0.1",
- "heck",
- "itertools 0.9.0",
- "log",
- "multimap",
- "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3382,27 +3017,14 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -3412,20 +3034,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "syn 1.0.74",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes 1.0.1",
- "prost 0.7.0",
 ]
 
 [[package]]
@@ -3435,7 +3047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -4011,23 +3623,11 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4036,11 +3636,11 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4049,10 +3649,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4090,7 +3690,7 @@ checksum = "28724a6e6f70b0cb115c580891483da6f3aa99e6a353598303a57f89d23aa6bc"
 dependencies = [
  "ed25519-dalek",
  "hmac 0.9.0",
- "sha2 0.9.5",
+ "sha2",
 ]
 
 [[package]]
@@ -4140,8 +3740,8 @@ dependencies = [
  "rand_core 0.6.3",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.5",
- "subtle 2.4.1",
+ "sha2",
+ "subtle",
  "x25519-dalek",
 ]
 
@@ -4227,12 +3827,6 @@ dependencies = [
  "stronghold-runtime",
  "thiserror",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -4604,8 +4198,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]


### PR DESCRIPTION
# Description of change

Firefly has been pointed at the `firefly-testing` branch of [`wallet.rs`](https://github.com/iotaledger/wallet.rs) for a while. While I think versions are the best option to use (easier to be consistent, has more semantic meaning than a commit, etc.), using the same revision as `wallet.rs` would be good. 

To be more specific, `wallet.rs` currently uses the commit `5f8fd262526aa09e2f548b3711964ea8fc18bc0b` for `iota.rs`, which _does_ contain different code. Firefly __must__ also use this revision so that the bindings can compile. Using versions and or commit revisions will alleviate this although it'll be important to make the sure Firefly and `wallet.rs` are using the __same__ version of `iota.rs`.

In summary:

- Changes the following dependencies in `packages/backend/Cargo.toml`:
    - `iota-wallet` now uses `rev = "8c1af4496cfecc6e17abc188ecc1a6b08e0b27b5"` rather than `branch = "firefly-testing"` 
    - `iota-client` now uses `rev = "5f8fd262526aa09e2f548b3711964ea8fc18bc0b"` rather than `branch = "dev"`
- Fixes an error in a relative path in `packages/backend/bindings/node/index.ts`
    - `require('./index.node')` throws an error; changed to `require('../index.node')` 

## Links to any relevant issues

None

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on:

- MacOS (Catalina 10.15.7)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes