### PR TITLE
Fix: seed/mnemonic textfield debounce

### DIFF
--- a/packages/shared/components/inputs/ImportTextfield.svelte
+++ b/packages/shared/components/inputs/ImportTextfield.svelte
@@ -62,6 +62,7 @@
         }
     }
 
+    /* eslint-disable @typescript-eslint/no-misused-promises */
     const handleKeyDown = async () => {
         value = ''
         statusMessage = ''
@@ -124,10 +125,7 @@
         class="text-14 leading-140 resize-none w-full p-4 pb-3 rounded-xl border border-solid {error ? 'border-red-300 hover:border-red-500 focus:border-red-500' : 'border-gray-300 hover:border-gray-500 dark:border-gray-700 dark:hover:border-gray-700'}
         text-gray-500 dark:text-white bg-white dark:bg-gray-800 scroll-secondary"
         bind:value={content}
-        on:keydown={() => {
-            /* eslint-disable @typescript-eslint/no-misused-promises */
-            debounce(handleKeyDown)
-        }}
+        on:keydown={debounce(handleKeyDown)}
         placeholder=""
         spellcheck={false}
         autofocus />


### PR DESCRIPTION
# Description of change

This PR aims to fix the `ImportTextField` component where the `debounce` was not working so `handleKeyDown` was never being called and the user could never continue the onboarding process importing a seed or a mnemonic.

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

1. Start a new profile
2. Migrate or restore a wallet
3. Select "I have an 81 character seed" or "I have a Firefly recovery phrase"
4. Type and check it works as expected

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
