### PR TITLE
Fix: Wrong error message on empty/corrupt stronghold import

### DIFF
--- a/packages/shared/lib/shell/walletApi.ts
+++ b/packages/shared/lib/shell/walletApi.ts
@@ -217,6 +217,9 @@ const handleError = (
 
     // TODO: Add full type list to remove this temporary fix
     const _getError = () => {
+        if (error.includes('Snapshot is too short to be valid') || error.includes('is this really a snapshot file?')) {
+            return 'error.backup.invalid'
+        }
         if (error.includes('try another password')) {
             return 'error.password.incorrect'
         }

--- a/packages/shared/routes/setup/import/Import.svelte
+++ b/packages/shared/routes/setup/import/Import.svelte
@@ -84,6 +84,8 @@
                 break
             }
             case ImportState.FileImport: {
+                error = ''
+
                 const strongholdRegex = /\.(stronghold)$/i
                 const seedvaultRegex = /\.(kdbx)$/i
                 const { file, fileName, filePath } = params


### PR DESCRIPTION
# Description of change

This PR fixes the message on empty or corrupt stronghold import, it was being displayed `Your password is incorrect`

## Links to any relevant issues

Fixes #967 (#974 already fixed it for seedvault but this PR is for stronghold)

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

- Create new profile > import file backup
- Use an empty stronghold or a corrupt one: message should be `The backup file was not recognised.`
- Use a correct stronghold with wrong password: message should be `Your password is incorrect.`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
