### PR TITLE
chore(ci): Avoid using latest to specify CI platforms

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
       fail-fast: false
 
     steps:
@@ -40,18 +40,18 @@ jobs:
     
     - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
       uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       with:
         version: "11.0"
         directory: ${{ runner.temp }}/llvm
       
     - name: Set LIBCLANG_PATH (Windows)
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
 
     - name: Set deployment target (macOS)
       run: echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-10.15'
 
     - name: Install required packages (Linux)
       run: |
@@ -63,11 +63,11 @@ jobs:
 
     - name: Enable verbose output for electron-builder (macOS/Linux)
       run: echo "DEBUG=electron-builder" >> $GITHUB_ENV
-      if: matrix.os != 'windows-latest' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
+      if: matrix.os != 'windows-2019' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
 
     - name: Enable verbose output for electron-builder (Windows)
       run: echo "DEBUG=electron-builder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      if: matrix.os == 'windows-latest' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
+      if: matrix.os == 'windows-2019' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
 
     - name: Install dependencies
       run: yarn
@@ -86,7 +86,7 @@ jobs:
         FIREFLY_APPLE_ID: ${{ secrets.APPLE_ID }}
         FIREFLY_APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       working-directory: packages/desktop
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-10.15'
 
     - name: Build Electron app (Windows)
       run: yarn compile:win
@@ -94,7 +94,7 @@ jobs:
         CSC_LINK: ${{ secrets.WIN_CERT_BASE64 }}
         CSC_KEY_PASSWORD: ${{ secrets.WIN_CERT_PASSWORD }}
       working-directory: packages/desktop
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
 
     - name: Build Electron app (Linux)
       run: yarn compile:linux
@@ -125,12 +125,12 @@ jobs:
     - name: Compute checksums (macOS)
       run: for i in `ls | grep 'firefly-desktop*'` ; do shasum -a 256 $i | awk {'print $1'} > $i.sha256 ; done
       working-directory: packages/desktop/out
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-10.15'
 
     - name: Compute checksums (Windows)
       run: Get-ChildItem "." -Filter firefly-desktop* | Foreach-Object { $(Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash | Set-Content ($_.FullName + '.sha256') }
       working-directory: packages/desktop/out
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
@@ -158,13 +158,13 @@ jobs:
     - name: Downloading artifacts
       uses: actions/download-artifact@v2
       with:
-        name: firefly-desktop-windows-latest
+        name: firefly-desktop-windows-2019
         path: assets
 
     - name: Downloading artifacts
       uses: actions/download-artifact@v2
       with:
-        name: firefly-desktop-macos-latest
+        name: firefly-desktop-macos-10.15
         path: assets
 
     - name: Downloading artifacts


### PR DESCRIPTION
# Description of change

We should use the exact platforms instead of using `latest` on the workflow that builds Firefly so that we can switch on our own timeline. There may be slight differences between the environments that could introduce potential issues.

## Links to any relevant issues

N/A

## Type of change

- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code