### PR TITLE
Feat: allow close popup on click outside

### DIFF
--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Icon } from 'shared/components'
+    import { clickOutside } from 'shared/lib/actions'
     import { closePopup, popupState } from 'shared/lib/popup'
     import { onMount } from 'svelte'
     import { fade } from 'svelte/transition'
@@ -99,7 +100,13 @@
     }
 
     const onkey = (e) => {
-        if (!hideClose && e.key === 'Escape') {
+        if (e.key === 'Escape') {
+            tryClosePopup()
+        }
+    }
+
+    const tryClosePopup = (): void => {
+        if (!hideClose) {
             if ('function' === typeof props?.onCancelled) {
                 props?.onCancelled()
             }
@@ -108,9 +115,11 @@
     }
 
     const focusableElements = () =>
-        [...popupContent.querySelectorAll('a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])')].filter(
-            (el) => !el.hasAttribute('disabled')
-        )
+        [
+            ...popupContent.querySelectorAll(
+                'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+            ),
+        ].filter((el) => !el.hasAttribute('disabled'))
 
     const handleFocusFirst = (e) => {
         const elems = focusableElements()
@@ -163,11 +172,13 @@
                 h-full overflow-hidden z-10 ${fullScreen ? 'bg-white dark:bg-gray-900' : 'bg-gray-800 bg-opacity-40'}`}>
     <div tabindex="0" on:focus={handleFocusFirst} />
     <popup-content
+        use:clickOutside
+        on:clickOutside={tryClosePopup}
         bind:this={popupContent}
         class={`${size} bg-white rounded-xl pt-6 px-8 pb-8 relative ${fullScreen ? 'full-screen dark:bg-gray-900' : 'dark:bg-gray-900'}`}>
         {#if !hideClose}
             <button
-                on:click={() => closePopup($popupState?.preventClose)}
+                on:click={tryClosePopup}
                 class="absolute top-6 right-8 text-gray-800 dark:text-white focus:text-blue-500">
                 <Icon icon="close" />
             </button>

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -2,6 +2,7 @@
     import { Icon } from 'shared/components'
     import { clickOutside } from 'shared/lib/actions'
     import { closePopup, popupState } from 'shared/lib/popup'
+    import type { Locale } from 'shared/lib/typings/i18n'
     import { onMount } from 'svelte'
     import { fade } from 'svelte/transition'
     import AddNode from './AddNode.svelte'
@@ -27,13 +28,12 @@
     import Password from './Password.svelte'
     import QR from './QR.svelte'
     import RemoveNode from './RemoveNode.svelte'
-    import SwitchNetwork from './SwitchNetwork.svelte'
     import RiskFunds from './RiskFunds.svelte'
     import Snapshot from './Snapshot.svelte'
+    import SwitchNetwork from './SwitchNetwork.svelte'
     import Transaction from './Transaction.svelte'
     import Version from './Version.svelte'
     import Video from './Video.svelte'
-    import { Locale } from 'shared/lib/typings/i18n'
 
     export let locale: Locale
 


### PR DESCRIPTION
# Description of change

This PRs adds the `clickOutside` action to the `Popup` component to be able to be closed (if possible) when you click outside of it. 
_Requested by UX_

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Ubuntu 20.04.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
