### PR TITLE
fix: Network node list

### DIFF
--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -256,10 +256,7 @@ export const checkNodeUrlValidity = (nodesList: Node[], newUrl: string, allowIns
  */
 export const updateClientOptions = (config: NetworkConfig): void => {
     const clientOptions = buildClientOptions(config)
-    if (!clientOptions.node) {
-        console.error('Error: The client options does not have a primary node.')
-        return
-    }
+    if (!clientOptions.node) return
 
     const hasMismatchedNetwork = clientOptions.node?.network?.id !== clientOptions.network
     if (hasMismatchedNetwork && isNewNotification('warning')) {
@@ -322,14 +319,15 @@ export const getNodeCandidates = (config: NetworkConfig): Node[] => {
     if (!config) return []
 
     const useAutomaticSelection = config.nodes.length === 0 || config.automaticNodeSelection
+    const officialNodes = getOfficialNodes(config.network.type).map((n, idx) => ({ ...n, isPrimary: false }))
 
     let nodeCandidates
     if (useAutomaticSelection) {
-        nodeCandidates = getOfficialNodes(config.network.type).map((n, idx) => ({ ...n, isPrimary: idx === 0 }))
+        nodeCandidates = officialNodes
     } else {
         nodeCandidates = config.includeOfficialNodes
             ? addOfficialNodes(config.network.type, config.nodes)
-            : config.nodes
+            : config.nodes.filter((n) => officialNodes.find((_n) => _n.url === n.url) === undefined)
     }
 
     return ensureSinglePrimaryNode(nodeCandidates)

--- a/packages/shared/routes/dashboard/settings/views/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Advanced.svelte
@@ -67,16 +67,7 @@
     }
 
     function ensureValidNodeSelection(): void {
-        /**
-         * NOTE: There's no need to ensure a valid node
-         * selection if it will be handled automatically.
-         */
-        if (networkConfig.automaticNodeSelection) return
-
         networkConfig.nodes = getNodeCandidates(networkConfig)
-        if (!networkConfig.includeOfficialNodes) {
-            networkConfig.nodes = networkConfig.nodes.filter((n) => !getOfficialNodes(networkConfig.network.type).map((_n) => _n.url.includes(n.url)))
-        }
     }
 
     function ensureOnePrimaryNode(): void {


### PR DESCRIPTION
# Description of change
Fixes some errors in logic around network configuration, namely:
- Un-checking "Include official nodes" will remove all nodes from the last even if they aren't official (__should ONLY__ remove official ones)
- Add fallback / reversion for profile if network switch fails after updating client options and removing wallet accounts

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on:
- MacOS (Catalina 10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
