### PR TITLE
fix: swallow receiving on a closed channel error

### DIFF
--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -90,7 +90,7 @@ export function init(id: string, storagePath?: string): { destroy: () => void; r
         runtime,
         (error, data) => {
             // Swallow error thrown when poll returns after the actor is destroyed
-            if (error && error.message.includes("receiving on a closed channel")) return
+            if (error && error.message.includes('receiving on a closed channel')) return
             const message = error || data
             // @ts-ignore
             onMessageListeners.forEach((listener) => listener(message))

--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -66,10 +66,10 @@ const onMessageListeners: ((payload: MessageResponse) => void)[] = []
 
 function _poll(
     runtime: typeof addon.ActorSystem,
-    cb: (error: string, data: unknown) => void,
+    cb: (error: Error, data: unknown) => void,
     shouldStop: () => boolean
 ) {
-    runtime.poll((err: string, data: string) => {
+    runtime.poll((err: Error, data: string) => {
         cb(err, err ? null : JSON.parse(data))
         if (!shouldStop()) {
             _poll(runtime, cb, shouldStop)
@@ -89,6 +89,8 @@ export function init(id: string, storagePath?: string): { destroy: () => void; r
     _poll(
         runtime,
         (error, data) => {
+            // Swallow error thrown when poll returns after the actor is destroyed
+            if (error && error.message.includes("receiving on a closed channel")) return
             const message = error || data
             // @ts-ignore
             onMessageListeners.forEach((listener) => listener(message))


### PR DESCRIPTION
# Description of change

Due to [the way the poll function is used](https://github.com/iotaledger/firefly/blob/9e136e56a5a16bf4f83b2c32718bd0a440ead02d/packages/backend/bindings/node/index.ts#L72) when sending messages to the backend, poll always returns after destroying the actor. There's no real reason to fundamentally refactor the approach here so we can instead swallow the associated error message.

## Links to any relevant issues

Fixes #1433 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on Mac dev

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
