### PR TITLE
update(desktop): Get more accurate OS version info on macOS

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -3,6 +3,7 @@ const { app, dialog, ipcMain, protocol, shell, BrowserWindow, session } = requir
 const path = require('path')
 const os = require('os')
 const fs = require('fs')
+const { execSync } = require('child_process')
 const Keychain = require('./lib/keychain')
 const { initMenu, contextMenu } = require('./lib/menu')
 
@@ -352,12 +353,18 @@ const getDiagnostics = () => {
 
     if (platform === 'darwin') {
         platform = 'macOS'
-        const verSplit = platformVersion.split('.')
-        const num = Number.parseInt(verSplit[0], 10)
-        if (!Number.isNaN(num)) {
-            const [_, version] = osXNameMap.get(num)
-            if (version) {
-                platformVersion = version
+
+        try {
+            platformVersion = execSync('sw_vers -productVersion').toString().trim()
+        } catch (_err) {
+            // Fall back to Darwin version map
+            const verSplit = platformVersion.split('.')
+            const num = Number.parseInt(verSplit[0], 10)
+            if (!Number.isNaN(num)) {
+                const [_, version] = osXNameMap.get(num)
+                if (version) {
+                    platformVersion = version
+                }
             }
         }
     }

--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -330,6 +330,8 @@ ipcMain.handle('get-path', (_e, path) => {
 // Diagnostics
 const getDiagnostics = () => {
     const osXNameMap = new Map([
+        // Source: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
+        [21, ['Monterey', '12']],
         [20, ['Big Sur', '11']],
         [19, ['Catalina', '10.15']],
         [18, ['Mojave', '10.14']],


### PR DESCRIPTION
# Description of change

We currently use `os.release()`, but on macOS this gives us the Darwin version, which then needs to be mapped to a major release of macOS. This PR uses `sw_vers -productVersion` to get the exact macOS version, as this may help debug issues in the future. It also allows us to get the macOS version without needing to add another entry to the map when a new one is released.

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas