### PR TITLE
fix: ensure stronghold password is requested if locked when syncing account history

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -13,7 +13,7 @@
         isSyncing,
         selectedAccountId,
         selectedMessage,
-        isFirstManualSync
+        isFirstManualSync,
     } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import type { Readable, Writable } from 'svelte/store'
@@ -39,12 +39,12 @@
     }
 
     function handleSyncAccountOptions() {
-        if(get(isFirstManualSync)) {
+        if (get(isFirstManualSync)) {
             isFirstManualSync.set(true)
 
             return {
                 gapLimit: $isSoftwareProfile ? 10 : 1,
-                accountDiscoveryThreshold: 1
+                accountDiscoveryThreshold: 1,
             }
         } else {
             return getSyncAccountOptions(true)
@@ -60,7 +60,9 @@
                     if (strongholdStatusResponse.payload.snapshot.status === 'Locked') {
                         openPopup({
                             type: 'password',
-                            props: { onSuccess: async () => asyncSyncAccounts(0, gapLimit, accountDiscoveryThreshold, false) }
+                            props: {
+                                onSuccess: async () => asyncSyncAccounts(0, gapLimit, accountDiscoveryThreshold, false),
+                            },
                         })
                     } else {
                         void asyncSyncAccounts(0, gapLimit, accountDiscoveryThreshold, false)
@@ -88,10 +90,9 @@
          *      3. The wallet setup type cannot be new (if it's new then there's no tx history to sync)
          *      4. Account must have no transactions (the length of $transactions must be zero)
          */
-        return $isFirstSessionSync &&
-            $walletSetupType &&
-            $walletSetupType !== SetupType.New &&
-            $transactions.length === 0
+        return (
+            $isFirstSessionSync && $walletSetupType && $walletSetupType !== SetupType.New && $transactions.length === 0
+        )
     }
 </script>
 


### PR DESCRIPTION
# Description of change

Currently the popup to unlock Stronghold only shows if you sync from the dashboard view. If you try sync from an address view it doesn't ask for the password to unlock Stronghold and generate addresses in syncing.

This PR fixes this issue.
Fixes https://github.com/iotaledger/firefly/issues/1519

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on Mac for software and Ledger profiles.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
