### PR TITLE
feat: call getParticipationOverview() when StakingManager component mounts

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -196,6 +196,9 @@
     }
 
     onMount(async () => {
+        // Fetch participation overview when this component mounts
+        await getParticipationOverview()
+
         /**
          * NOTE: Because of Stronghold and Ledger prompts to "unlock"
          * the wallets, this popup MAY BE instantiated with an "accountToAction",


### PR DESCRIPTION
# Description of change

Not calling this when the component mounts leaves the staking overview fields to default so even though you have unstaked balance, it will still show 0. 

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Manually tested

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
