### PR TITLE
Extract participation object from indexation payload

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -196,6 +196,9 @@
     }
 
     onMount(async () => {
+        // Fetch participation overview when this component mounts
+        await getParticipationOverview()
+
         /**
          * NOTE: Because of Stronghold and Ledger prompts to "unlock"
          * the wallets, this popup MAY BE instantiated with an "accountToAction",

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -7,7 +7,7 @@ import type { WalletAccount } from '../typings/wallet'
 
 import { ASSEMBLY_EVENT_ID, SHIMMER_EVENT_ID, STAKING_AIRDROP_TOKENS, STAKING_EVENT_IDS } from './constants'
 import { partiallyStakedAccounts, participationEvents, participationOverview, stakedAccounts } from './stores'
-import { ParticipationEvent, StakingAirdrop } from './types'
+import { ParticipationEvent, StakingAirdrop, Participation } from './types'
 
 /**
  * Determines whether an account is currently being staked or not.
@@ -189,4 +189,34 @@ export const getUnstakedFunds = (account: WalletAccount): number => {
     const accountParticipation = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
     if (!accountParticipation) return 0
     else return accountParticipation.shimmerUnstakedFunds
+}
+
+/**
+ * Determines if partipations include shimmer event id
+ *
+ * @method isStakingForShimmer
+ *
+ * @param {Participation[]} participations
+ *
+ * @returns {boolean}
+ */
+export const isStakingForShimmer = (participations: Participation[]): boolean => {
+    const eventIds = participations.map((participation) => participation.eventId);
+
+    return eventIds.includes(SHIMMER_EVENT_ID);
+}
+
+/**
+ * Determines if partipations include assembly event id
+ *
+ * @method isStakingForAssembly
+ *
+ * @param {Participation[]} participations
+ *
+ * @returns {boolean}
+ */
+ export const isStakingForAssembly = (participations: Participation[]): boolean => {
+    const eventIds = participations.map((participation) => participation.eventId);
+
+    return eventIds.includes(ASSEMBLY_EVENT_ID);
 }

--- a/packages/shared/lib/typings/message.ts
+++ b/packages/shared/lib/typings/message.ts
@@ -22,6 +22,7 @@ export interface RegularEssence {
     payload?: {
         type: 'Indexation'
         data: {
+            data: number[];
             index: number[]
         }
     }


### PR DESCRIPTION
# Description of change

Add a method to extract the participation object from indexation payload. This is needed to determine if a given message was used for staking in which particular event. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- New (a change which implements a new feature)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
