### PR TITLE
Keep track of pending participations

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -92,11 +92,6 @@
         const isPartialStake = $partiallyStakedAccounts.find((psa) => psa.id === $accountToParticipate?.id) !== undefined
 
         const _sync = async () => {
-            // Add a delay to cover for the transaction confirmation time
-            // TODO: Might need to rethink of a better solution here.
-            await new Promise((resolve) => setTimeout(resolve, 11000));
-
-            await asyncSyncAccounts()
             await getParticipationOverview()
 
             showAppNotification({

--- a/packages/shared/lib/participation/api.ts
+++ b/packages/shared/lib/participation/api.ts
@@ -3,9 +3,9 @@ import { get } from 'svelte/store'
 import { localize } from '../i18n'
 import type { Event } from '../typings/events'
 import { showAppNotification } from '../notifications'
-import { api } from '../wallet'
+import { api, saveNewMessage } from '../wallet'
 
-import { participationEvents, participationOverview } from './stores'
+import { participationEvents, participationOverview, addNewPendingParticipationTransactionIds } from './stores'
 import type {
     ParticipateResponsePayload,
     Participation,
@@ -90,6 +90,9 @@ export function participate(accountId: string, participations: Participation[]):
             participations,
             {
                 onSuccess(response: Event<ParticipateResponsePayload>) {
+                    response.payload.forEach((message) => saveNewMessage(accountId, message));
+
+                    addNewPendingParticipationTransactionIds(response.payload);
                     resolve()
                 },
                 onError(error) {
@@ -127,8 +130,9 @@ export function stopParticipating(accountId: string, eventIds: string[]): Promis
             eventIds,
             {
                 onSuccess(response: Event<ParticipateResponsePayload>) {
-                    response?.payload.forEach((msg) => {
-                    })
+                    response.payload.forEach((message) => saveNewMessage(accountId, message));
+                    addNewPendingParticipationTransactionIds(response.payload);
+
                     resolve()
                 },
                 onError(error) {

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -11,8 +11,14 @@ import {
     ParticipationAction,
     ParticipationEvent,
     ParticipationEventState,
-    ParticipationOverview
+    ParticipationOverview,
+    ParticipateResponsePayload
 } from './types'
+
+/**
+ * The store for keeping track of transaction ids generated as part of participation events.
+ */
+ export const pendingParticipationTransactionIds = writable<string[]>([])
 
 /**
  * The persisted store variable for if the staking feature is new for a Firefly installation.
@@ -218,3 +224,29 @@ export const shimmerStakingRemainingTime: Readable<number> = derived(
             $participationEvents.find((pe) => pe.eventId === SHIMMER_EVENT_ID)
         )
 )
+
+/**
+ * Adds newly broadcasted (yet unconfirmed) message ids that were generated as part of participation event.
+ *
+ * @method addNewPendingParticipationTransactionIds
+ *
+ * @param {ParticipateResponsePayload} payload
+ *
+ * @returns {void}
+ */
+export const addNewPendingParticipationTransactionIds = (payload: ParticipateResponsePayload): void => {
+    pendingParticipationTransactionIds.update((txs) => [...txs, ...payload.map((tx) => tx.id)]);
+};
+
+/**
+ * Removes pending participation transaction id (after it has confirmed)
+ *
+ * @method removePendingParticipationTransactionIds
+ *
+ * @param {ParticipateResponsePayload} payload
+ *
+ * @returns {void}
+ */
+ export const removePendingParticipationTransactionIds = (ids: string[]): void => {
+    pendingParticipationTransactionIds.update((txs) => txs.filter((id) => !ids.includes(id)));
+};

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -69,6 +69,8 @@ import type {
     ParticipationOverviewResponse
 } from './participation/types'
 
+import { removePendingParticipationTransactionIds } from './participation/stores'
+
 const ACCOUNT_COLORS = ['turquoise', 'green', 'orange', 'yellow', 'purple', 'pink']
 
 export const MAX_PROFILE_NAME_LENGTH = 20
@@ -886,6 +888,9 @@ export const initialiseListeners = (): void => {
             const { message } = response.payload
 
             if (message.payload.type === 'Transaction') {
+                // For participation
+                removePendingParticipationTransactionIds([message.id]);
+
                 const { confirmed } = response.payload
                 const { essence } = message.payload.data
 

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -62,7 +62,7 @@
         }
     }
 
-    const getTransactions = (): AccountMessage[] => {
+    const getTransactions = (): AccountMessage[] => {        
         return transactions
     }
 </script>


### PR DESCRIPTION
# Description of change

This PR also ensures that newly sent participation messages are added to the local application state.

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Manually

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
