### PR TITLE
fix: remove code related to maintenance of pending participations

### DIFF
--- a/packages/shared/lib/participation/api.ts
+++ b/packages/shared/lib/participation/api.ts
@@ -5,7 +5,7 @@ import type { Event } from '../typings/events'
 import { showAppNotification } from '../notifications'
 import { api, saveNewMessage } from '../wallet'
 
-import { participationEvents, participationOverview, addNewPendingParticipationTransactionIds } from './stores'
+import { participationEvents, participationOverview } from './stores'
 import type {
     ParticipateResponsePayload,
     Participation,
@@ -92,7 +92,6 @@ export function participate(accountId: string, participations: Participation[]):
                 onSuccess(response: Event<ParticipateResponsePayload>) {
                     response.payload.forEach((message) => saveNewMessage(accountId, message));
 
-                    addNewPendingParticipationTransactionIds(response.payload);
                     resolve()
                 },
                 onError(error) {
@@ -131,7 +130,6 @@ export function stopParticipating(accountId: string, eventIds: string[]): Promis
             {
                 onSuccess(response: Event<ParticipateResponsePayload>) {
                     response.payload.forEach((message) => saveNewMessage(accountId, message));
-                    addNewPendingParticipationTransactionIds(response.payload);
 
                     resolve()
                 },

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -17,11 +17,6 @@ import {
 import { NodePlugin } from '../typings/node'
 
 /**
- * The store for keeping track of transaction ids generated as part of participation events.
- */
- export const pendingParticipationTransactionIds = writable<string[]>([])
-
-/**
  * The persisted store variable for if the staking feature is new for a Firefly installation.
  * Once the user navigates to the staking dashboard, this is set to false. This helps the UX
  * to highlight the new feature.
@@ -227,29 +222,3 @@ export const shimmerStakingRemainingTime: Readable<number> = derived(
             $participationEvents.find((pe) => pe.eventId === SHIMMER_EVENT_ID)
         )
 )
-
-/**
- * Adds newly broadcasted (yet unconfirmed) message ids that were generated as part of participation event.
- *
- * @method addNewPendingParticipationTransactionIds
- *
- * @param {ParticipateResponsePayload} payload
- *
- * @returns {void}
- */
-export const addNewPendingParticipationTransactionIds = (payload: ParticipateResponsePayload): void => {
-    pendingParticipationTransactionIds.update((txs) => [...txs, ...payload.map((tx) => tx.id)]);
-};
-
-/**
- * Removes pending participation transaction id (after it has confirmed)
- *
- * @method removePendingParticipationTransactionIds
- *
- * @param {ParticipateResponsePayload} payload
- *
- * @returns {void}
- */
- export const removePendingParticipationTransactionIds = (ids: string[]): void => {
-    pendingParticipationTransactionIds.update((txs) => txs.filter((id) => !ids.includes(id)));
-};

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -69,8 +69,6 @@ import type {
     ParticipationOverviewResponse
 } from './participation/types'
 
-import { removePendingParticipationTransactionIds } from './participation/stores'
-
 const ACCOUNT_COLORS = ['turquoise', 'green', 'orange', 'yellow', 'purple', 'pink']
 
 export const MAX_PROFILE_NAME_LENGTH = 20
@@ -888,9 +886,6 @@ export const initialiseListeners = (): void => {
             const { message } = response.payload
 
             if (message.payload.type === 'Transaction') {
-                // For participation
-                removePendingParticipationTransactionIds([message.id]);
-
                 const { confirmed } = response.payload
                 const { essence } = message.payload.data
 


### PR DESCRIPTION
# Description of change

Removes code related to maintenance of pending participations. It is no longer needed as we need to maintain only account ids which we are already maintaining.

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
