### PR TITLE
fix: ensure there is no crash when you are sending funds

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -393,7 +393,7 @@
             openPopup({
                 type: 'transaction',
                 props: {
-                    isSendingFromParticpatingAccount: isAccountStaked($account.id),
+                    isSendingFromParticpatingAccount: isAccountStaked(from.id),
                     internal: internal || accountAlias,
                     amount: amountRaw,
                     unit,


### PR DESCRIPTION
# Description of change

`$account` is not defined if you try to send directly from the dashboard and it was causing a crash. 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually tested

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
