### PR TITLE
fix: make change of dev profile checkbox persistent

### DIFF
--- a/packages/shared/routes/setup/Profile.svelte
+++ b/packages/shared/routes/setup/Profile.svelte
@@ -60,10 +60,11 @@
 
             const previousInitializedId = $newProfile?.id
             const nameChanged = $newProfile?.name !== trimmedProfileName
+            const isDeveloperProfileChanged = $newProfile?.isDeveloperProfile !== isDeveloperProfile
 
             // If the name has changed from the previous initialization
             // then make sure we cleanup the last profile and actor
-            if (nameChanged && previousInitializedId) {
+            if ((nameChanged || isDeveloperProfileChanged) && previousInitializedId) {
                 // The initialized profile name has changed
                 // so we need to destroy the previous actor
                 destroyActor(previousInitializedId)
@@ -72,7 +73,7 @@
             try {
                 busy = true
 
-                if (nameChanged) {
+                if (nameChanged || isDeveloperProfileChanged) {
                     profile = createProfile(trimmedProfileName, isDeveloperProfile)
                     profileInProgress.set(trimmedProfileName)
 


### PR DESCRIPTION
# Description of change

When creating a new profile, the profile is initialised after you press next on the create profile page (name and devprofile selection). If they press back after they have already submitted this page, they can change the options (i.e. name and devprofile checkbox). However, it was only deleting the old acter and reinitialising the wallet if the name had changed. This fix makes it so that it happens if the name is changed or the checkbox changes.

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
