### PR TITLE
chore(ci): Update "verify download" link in release notes template

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -184,7 +184,7 @@ jobs:
         echo '### Changelog' >> CHANGELOG.md
         echo '------' >> CHANGELOG.md
         echo '### File Hashes' >> CHANGELOG.md
-        echo '[How to verify the authenticity of your Firefly Desktop download](https://chrysalis.docs.iota.org/firefly/verify_download.html)' >> CHANGELOG.md
+        echo '[How to verify the authenticity of your Firefly Desktop download](https://wiki.iota.org/chrysalis-docs/firefly/verify_download)' >> CHANGELOG.md
         echo '| File | Platform | SHA256 Hash |' >> CHANGELOG.md
         echo '| --- | --- | --- |' >> CHANGELOG.md
         echo '| firefly-desktop-${{ env.RELEASE_VERSION }}.exe | Windows |' $WIN_SHA256 '|' >> CHANGELOG.md


### PR DESCRIPTION
# Description of change

Updates the "verify download" link in the release notes template to point to the wiki. The redirect from `chrysalis.docs.iota.org` is currently not working due to SSL cert issues.

## Links to any relevant issues

N/A

## Type of change

- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
