### PR TITLE
fix: improve error message when trying to delete a non empty profile

### DIFF
--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -8,7 +8,7 @@
     import { AppRoute } from 'shared/lib/typings/routes'
     import { api, asyncRemoveStorage, asyncRemoveWalletAccounts, wallet } from 'shared/lib/wallet'
     import { get } from 'svelte/store'
-    import { Locale } from 'shared/lib/typings/i18n'
+    import type { Locale } from 'shared/lib/typings/i18n'
 
     export let locale: Locale
 
@@ -78,10 +78,18 @@
              */
             await removeProfileFolder(_activeProfile.name)
         } catch (err) {
-            showAppNotification({
-                type: 'error',
-                message: locale('error.global.generic'),
-            })
+            if (err && err?.type && err?.type == 'AccountNotEmpty') {
+                showAppNotification({
+                    type: 'error',
+                    message: locale('error.profile.delete.nonEmptyAccounts'),
+                })
+            } else {
+                showAppNotification({
+                    type: 'error',
+                    message: locale('error.global.generic'),
+                })
+            }
+
         } finally {
             isBusy = false
         }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -957,7 +957,10 @@
     "error": {
         "profile": {
             "length": "Your profile name can't be longer than {length, plural, one {1 character} other {# characters}}.",
-            "duplicate": "A profile with this name already exists."
+            "duplicate": "A profile with this name already exists.",
+            "delete": {
+                "nonEmptyAccounts": "Cannot delete profile as one or more accounts are non empty."
+            }
         },
         "password": {
             "doNotMatch": "Passwords do not match.",

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -959,7 +959,7 @@
             "length": "Your profile name can't be longer than {length, plural, one {1 character} other {# characters}}.",
             "duplicate": "A profile with this name already exists.",
             "delete": {
-                "nonEmptyAccounts": "Cannot delete profile as one or more accounts are non empty."
+                "nonEmptyAccounts": "You must transfer all balances before you can delete your profile."
             }
         },
         "password": {

--- a/packages/shared/routes/dashboard/settings/views/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Security.svelte
@@ -5,11 +5,11 @@
     import passwordInfo from 'shared/lib/password'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, isSoftwareProfile, updateProfile } from 'shared/lib/profile'
+    import type { Locale } from 'shared/lib/typings/i18n'
     import { getDefaultStrongholdName, PIN_LENGTH } from 'shared/lib/utils'
-    import { api, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
+    import { api, MAX_PASSWORD_LENGTH, wallet } from 'shared/lib/wallet'
     import { get } from 'svelte/store'
     import zxcvbn from 'zxcvbn'
-    import { Locale } from 'shared/lib/typings/i18n'
 
     export let locale: Locale
 
@@ -21,7 +21,10 @@
         return locale('views.settings.appLock.durationMinute', { values: { time: timeInMinutes } })
     }
 
-    const lockScreenTimeoutOptions = [1, 5, 10, 30, 60].map((time) => ({ value: time, label: assignTimeoutOptionLabel(time) }))
+    const lockScreenTimeoutOptions = [1, 5, 10, 30, 60].map((time) => ({
+        value: time,
+        label: assignTimeoutOptionLabel(time),
+    }))
 
     let exportStrongholdChecked
     let currentPassword = ''
@@ -260,6 +263,12 @@
     }
 
     function reset() {
+        if (get(get(wallet).balanceOverview).balanceRaw > 0) {
+            return showAppNotification({
+                type: 'error',
+                message: locale('error.profile.delete.nonEmptyAccounts'),
+            })
+        }
         openPopup({ type: 'deleteProfile' })
     }
 </script>
@@ -349,7 +358,9 @@
             <Text type="h4" classes="mb-3">{locale('views.settings.changePincode.title')}</Text>
             <Text type="p" secondary classes="mb-5">{locale('views.settings.changePincode.description')}</Text>
 
-            <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.currentPincode')}</Text>
+            <Text type="p" secondary smaller classes="mb-2">
+                {locale('views.settings.changePincode.currentPincode')}
+            </Text>
             <Pin
                 smaller
                 error={currentPincodeError}
@@ -365,7 +376,9 @@
                 bind:value={newPincode}
                 disabled={pinCodeBusy}
                 on:submit={changePincode} />
-            <Text type="p" secondary smaller classes="mb-2">{locale('views.settings.changePincode.confirmNewPincode')}</Text>
+            <Text type="p" secondary smaller classes="mb-2">
+                {locale('views.settings.changePincode.confirmNewPincode')}
+            </Text>
             <Pin
                 smaller
                 error={confirmationPincodeError}


### PR DESCRIPTION
# Description of change

Add an more specific error message when attempting to delete a profile where 1 or more accounts is non empty.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

Manually on MacOS

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
