### PR TITLE
fix: correct url to chrysalis documentation

### DIFF
--- a/packages/desktop/electron/lib/menu.js
+++ b/packages/desktop/electron/lib/menu.js
@@ -214,7 +214,7 @@ const buildTemplate = () => {
             {
                 label: state.strings.documentation,
                 click: function () {
-                    shell.openExternal('https://chrysalis.docs.iota.org/')
+                    shell.openExternal('https://wiki.iota.org/learn/networks/iota-1.5-chrysalis/')
                 },
             },
             {

--- a/packages/desktop/electron/lib/menu.js
+++ b/packages/desktop/electron/lib/menu.js
@@ -214,7 +214,7 @@ const buildTemplate = () => {
             {
                 label: state.strings.documentation,
                 click: function () {
-                    shell.openExternal('https://wiki.iota.org/learn/networks/iota-1.5-chrysalis/')
+                    shell.openExternal('https://wiki.iota.org/')
                 },
             },
             {

--- a/packages/shared/routes/dashboard/settings/views/Help.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Help.svelte
@@ -10,7 +10,7 @@
     // }
 
     const handleDocumentationClick = () => {
-        Electron.openUrl('https://chrysalis.docs.iota.org/')
+        Electron.openUrl('https://wiki.iota.org/learn/networks/iota-1.5-chrysalis/')
     }
 
     const handleFaqClick = () => {

--- a/packages/shared/routes/dashboard/settings/views/Help.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Help.svelte
@@ -10,7 +10,7 @@
     // }
 
     const handleDocumentationClick = () => {
-        Electron.openUrl('https://wiki.iota.org/learn/networks/iota-1.5-chrysalis/')
+        Electron.openUrl('https://wiki.iota.org/')
     }
 
     const handleFaqClick = () => {


### PR DESCRIPTION
# Description of change

The chrysalis documentation was moved from https://chrysalis.docs.iota.org to https://wiki.iota.org/learn/networks/iota-1.5-chrysalis. I changed the url to the chrysalis documentation in the help section and menu bar.

## Links to any relevant issues

[Discord](https://discord.com/channels/397872799483428865/817057519062614016/920012018805776395)

## Type of change

- Update (a change which updates existing functionality)