### PR TITLE
fix: zero value fiat conversion

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -74,7 +74,7 @@
             const rawAmount = changeUnits(amountAsFloat, unit as Unit, Unit.i)
             const fiatAmount = convertToFiat(rawAmount, $currencies[CurrencyTypes.USD], $exchangeRates[currency])
 
-            return fiatAmount === 0 ? replaceCurrencyDecimal('< 0.01') : formatCurrency(fiatAmount)
+            return fiatAmount === 0 ? rawAmount === 0 ? formatCurrency(0) : '< ' + formatCurrency(0.01) : formatCurrency(fiatAmount)
         }
 
         return convertAmount(_amount, undefined, _convert)
@@ -92,10 +92,8 @@
     }
 
     const convertAmount = (_amount, _unit, convertFn) => {
-        if (!amount) return null
-
         const amountAsFloat = parseCurrency(_amount, _unit)
-        if (amountAsFloat === 0 || Number.isNaN(amountAsFloat)) return null
+        if (Number.isNaN(amountAsFloat)) return null
 
         return convertFn(amountAsFloat)
     }
@@ -114,7 +112,7 @@
 
         // IOTA -> FIAT
         if (isFiatCurrency(toUnit)) {
-            amount = convertAmountToFiat(amount).slice(2)
+            amount = parseFloat(convertAmountToFiat(amount).slice(2))
         } else {
             let rawAmount
 


### PR DESCRIPTION
# Description of change
Fixes some broken logic around IOTA -> fiat conversions if the amount is zero.

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on: 
- MacOS (Catalina 10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes