### PR TITLE
feat: display a proper node error if participation plugin is not available

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -777,7 +777,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde 1.0.131",
 ]
@@ -1201,7 +1201,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1242,7 +1242,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=234416faecca87437324b055d225df75bef2977c#234416faecca87437324b055d225df75bef2977c"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=b320400e188b97be68455ac649142f1440da1e34#b320400e188b97be68455ac649142f1440da1e34"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1574,6 +1574,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -1682,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.111"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e167738f1866a7ec625567bae89ca0d44477232a4f7c52b1c7f2adc2c98804f"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libloading"
@@ -2518,11 +2524,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde 1.0.131",
 ]
@@ -2554,7 +2560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde 1.0.131",
 ]
@@ -2811,7 +2817,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "libc",
 ]
 

--- a/packages/shared/lib/shell/walletApi.ts
+++ b/packages/shared/lib/shell/walletApi.ts
@@ -14,7 +14,7 @@ import { ErrorType } from '../typings/events'
 import { logError } from './errorLogger'
 import { getErrorMessage } from './walletErrors'
 import { ErrorTypes as ValidatorErrorTypes } from '../typings/validator'
-import { NodePlugin } from '../typings/node';
+import { NodePlugin } from '../typings/node'
 
 type CallbacksStore = {
     [id: string]: CallbacksPattern
@@ -231,9 +231,9 @@ const handleError = (
 ): { type: ErrorType | ValidatorErrorTypes; error: string } => {
     const newError = { type, message: error, time: Date.now() }
 
-     if (error.includes('Response error with status code 403')) {
+    if (error.includes('Response error with status code 403')) {
         if (action && action.includes(NodePlugin.Participation)) {
-            newError.message = `${NodePlugin.Participation} not available on your current node. Please try a different node and try again.`;
+            newError.message = `${NodePlugin.Participation} not available on your current node. Please try a different node and try again.`
             logError(newError)
         }
     } else {

--- a/packages/shared/lib/shell/walletApi.ts
+++ b/packages/shared/lib/shell/walletApi.ts
@@ -14,6 +14,7 @@ import { ErrorType } from '../typings/events'
 import { logError } from './errorLogger'
 import { getErrorMessage } from './walletErrors'
 import { ErrorTypes as ValidatorErrorTypes } from '../typings/validator'
+import { NodePlugin } from '../typings/node';
 
 type CallbacksStore = {
     [id: string]: CallbacksPattern
@@ -180,7 +181,7 @@ Wallet.onMessage((message: MessageResponse) => {
         const { onSuccess, onError } = callbacksStore[id]
 
         if (message.type === ResponseTypes.Error) {
-            onError(handleError(message.payload.type, message.payload.error))
+            onError(handleError(message.payload.type, message.payload.error, message.action))
         } else if (message.type === ResponseTypes.Panic) {
             onError(handleError(ErrorType.Panic, message.payload))
         } else {
@@ -225,11 +226,19 @@ const storeCallbacks = (__id: string, type: ResponseTypes, callbacks?: Callbacks
  */
 const handleError = (
     type: ErrorType | ValidatorErrorTypes,
-    error: string
+    error: string,
+    action?: string
 ): { type: ErrorType | ValidatorErrorTypes; error: string } => {
     const newError = { type, message: error, time: Date.now() }
 
-    logError(newError)
+     if (error.includes('Response error with status code 403')) {
+        if (action && action.includes(NodePlugin.Participation)) {
+            newError.message = `${NodePlugin.Participation} not available on your current node. Please try a different node and try again.`;
+            logError(newError)
+        }
+    } else {
+        logError(newError)
+    }
 
     // TODO: Add full type list to remove this temporary fix
     const _getError = () => {


### PR DESCRIPTION
# Description of change

This PR covers the following:

- Update the cargo lock file;
- Display a proper (readable) error in error log if the node doesn't have participation plugin enabled

## Links to any relevant issues

N/A

## Type of change

- New (a change which implements a new feature)

## How the change has been tested

Manually tested macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
