### PR TITLE
fix: airdrop selection for partial stake

### DIFF
--- a/packages/shared/components/Text.svelte
+++ b/packages/shared/components/Text.svelte
@@ -1,7 +1,7 @@
 
 <script lang="typescript">
     import { appSettings } from 'shared/lib/appSettings'
-    
+
     export let type = 'p'
     export let secondary = false
     export let disabled = false
@@ -50,7 +50,7 @@
             @apply text-gray-500;
         }
         &.disabled {
-            @apply text-gray-900;
+            @apply text-gray-400;
             &.darkmode {
                 @apply text-gray-600;
             }

--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -37,7 +37,8 @@
         true
     )
 
-    const activeAirdrops = $participationOverview.find((apo) => apo.accountIndex === accountToStake.index)?.participations.map((p) => getAirdropFromEventId(p.eventId)) || []
+    const activeAirdrops: StakingAirdrop[] =
+        $participationOverview.find((apo) => apo.accountIndex === accountToStake.index)?.participations.map((p) => getAirdropFromEventId(p.eventId)) || []
 
     const airdropSelections: { [key in StakingAirdrop]: boolean } = {
         [StakingAirdrop.Assembly]: activeAirdrops?.length > 0 ? activeAirdrops?.includes(StakingAirdrop.Assembly) : true,
@@ -110,19 +111,19 @@
 <div class="flex flex-row justify-between items-center mb-6 space-x-2">
     {#each Object.keys(StakingAirdrop).map((sa) => sa.toLowerCase()) as airdrop}
         <div
-            on:click={(activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop)) ? () => {} : () => toggleAirdropSelection(airdrop)}
-            class="p-4 w-1/2 flex flex-col items-center text-center border border-1 border-solid border-gray-300 rounded-xl {activeAirdrops?.length && !activeAirdrops?.includes(airdrop) ? 'cursor-default' : 'cursor-pointer hover:bg-blue-50 hover:border-blue-500 focus:border-blue-500 focus:bg-blue-50 dark:hover:bg-gray-800'}"
+            on:click={(activeAirdrops.length > 0 && activeAirdrops.includes(airdrop)) ? () => {} : () => toggleAirdropSelection(airdrop)}
+            class="p-4 w-1/2 flex flex-col items-center text-center border border-1 border-solid border-gray-300 rounded-xl {activeAirdrops?.length && activeAirdrops?.includes(airdrop) ? 'cursor-default' : 'cursor-pointer hover:bg-blue-50 hover:border-blue-500 focus:border-blue-500 focus:bg-blue-50 dark:hover:bg-gray-800'}"
         >
             <div class="mb-2 flex flex-row justify-center">
-                <Text type="p" disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop))} classes="font-extrabold text-lg">{capitalize(airdrop)}&nbsp;</Text>
-                <Text type="p" disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop))} classes="text-lg inline">({STAKING_AIRDROP_TOKENS[airdrop]})</Text>
+                <Text type="p" disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))} classes="font-extrabold text-lg">{capitalize(airdrop)}&nbsp;</Text>
+                <Text type="p" disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))} classes="text-lg inline">({STAKING_AIRDROP_TOKENS[airdrop]})</Text>
             </div>
-            <Text type="p" secondary disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop))}>{locale('popups.stakingConfirmation.estimatedAirdrop')}:</Text>
-            <Checkbox bind:checked={airdropSelections[airdrop]} onClick={() => toggleAirdropSelection(airdrop)} disabled={(activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop))} classes="my-5" />
-            <Text type="p" disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop))} classes="font-bold text-lg">
+            <Text type="p" secondary disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))}>{locale('popups.stakingConfirmation.estimatedAirdrop')}:</Text>
+            <Checkbox bind:checked={airdropSelections[airdrop]} onClick={() => toggleAirdropSelection(airdrop)} disabled={(activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))} classes="my-5" />
+            <Text type="p" disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))} classes="font-bold text-lg">
                 {(airdropSelections[airdrop] ? getRewards(capitalize(airdrop)) : estimateStakingAirdropReward(airdrop, 0, true, 0)).split(' ')[0]}
             </Text>
-            <Text type="p" secondary disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && !activeAirdrops.includes(airdrop))} classes="font-bold text-lg">
+            <Text type="p" secondary disabled={!airdropSelections[airdrop] || (activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))} classes="font-bold text-lg">
                 {(airdropSelections[airdrop] ? getRewards(capitalize(airdrop)) : estimateStakingAirdropReward(airdrop, 0, true, 0)).split(' ')[1]}
             </Text>
         </div>


### PR DESCRIPTION
# Description of change
The logic for disabling UI elements based on the airdrops an account was participating in was incorrect (in `popups/StakingConfirmation.svelte`).

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on:
- MacOS (10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes