### PR TITLE
fix: partial staking UI disappearing

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -14,7 +14,7 @@
     import { getParticipationOverview, participate, stopParticipating } from 'shared/lib/participation/api'
     import { STAKING_EVENT_IDS } from 'shared/lib/participation/constants'
     import {
-        accountToParticipate,
+        accountToParticipate, partiallyStakedAccounts,
         participatedAccountsMapPerSession,
         participationAction,
         participationOverview,
@@ -281,7 +281,7 @@
                         {:else}{locale(`actions.${isAccountStaked(account?.id) ? 'unstake' : 'stake'}`)}{/if}
                     </Button>
                 </div>
-                {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id && !$participatedAccountsMapPerSession.get($accountToParticipate?.id)}
+                {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id}
                     <div
                         class="space-x-4 mx-1 mb-1 px-4 py-3 flex flex-row justify-between items-center rounded-lg bg-yellow-50">
                         <Icon icon="exclamation" width="24" height="24" classes="fill-current text-yellow-600" />

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -107,9 +107,7 @@
                     on:mouseenter={toggleTooltip}
                     on:mouseleave={toggleTooltip}
                 >
-                    {#if isPartiallyStaked}
-                        <Icon icon="exclamation" classes="fill-current text-yellow-600" />
-                    {/if}
+                    <Icon icon="exclamation" classes="fill-current text-yellow-600" />
                 </div>
             {/if}
         </div>


### PR DESCRIPTION
# Description of change
Account list UI disappears for partial stake items if more than one (only in specific part of the staking / unstaking flow).

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on:
- MacOS (10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes