### PR TITLE
fix: amount input

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -112,7 +112,8 @@
 
         // IOTA -> FIAT
         if (isFiatCurrency(toUnit)) {
-            amount = parseFloat(convertAmountToFiat(amount).slice(2)).toString()
+            let _amount = parseFloat(convertAmountToFiat(amount).slice(2)) ?? 0
+            amount = isNaN(_amount)  ? '0' : _amount.toString() 
         } else {
             let rawAmount
 

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -112,7 +112,7 @@
 
         // IOTA -> FIAT
         if (isFiatCurrency(toUnit)) {
-            amount = parseFloat(convertAmountToFiat(amount).slice(2))
+            amount = parseFloat(convertAmountToFiat(amount).slice(2)).toString()
         } else {
             let rawAmount
 
@@ -186,28 +186,28 @@
 </script>
 
 <style type="text/scss">
-    amount-input {
-        nav {
-            &.dropdown {
-                @apply opacity-100;
-                @apply pointer-events-auto;
-            }
-        }
-
-        &.disabled {
-            @apply pointer-events-none;
-            actions {
-                @apply opacity-50;
-            }
-        }
+  amount-input {
+    nav {
+      &.dropdown {
+        @apply opacity-100;
+        @apply pointer-events-auto;
+      }
     }
+
+    &.disabled {
+      @apply pointer-events-none;
+      actions {
+        @apply opacity-50;
+      }
+    }
+  }
 </style>
 
 <svelte:window on:click={onOutsideClick} />
 <amount-input class:disabled class="relative block {classes}" on:keydown={handleKey}>
     <Input
         {error}
-        label={amountForLabel ?? (label || locale('general.amount'))}
+        label={amountForLabel || locale('general.amount')}
         placeholder={placeholder || locale('general.amount')}
         bind:value={amount}
         maxlength={17}

--- a/packages/shared/lib/currency.ts
+++ b/packages/shared/lib/currency.ts
@@ -107,6 +107,9 @@ export const isFiatCurrency = (currency: string): boolean =>
  *
  * @param {number | string} data
  * @param {string} currency
+ * @param {number} fiatFixed
+ * @param {number} btcFixed
+ * @param {number} ethFixed
  *
  * @returns {string}
  */


### PR DESCRIPTION
# Description of change
The amount input component fails to convert values for IOTA and fiat.

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on: 
- MacOS (10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes