### PR TITLE
chore: allow change of install directory windows

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -91,7 +91,8 @@
             ]
         },
         "nsis": {
-            "deleteAppDataOnUninstall": false
+            "deleteAppDataOnUninstall": false,
+            "allowToChangeInstallationDirectory": true
         },
         "win": {
             "icon": "./public/assets/icons/win/icon.ico",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -91,6 +91,7 @@
             ]
         },
         "nsis": {
+            "oneClick": false,
             "deleteAppDataOnUninstall": false,
             "allowToChangeInstallationDirectory": true
         },


### PR DESCRIPTION
# Description of change

Creating this pull request in case we feel that this would be beneficial. Specifically when we create alpha or beta builds, windows will install it over the users main firefly application. Switching from the NSIS one click installer to the multi step will allow the user to select the location where they want to install.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

Built branch using github actions and test install on windows machine.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
