### PR TITLE
Feat: refactor tooltip component

### DIFF
--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-    import { tick } from 'svelte'
     import { get } from 'svelte/store'
     import { Icon, Text, Tooltip } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
@@ -74,28 +73,7 @@
     $: showWarningState = isPartiallyStaked || isBelowMinimumStakingRewards
 
     let showTooltip = false
-    let iconBox
-    let parentWidth = 0
-    let parentLeft = 0
-    let parentTop = 0
-
-    $: iconBox, showTooltip, void refreshIconBox()
-
-    const refreshIconBox = async (): Promise<void> => {
-        if (!iconBox || !showTooltip) return
-
-        await tick()
-
-        parentWidth = iconBox?.offsetWidth / 2 ?? 0
-        parentLeft = iconBox?.getBoundingClientRect().left ?? 0
-
-        /**
-         * CAUTION: The top requires a specific multiplier that
-         * does seem to play nicely with responsiveness.
-         */
-        const top = iconBox?.getBoundingClientRect().top ?? 0
-        parentTop = top * 1.15
-    }
+    let tooltipAnchor
 
     const toggleTooltip = (): void => {
         showTooltip = !showTooltip
@@ -118,7 +96,6 @@
         }
     }
 
-    let tooltipText
     $: tooltipText = getLocalizedTooltipText($participationOverview)
 
     const getLocalizedTooltipText = (overview: ParticipationOverview): { title: string; body: string } => {
@@ -205,7 +182,7 @@
     <div class="mb-2 w-full flex flex-row justify-between items-start space-x-1.5">
         <div class="flex flex-row space-x-1.5 items-start">
             {#if showWarningState}
-                <div bind:this={iconBox} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
+                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
                     <Icon icon="exclamation" width="16" height="16" classes="mt-0.5 fill-current text-gray-800" />
                 </div>
             {:else if isStaked}
@@ -254,7 +231,7 @@
     </div>
 </button>
 {#if showTooltip}
-    <Tooltip {parentTop} {parentLeft} {parentWidth} position="right">
+    <Tooltip anchor={tooltipAnchor} position="right">
         <Text type="p" classes="text-gray-900 bold mb-1 text-left">{tooltipText?.title}</Text>
         <Text type="p" secondary classes="text-left">{tooltipText?.body}</Text>
     </Tooltip>

--- a/packages/shared/components/BalanceSummary.svelte
+++ b/packages/shared/components/BalanceSummary.svelte
@@ -2,22 +2,16 @@
     import { Unit } from '@iota/unit-converter'
     import { Text, Tooltip } from 'shared/components'
     import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
-    import { tick } from 'svelte'
 
     export let color = 'blue' // TODO: profiles will have different colors
 
     export let balanceRaw = 0
     export let balanceFiat = 0
 
-    let balanceBox
-    let parentWidth = 0
-    let parentLeft = 0
-    let parentTop = 0
+    let tooltipAnchor
 
     let showTooltip = false
     let showPreciseBalance = false
-
-    $: balanceBox, showTooltip, showPreciseBalance, void refreshParentBox()
 
     function toggleTooltip() {
         showTooltip = !showTooltip
@@ -26,21 +20,11 @@
     function togglePreciseBalance() {
         showPreciseBalance = !showPreciseBalance
     }
-
-    async function refreshParentBox() {
-        if (!balanceBox || !showTooltip) {
-            return
-        }
-        await tick()
-        parentWidth = balanceBox?.offsetWidth / 2 ?? 0
-        parentLeft = balanceBox?.getBoundingClientRect().left ?? 0
-        parentTop = balanceBox?.getBoundingClientRect().top ?? 0
-    }
 </script>
 
 <div class="flex items-start flex-col flex-wrap space-y-1.5">
     <balance-box
-        bind:this={balanceBox}
+        bind:this={tooltipAnchor}
         on:mouseenter={toggleTooltip}
         on:mouseleave={toggleTooltip}
         on:click={togglePreciseBalance}>
@@ -52,7 +36,7 @@
         <Text type="p" overrideColor smaller classes="text-{color}-200 dark:text-blue-300">{balanceFiat}</Text>
     {/if}
     {#if showTooltip}
-        <Tooltip {parentTop} {parentLeft} {parentWidth}>
+        <Tooltip anchor={tooltipAnchor} refresh={showPreciseBalance} position="top">
             <Text type="p">
                 {!showPreciseBalance ? formatUnitPrecision(balanceRaw, Unit.Mi) : formatUnitBestMatch(balanceRaw, true, 3)}
             </Text>

--- a/packages/shared/components/SpentAddress.svelte
+++ b/packages/shared/components/SpentAddress.svelte
@@ -24,18 +24,8 @@
 
     export let onClick = (): void => {}
 
-    let showErrorTooltip = false
-    let showRiskTooltip = false
-    let errorBox
-    let riskBox
-    let parentTop,
-        parentLeft,
-        parentWidth = 0
-
-    enum TooltipType {
-        Risk,
-        Error,
-    }
+    let showTooltip = false
+    let tooltipAnchor
 
     let riskColor = 'gray'
     let localeRiskLevel = ''
@@ -46,20 +36,8 @@
         AvailableExchangeRates.USD
     )
 
-    function toggleTooltip(type: TooltipType) {
-        if (risk) {
-            if (type === TooltipType.Risk) {
-                showRiskTooltip = !showRiskTooltip
-                parentWidth = riskBox.offsetWidth / 2
-                parentLeft = riskBox.getBoundingClientRect().left
-                parentTop = riskBox.getBoundingClientRect().top
-            } else if (type === TooltipType.Error) {
-                showErrorTooltip = !showErrorTooltip
-                parentWidth = errorBox.offsetWidth / 2
-                parentLeft = errorBox.getBoundingClientRect().left
-                parentTop = errorBox.getBoundingClientRect().top
-            }
-        }
+    function toggleTooltip(): void {
+        showTooltip = !showTooltip
     }
 
     onMount(() => {
@@ -134,18 +112,21 @@
         </div>
         {#if showRiskLevel}
             <risk-meter
-                bind:this={riskBox}
-                on:mouseenter={() => toggleTooltip(TooltipType.Risk)}
-                on:mouseleave={() => toggleTooltip(TooltipType.Risk)}
-                class="flex flex-row items-center space-x-0.5">
-                <Icon icon="info" classes="mr-1 text-gray-800 dark:text-white" width={20} height={20} />
-                {#each Array(Object.keys(RiskLevel).length / 2) as _, i}
-                    <span
-                        class="h-4 w-1 rounded-2xl {i <= riskBars - 1 ? `bg-${riskColor}-500` : 'bg-gray-300 dark:bg-gray-700'}" />
-                {/each}
+                on:mouseenter={toggleTooltip}
+                on:mouseleave={toggleTooltip}
+                class="flex flex-row items-center">
+                <div bind:this={tooltipAnchor}>
+                    <Icon icon="info" classes="text-gray-800 dark:text-white" width={20} height={20} />
+                </div>
+                <div class="ml-2 flex flex-row items-center space-x-0.5">
+                    {#each Array(Object.keys(RiskLevel).length / 2) as _, i}
+                        <span
+                            class="h-4 w-1 rounded-2xl {i <= riskBars - 1 ? `bg-${riskColor}-500` : 'bg-gray-300 dark:bg-gray-700'}" />
+                    {/each}
+                </div>
             </risk-meter>
-            {#if showRiskTooltip && risk}
-                <Tooltip {parentTop} {parentLeft} {parentWidth}>
+            {#if showTooltip && risk}
+                <Tooltip anchor={tooltipAnchor}>
                     <Text>{locale('tooltips.risk.title', { values: { risk: locale(`tooltips.risk.${localeRiskLevel}`) } })}</Text>
                 </Tooltip>
             {/if}

--- a/packages/shared/components/StakingIndicator.svelte
+++ b/packages/shared/components/StakingIndicator.svelte
@@ -1,36 +1,17 @@
 <script lang="typescript">
-    import { tick } from 'svelte'
     import { Icon, Text, Tooltip } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
     import { stakedAccounts, stakingEventState } from 'shared/lib/participation/stores'
     import { ParticipationEventState } from 'shared/lib/participation/types'
 
-    let indicatorIcon
     $: indicatorIcon = getIndicatorIcon($stakingEventState, $stakedAccounts.length > 0)
 
-    let indicatorText
     $: indicatorText = getLocalizedIndicatorText($stakingEventState, $stakedAccounts.length > 0)
 
-    let tooltipText
     $: tooltipText = getLocalizedTooltipText($stakingEventState, $stakedAccounts.length > 0)
 
     let showTooltip = false
-    let indicatorBox
-    let parentWidth = 0
-    let parentLeft = 0
-    let parentTop = 0
-
-    $: indicatorBox, showTooltip, void refreshIndicatorBox()
-
-    async function refreshIndicatorBox() {
-        if (!indicatorBox || !showTooltip) {
-            return
-        }
-        await tick()
-        parentWidth = indicatorBox?.offsetWidth / 2
-        parentLeft = indicatorBox?.getBoundingClientRect().left ?? 0
-        parentTop = indicatorBox?.getBoundingClientRect().top ?? 0
-    }
+    let tooltipAnchor
 
     const toggleTooltip = (): void => {
         showTooltip = !showTooltip
@@ -98,14 +79,14 @@
     on:mouseenter={toggleTooltip}
     on:mouseleave={toggleTooltip}
 >
-    <div bind:this={indicatorBox} class="mr-1">
+    <div bind:this={tooltipAnchor} class="mr-1">
         <Icon icon='info-filled' width="16" height="16" classes="text-gray-600" />
     </div>
     <Text type="p">{indicatorText}</Text>
     <Icon icon={indicatorIcon} width="24" height="24" classes="text-blue-500" />
 </div>
 {#if showTooltip}
-    <Tooltip {parentTop} {parentLeft} {parentWidth} position="bottom">
+    <Tooltip anchor={tooltipAnchor} position="bottom">
         <Text type="p" classes="text-gray-900 bold mb-1 text-left">{tooltipText?.title}</Text>
         <Text type="p" secondary classes="text-left">{tooltipText?.body}</Text>
     </Tooltip>

--- a/packages/shared/components/Tooltip.svelte
+++ b/packages/shared/components/Tooltip.svelte
@@ -17,7 +17,7 @@
     let tooltip: HTMLElement
     let top = 0
     let left = 0
-    let anchorBox: {
+    const anchorBox: {
         top: number
         left: number
         width: number

--- a/packages/shared/components/TransactionItem.svelte
+++ b/packages/shared/components/TransactionItem.svelte
@@ -34,16 +34,10 @@
     const balanceString = `${formatUnitBestMatch(balance, true, 3)} • ${fiatBalance}`
 
     let showTooltip = false
-    let errorBox
-    let tooltipTop,
-        tooltipLeft,
-        iconWidth = 0
+    let tooltipAnchor
 
     function toggleShow() {
         showTooltip = !showTooltip
-        iconWidth = errorBox.offsetWidth / 2
-        tooltipLeft = errorBox.getBoundingClientRect().left
-        tooltipTop = errorBox.getBoundingClientRect().top
     }
 </script>
 
@@ -65,14 +59,14 @@
             {:else if status === -1}
                 <div class="flex items-center relative">
                     <Text type="p" secondary smaller classes="mr-3">{locale('views.migrate.migrationFailed')}</Text>
-                    <div class="relative" on:mouseenter={toggleShow} on:mouseleave={toggleShow} bind:this={errorBox}>
+                    <div class="relative" on:mouseenter={toggleShow} on:mouseleave={toggleShow} bind:this={tooltipAnchor}>
                         <Icon icon="status-error" classes="text-white bg-red-500 rounded-full " />
-                        {#if showTooltip && errorText}
-                            <Tooltip topOffset={tooltipTop} leftOffset={tooltipLeft} elementWidth={iconWidth}>
-                                <Text>{errorText}</Text>
-                            </Tooltip>
-                        {/if}
                     </div>
+                    {#if showTooltip && errorText}
+                        <Tooltip anchor={tooltipAnchor}>
+                            <Text>{errorText}</Text>
+                        </Tooltip>
+                    {/if}
                 </div>
             {/if}
         </div>

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-    import { tick } from 'svelte'
     import { get } from 'svelte/store'
     import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
@@ -26,19 +25,14 @@
 
     $: $participationOverview, $stakedAccounts, $partiallyStakedAccounts
 
-    let showSpinner
     $: showSpinner = !$popupState.active && $participationAction && $accountToParticipate
 
-    let canParticipateInEvent
     $: canParticipateInEvent = isStakingPossible($stakingEventState)
 
-    let canStakeAnAccount
     $: canStakeAnAccount = get($wallet.accounts).filter((wa) => canAccountParticipate(wa)).length > 0
 
-    let isStaked
     $: isStaked = $stakedAmount > 0 && canParticipateInEvent
 
-    let isPartiallyStaked
     $: isPartiallyStaked = $partiallyStakedAccounts.length > 0 && canParticipateInEvent
 
     let canParticipateWithNode = false
@@ -50,29 +44,7 @@
             showTooltip = false
     }
 
-    let iconBox
-    let parentWidth = 0
-    let parentLeft = 0
-    let parentTop = 0
-
-    $: iconBox, showTooltip, void refreshIconBox()
-
-    const refreshIconBox = async (): Promise<void> => {
-        if (!iconBox || !showTooltip) return
-
-        await tick()
-
-        parentWidth = iconBox?.offsetWidth / 2 ?? 0
-        parentLeft = iconBox?.getBoundingClientRect().left ?? 0
-
-        /**
-         * CAUTION: The top requires a specific multiplier that
-         * does seem to play nicely with responsiveness.
-         */
-        const top = iconBox?.getBoundingClientRect().top ?? 0
-        const topMultiplier = isPartiallyStaked ? 1.6 : -10000
-        parentTop = top * topMultiplier
-    }
+    let tooltipAnchor
 
     const toggleTooltip = (): void => {
         showTooltip = !showTooltip
@@ -103,7 +75,7 @@
             </Text>
             {#if isPartiallyStaked}
                 <div
-                    bind:this={iconBox}
+                    bind:this={tooltipAnchor}
                     on:mouseenter={toggleTooltip}
                     on:mouseleave={toggleTooltip}
                 >
@@ -138,7 +110,7 @@
     </Button>
 </div>
 {#if showTooltip}
-    <Tooltip {parentTop} {parentLeft} {parentWidth} position="right">
+    <Tooltip anchor={tooltipAnchor} position="right">
         {#if isPartiallyStaked}
             <Text type="p" classes="text-gray-900 bold mb-1 text-left">
                 {localize(


### PR DESCRIPTION
# Description of change

This PR aims to refactor the `Tooltip` component and its usage. You dont need to calculate the bounding boxes of the parent anymore, just have to pass an `anchor` component from which the `Tooltip` will position relative to. 

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Ubuntu 20.04. Desktop.
I tried covering all the cases and refactor all its usage.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
