### PR TITLE
fix: set primary node on new profile

### DIFF
--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -29,13 +29,19 @@ export const CHRYSALIS_DEVNET_BECH32_HRP = 'atoi'
  *
  * @returns {NetworkConfig}
  */
-export const getOfficialNetworkConfig = (type: NetworkType): NetworkConfig => ({
-    network: getOfficialNetwork(type),
-    nodes: getOfficialNodes(type),
-    automaticNodeSelection: true,
-    includeOfficialNodes: true,
-    localPow: true,
-})
+export const getOfficialNetworkConfig = (type: NetworkType): NetworkConfig => {
+    const officialNodes = getOfficialNodes(type)
+    const randIdx = Math.floor(Math.random() * officialNodes.length)
+    const officialNodesWithPrimary = officialNodes.map((n, idx) => ({ ...n, isPrimary: idx === randIdx }))
+
+    return {
+        network: getOfficialNetwork(type),
+        nodes: officialNodesWithPrimary,
+        automaticNodeSelection: true,
+        includeOfficialNodes: true,
+        localPow: true,
+    }
+}
 
 /**
  * Constructs an official IOTA network object given the type of network

--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -30,13 +30,9 @@ export const CHRYSALIS_DEVNET_BECH32_HRP = 'atoi'
  * @returns {NetworkConfig}
  */
 export const getOfficialNetworkConfig = (type: NetworkType): NetworkConfig => {
-    const officialNodes = getOfficialNodes(type)
-    const randIdx = Math.floor(Math.random() * officialNodes.length)
-    const officialNodesWithPrimary = officialNodes.map((n, idx) => ({ ...n, isPrimary: idx === randIdx }))
-
     return {
         network: getOfficialNetwork(type),
-        nodes: officialNodesWithPrimary,
+        nodes: setRandomPrimaryNode(getOfficialNodes(type)),
         automaticNodeSelection: true,
         includeOfficialNodes: true,
         localPow: true,
@@ -374,12 +370,16 @@ export const ensureSinglePrimaryNode = (nodes: Node[]): Node[] => {
 
     const numPrimaryNodes = nodes.filter((n) => n.isPrimary).length
     if (numPrimaryNodes === 0) {
-        const randIdx = Math.floor(Math.random() * nodes.length)
-        return nodes.map((n, idx) => ({ ...n, isPrimary: idx === randIdx }))
+        return setRandomPrimaryNode(nodes)
     } else if (numPrimaryNodes === 1) {
         return nodes
     } else if (numPrimaryNodes > 1) {
         const activeNode = nodes.find((n) => n.isPrimary)
         return nodes.map((n, idx) => ({ ...n, isPrimary: n.url === activeNode.url }))
     }
+}
+
+const setRandomPrimaryNode = (nodes: Node[]): Node[] => {
+    const randIdx = Math.floor(Math.random() * nodes.length)
+    return nodes.map((n, idx) => ({ ...n, isPrimary: idx === randIdx }))
 }


### PR DESCRIPTION
# Description of change

Issue was that staking wasn't loading when the profile was new, until the user went to the networking settings. This was because when the profile is first created it doesn't set any of the official nodes in the official network config to the primary node. I added some code to select a random one as the primary node.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

Tested manually on MacOS by recovering a profile using a 24 word mnemonic.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
