### PR TITLE
fix: make close settings go back to previous tab

### DIFF
--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -7,7 +7,7 @@
     import { NETWORK_HEALTH_COLORS, networkStatus } from 'shared/lib/networkStatus'
     import { isStakingFeatureNew } from 'shared/lib/participation/stores'
     import { activeProfile } from 'shared/lib/profile'
-    import { dashboardRoute, settingsRoute, resetWalletRoute } from 'shared/lib/router'
+    import { dashboardRoute, settingsRoute, resetWalletRoute, previousDashboardRoute } from 'shared/lib/router'
     import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
 
     export let locale: Locale
@@ -30,6 +30,7 @@
     })
 
     function openSettings() {
+        previousDashboardRoute.set(get(dashboardRoute))
         dashboardRoute.set(Tabs.Settings)
         settingsRoute.set(SettingsRoutes.Init)
     }

--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -65,6 +65,11 @@ const history = writable<string[]>([])
 export const dashboardRoute = writable<Tabs>(Tabs.Wallet)
 
 /**
+ * Previous dashboard tab
+ */
+export const previousDashboardRoute = writable<Tabs>(undefined)
+
+/**
  * Ledger setup route
  */
 export const ledgerRoute = writable<LedgerRoutes>(LedgerRoutes.LegacyIntro)

--- a/packages/shared/routes/dashboard/settings/Settings.svelte
+++ b/packages/shared/routes/dashboard/settings/Settings.svelte
@@ -1,13 +1,12 @@
 <script lang="typescript">
     import { Icon } from 'shared/components'
-    import { appSettings } from 'shared/lib/appSettings'
     import { isLocaleLoaded } from 'shared/lib/i18n'
-    import { accountRoute, dashboardRoute, settingsChildRoute, settingsRoute, walletRoute } from 'shared/lib/router'
-    import { AccountRoutes, SettingsRoutes, Tabs, WalletRoutes } from 'shared/lib/typings/routes'
-    import { selectedAccountId } from 'shared/lib/wallet'
+    import { dashboardRoute,previousDashboardRoute,settingsChildRoute,settingsRoute } from 'shared/lib/router'
+    import type { Locale } from 'shared/lib/typings/i18n'
+    import { SettingsRoutes } from 'shared/lib/typings/routes'
     import { onDestroy } from 'svelte'
-    import { SettingsHome, SettingsViewer } from './views'
-    import { Locale } from 'shared/lib/typings/i18n'
+    import { get } from 'svelte/store'
+    import { SettingsHome,SettingsViewer } from './views'
 
     export let locale: Locale
 
@@ -15,10 +14,8 @@
     export let handleClose
 
     function closeSettings() {
-        dashboardRoute.set(Tabs.Wallet)
-        walletRoute.set(WalletRoutes.Init)
-        accountRoute.set(AccountRoutes.Init)
-        selectedAccountId.set(null)
+        dashboardRoute.set(get(previousDashboardRoute))
+        previousDashboardRoute.set(undefined)
     }
 
     onDestroy(() => {


### PR DESCRIPTION
# Description of change

Added a store to keep track of the previous tab. This way when closing settings etc we don't need to default to the wallet tab home view, we can just go to the previous tab as expected by the user.

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Fix (a change which fixes an issue)

## How the change has been tested

Manually on MacOS

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
