### PR TITLE
fix: prevent staking on an account while it has unconfirmed transactions

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -5,7 +5,7 @@
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'
     import { showAppNotification } from 'shared/lib/notifications'
     import {
-        canAccountParticipate,
+        getAccountParticipationAbility,
         canParticipate,
         getStakedFunds,
         getUnstakedFunds,
@@ -223,7 +223,7 @@
 <Text type="p" secondary classes="mt-6 mb-2">{locale('popups.stakingManager.description')}</Text>
 <div class="staking flex flex-col scrollable-y">
     {#each $accounts as account}
-        {#if canAccountParticipate(account) === AccountParticipationAbility.Yes || canAccountParticipate(account) === AccountParticipationAbility.NoHasPendingTransaction}
+        {#if getAccountParticipationAbility(account) === AccountParticipationAbility.Yes || getAccountParticipationAbility(account) === AccountParticipationAbility.NoHasPendingTransaction}
             <div
                 class="w-full mt-4 flex flex-col rounded-xl border border-1 border-solid border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-gray-500 focus:hover:border-gray-700">
                 <div class="w-full space-x-4 px-5 py-3 flex flex-row justify-between items-center">
@@ -277,7 +277,7 @@
                         {/if}
                     </div>
                     <Button
-                        disabled={$isPerformingParticipation || canAccountParticipate(account) === AccountParticipationAbility.NoHasPendingTransaction}
+                        disabled={$isPerformingParticipation || getAccountParticipationAbility(account) === AccountParticipationAbility.NoHasPendingTransaction}
                         secondary={isAccountStaked(account?.id)}
                         onClick={() => (isAccountStaked(account?.id) ? handleUnstakeClick(account) : handleStakeClick(account))}>
                         {#if $accountToParticipate?.id === account?.id && $accountToParticipate && $participationAction}
@@ -301,7 +301,7 @@
                                 </Text>
                             </Text>
                         </div>
-                        <Button disabled={$isPerformingParticipation || canAccountParticipate(account) === AccountParticipationAbility.NoHasPendingTransaction} onClick={() => handleStakeClick(account)}>
+                        <Button disabled={$isPerformingParticipation || getAccountParticipationAbility(account) === AccountParticipationAbility.NoHasPendingTransaction} onClick={() => handleStakeClick(account)}>
                             {locale('actions.merge')}
                         </Button>
                     </div>

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -24,7 +24,7 @@
         stakedAmount,
         stakingEventState,
     } from 'shared/lib/participation/stores'
-    import { Participation, ParticipationAction } from 'shared/lib/participation/types'
+    import { AccountParticipationAbility, Participation, ParticipationAction } from 'shared/lib/participation/types'
     import { openPopup, popupState } from 'shared/lib/popup'
     import { activeProfile, isSoftwareProfile } from 'shared/lib/profile'
     import { checkStronghold } from 'shared/lib/stronghold'
@@ -45,7 +45,8 @@
     let canStake
     $: canStake = canParticipate($stakingEventState)
 
-    let accounts = get($wallet.accounts)
+    let { accounts } = $wallet
+    
     const hasStakedAccounts = $stakedAccounts.length > 0
 
     let pendingParticipationIds = []
@@ -221,8 +222,8 @@
 <Text type="h5">{locale(`popups.stakingManager.titleWith${hasStakedAccounts ? '' : 'No'}Stake`)}</Text>
 <Text type="p" secondary classes="mt-6 mb-2">{locale('popups.stakingManager.description')}</Text>
 <div class="staking flex flex-col scrollable-y">
-    {#each accounts as account}
-        {#if canAccountParticipate(account)}
+    {#each $accounts as account}
+        {#if canAccountParticipate(account) === AccountParticipationAbility.Yes || canAccountParticipate(account) === AccountParticipationAbility.NoHasPendingTransaction}
             <div
                 class="w-full mt-4 flex flex-col rounded-xl border border-1 border-solid border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-gray-500 focus:hover:border-gray-700">
                 <div class="w-full space-x-4 px-5 py-3 flex flex-row justify-between items-center">
@@ -276,7 +277,7 @@
                         {/if}
                     </div>
                     <Button
-                        disabled={$isPerformingParticipation}
+                        disabled={$isPerformingParticipation || canAccountParticipate(account) === AccountParticipationAbility.NoHasPendingTransaction}
                         secondary={isAccountStaked(account?.id)}
                         onClick={() => (isAccountStaked(account?.id) ? handleUnstakeClick(account) : handleStakeClick(account))}>
                         {#if $accountToParticipate?.id === account?.id && $accountToParticipate && $participationAction}
@@ -300,7 +301,7 @@
                                 </Text>
                             </Text>
                         </div>
-                        <Button disabled={$isPerformingParticipation} onClick={() => handleStakeClick(account)}>
+                        <Button disabled={$isPerformingParticipation || canAccountParticipate(account) === AccountParticipationAbility.NoHasPendingTransaction} onClick={() => handleStakeClick(account)}>
                             {locale('actions.stake')}
                         </Button>
                     </div>

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -94,11 +94,7 @@ export const canParticipate = (eventState: ParticipationEventState): boolean => 
 export const canAccountParticipate = (account: WalletAccount): AccountParticipationAbility => {
     if (account?.rawIotaBalance < DUST_THRESHOLD) {
         return AccountParticipationAbility.NoHasDustAmount
-    } else if (
-        account?.messages.some((message) => {
-            return !message.confirmed
-        })
-    ) {
+    } else if (account?.messages.some((message) => !message.confirmed)) {
         return AccountParticipationAbility.NoHasPendingTransaction
     } else {
         return AccountParticipationAbility.Yes

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -11,7 +11,7 @@ import {
     participationOverview,
     pendingParticipations,
 } from './stores'
-import { ParticipationEventState, Participation } from './types'
+import { ParticipationEventState, Participation, AccountParticipationAbility } from './types'
 
 let participationPollInterval
 
@@ -91,7 +91,19 @@ export const canParticipate = (eventState: ParticipationEventState): boolean => 
  *
  * @returns {boolean}
  */
-export const canAccountParticipate = (account: WalletAccount): boolean => account?.rawIotaBalance >= DUST_THRESHOLD
+export const canAccountParticipate = (account: WalletAccount): AccountParticipationAbility => {
+    if (account?.rawIotaBalance < DUST_THRESHOLD) {
+        return AccountParticipationAbility.NoHasDustAmount
+    } else if (
+        account?.messages.some((message) => {
+            return !message.confirmed
+        })
+    ) {
+        return AccountParticipationAbility.NoHasPendingTransaction
+    } else {
+        return AccountParticipationAbility.Yes
+    }
+}
 
 /**
  * Extracts participations from indexation payload

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -85,13 +85,13 @@ export const canParticipate = (eventState: ParticipationEventState): boolean => 
 /**
  * Determines whether an account can participate in an event.
  *
- * @method canAccountParticipate
+ * @method getAccountParticipationAbility
  *
  * @param {WalletAccount} account
  *
  * @returns {boolean}
  */
-export const canAccountParticipate = (account: WalletAccount): AccountParticipationAbility => {
+export const getAccountParticipationAbility = (account: WalletAccount): AccountParticipationAbility => {
     if (account?.rawIotaBalance < DUST_THRESHOLD) {
         return AccountParticipationAbility.NoHasDustAmount
     } else if (account?.messages.some((message) => !message.confirmed)) {

--- a/packages/shared/lib/participation/types.ts
+++ b/packages/shared/lib/participation/types.ts
@@ -1,5 +1,11 @@
 import type { Message } from '../typings/message'
 
+export enum AccountParticipationAbility {
+    Yes = 'yes',
+    NoHasDustAmount = 'noHasDustAmount',
+    NoHasPendingTransaction = 'noHasPendingTransaction',
+}
+
 /**
  * The official staking airdrops, Assembly (ASMB) and Shimmer (SMR).
  */

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -21,7 +21,7 @@
         stakingEventState,
         unstakedAmount,
     } from 'shared/lib/participation/stores'
-    import { ParticipationAction, ParticipationEventState } from 'shared/lib/participation/types'
+    import { AccountParticipationAbility, ParticipationAction, ParticipationEventState } from 'shared/lib/participation/types'
 
     $: $participationOverview, $stakedAccounts, $partiallyStakedAccounts
 
@@ -29,7 +29,8 @@
 
     $: canParticipateInEvent = isStakingPossible($stakingEventState)
 
-    $: canStakeAnAccount = get($wallet.accounts).filter((wa) => canAccountParticipate(wa)).length > 0
+    let { accounts } = $wallet
+    $: canStakeAnAccount = $accounts.some((wa) => canAccountParticipate(wa) === AccountParticipationAbility.Yes)
 
     $: isStaked = $stakedAmount > 0 && canParticipateInEvent
 

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -9,7 +9,7 @@
     import { formatUnitBestMatch } from 'shared/lib/units'
     import { wallet } from 'shared/lib/wallet'
 
-    import { canAccountParticipate, isStakingPossible } from 'shared/lib/participation'
+    import { getAccountParticipationAbility, isStakingPossible } from 'shared/lib/participation'
     import {
         accountToParticipate,
         partiallyStakedAccounts,
@@ -30,7 +30,7 @@
     $: canParticipateInEvent = isStakingPossible($stakingEventState)
 
     let { accounts } = $wallet
-    $: canStakeAnAccount = $accounts.some((wa) => canAccountParticipate(wa) === AccountParticipationAbility.Yes)
+    $: canStakeAnAccount = $accounts.some((wa) => getAccountParticipationAbility(wa) === AccountParticipationAbility.Yes)
 
     $: isStaked = $stakedAmount > 0 && canParticipateInEvent
 


### PR DESCRIPTION
# Description of change

This fix prevents a user from staking on an account while the account has an unconfirmed transaction.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

Tested Manually on MacOS, by sending internal and external transactions and visiting the staking page as soon as they are sent or pending in account. 

Test cases:
- All empty accounts
- All empty accounts with pending transactions
- Some non empty accounts each with pending transactions
- Some non empty accounts with some have pending transactions
- All non empty accounts with some have pending transactions
- All non empty accounts all with pending transactions
- All non empty accounts with partially staked account having pending transaction

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
