### PR TITLE
Feat: Polish staking UI

### DIFF
--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
-    import { get } from 'svelte/store'
     import { Icon, Text, Tooltip } from 'shared/components'
+    import { appSettings } from 'shared/lib/appSettings'
     import { localize } from 'shared/lib/i18n'
     import {
         formatStakingAirdropReward,
@@ -21,10 +21,9 @@
     import { ParticipationEventState, ParticipationOverview, StakingAirdrop } from 'shared/lib/participation/types'
     import { openPopup } from 'shared/lib/popup'
     import { getBestTimeDuration } from 'shared/lib/time'
+    import type { WalletAccount } from 'shared/lib/typings/wallet'
     import { formatUnitBestMatch } from 'shared/lib/units'
     import { capitalize } from 'shared/lib/utils'
-    import { wallet } from 'shared/lib/wallet'
-    import type { WalletAccount } from 'shared/lib/typings/wallet'
 
     export let name = ''
     export let balance = ''
@@ -37,6 +36,8 @@
     export let disabled = false
 
     export let onClick = (): void | string => ''
+
+    $: darkModeEnabled = $appSettings.darkMode
 
     if (airdrop) {
         disabled = true
@@ -173,59 +174,117 @@
         &.size-l {
             min-height: 140px;
         }
+        &.partial-stake {
+            @apply border;
+            @apply border-solid;
+            @apply border-orange-500;
+            &:not(:hover) {
+                @apply bg-transparent;
+            }
+            &:hover {
+                @apply border-transparent;
+            }
+            &.darkmode {
+                @apply border;
+                @apply border-solid;
+                @apply border-orange-500;
+                &:hover {
+                    @apply border-transparent;
+                }
+            }
+        }
+        &.staked:not(.partial-stake) {
+            @apply border;
+            @apply border-solid;
+            @apply border-gray-200;
+            &:not(:hover) {
+                @apply bg-transparent;
+            }
+            &:hover {
+                @apply border-transparent;
+            }
+            &.darkmode {
+                @apply border-gray-900;
+            }
+        }
+        &.airdrop {
+            @apply opacity-50;
+            @apply border;
+            @apply border-solid;
+            @apply border-gray-200;
+            &:not(:hover) {
+                @apply bg-transparent;
+            }
+            &:hover {
+                @apply bg-gray-500;
+            }
+            &.darkmode {
+                @apply bg-gray-900;
+                @apply border-transparent;
+                &:hover {
+                    @apply bg-gray-600;
+                }
+            }
+        }
+        &.hidden-wallet {
+            @apply opacity-50;
+        }
     }
 </style>
 
 <button
     on:click={handleTileClick}
-    class="size-{size} group rounded-xl {showWarningState ? 'bg-yellow-100 hover:bg-yellow-400' : `border-gray-100 dark:border-gray-900 hover:bg-${color}-500 ${isStaked ? `border border-1 border-solid border-gray-200 dark:border-gray-900 hover:border-${color}-500` : 'bg-gray-100 dark:bg-gray-900'}`} font-400 flex flex-col justify-between text-left p-{size === 's' ? '3' : '6'} {hidden ? 'opacity-50' : ''} {airdrop ? 'opacity-50 bg-gray-100 dark:bg-gray-900 hover:bg-gray-700 dark:hover:bg-gray-600' : ''}">
+    class="bg-gray-100 dark:bg-gray-900 hover:bg-{color}-500 size-{size} group rounded-xl font-400 flex flex-col justify-between text-left p-{size === 's' ? '3' : '6'}"
+    class:staked={isStaked}
+    class:partial-stake={showWarningState}
+    class:airdrop
+    class:hidden-wallet={hidden}
+    class:darkmode={darkModeEnabled}>
     <div class="mb-2 w-full flex flex-row justify-between items-start space-x-1.5">
         <div class="flex flex-row space-x-1.5 items-start">
             {#if showWarningState}
                 <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
-                    <Icon icon="exclamation" width="16" height="16" classes="mt-0.5 fill-current text-gray-800" />
+                    <Icon
+                        icon="exclamation"
+                        width="16"
+                        height="16"
+                        classes="mt-0.5 fill-current text-orange-500 group-hover:text-white" />
                 </div>
             {:else if isStaked}
                 <Icon
                     icon="tokens"
                     width="16"
                     height="16"
-                    classes="fill-current mt-0.5 text-gray-800 dark:text-white" />
+                    classes="fill-current mt-0.5 text-gray-800 dark:text-white group-hover:text-white" />
             {/if}
             <Text
                 bold
                 smaller={size === 's'}
                 overrideColor
-                classes="inline text-gray-800 {showWarningState ? '' : 'dark:text-white group-hover:text-white'} overflow-hidden overflow-ellipsis">
+                classes="inline text-gray-800 dark:text-white group-hover:text-white overflow-hidden overflow-ellipsis">
                 {getName()}
             </Text>
         </div>
         {#if airdrop}
             <Icon
                 icon={airdrop}
-                classes="fill-current text-gray-{disabled ? '500' : '400'} dark:text-gray-700"
+                classes="fill-current text-gray-{disabled ? '500' : '400'} dark:text-gray-700 group-hover:text-white"
                 width={size === 's' ? 13 : 18}
                 height={size === 's' ? 13 : 18} />
         {:else if ledger}
             <Icon
                 icon="ledger"
-                classes="fill-current text-gray-400 dark:text-gray-700"
+                classes="fill-current text-gray-800 dark:text-white group-hover:text-white"
                 width={size === 's' ? 13 : 18}
                 height={size === 's' ? 13 : 18} />
         {/if}
     </div>
     <div
         class="flex {size === 'l' ? 'flex-row space-x-4' : 'flex-col space-y-1'} justify-between w-full flex-{size === 'l' ? 'nowrap' : 'wrap'}">
-        <Text
-            smaller
-            overrideColor
-            classes="block text-gray-800 {showWarningState ? '' : 'dark:text-white group-hover:text-white'}">
+        <Text smaller overrideColor classes="block text-gray-800 dark:text-white group-hover:text-white">
             {#if airdrop}{formatStakingAirdropReward(airdrop, Number(balance), 6)}{:else}{balance}{/if}
         </Text>
-        <Text
-            smaller
-            overrideColor
-            classes="block text-blue-500 dark:text-gray-600 {showWarningState ? '' : 'group-hover:text-white'}">
+        <Text smaller overrideColor classes="block text-blue-500 dark:text-gray-600 group-hover:text-white">
             {balanceEquiv}
         </Text>
     </div>

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -177,7 +177,7 @@
         &.partial-stake {
             @apply border;
             @apply border-solid;
-            @apply border-orange-500;
+            @apply border-yellow-600;
             &:not(:hover) {
                 @apply bg-transparent;
             }
@@ -187,7 +187,7 @@
             &.darkmode {
                 @apply border;
                 @apply border-solid;
-                @apply border-orange-500;
+                @apply border-yellow-600;
                 &:hover {
                     @apply border-transparent;
                 }
@@ -248,7 +248,7 @@
                         icon="exclamation"
                         width="16"
                         height="16"
-                        classes="mt-0.5 fill-current text-orange-500 group-hover:text-white" />
+                        classes="mt-0.5 fill-current text-yellow-600 group-hover:text-white" />
                 </div>
             {:else if isStaked}
                 <Icon

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -241,7 +241,7 @@
     class:hidden-wallet={hidden}
     class:darkmode={darkModeEnabled}>
     <div class="mb-2 w-full flex flex-row justify-between items-start space-x-1.5">
-        <div class="flex flex-row space-x-1.5 items-start">
+        <div class="flex flex-row space-x-1.5 items-start w-full whitespace-nowrap">
             {#if showWarningState}
                 <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
                     <Icon

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -169,7 +169,7 @@
 <style type="text/scss">
     button {
         height: auto;
-        min-height: 100px;
+        min-height: 110px;
         max-height: 100%;
         &.size-l {
             min-height: 140px;

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -135,7 +135,7 @@
         switch (action) {
             case ParticipationAction.Stake:
             case ParticipationAction.Vote:
-                return 'yellow-600'
+                return 'orange-500'
             case ParticipationAction.Unstake:
             case ParticipationAction.Unvote:
             default:

--- a/packages/shared/components/Button.svelte
+++ b/packages/shared/components/Button.svelte
@@ -65,11 +65,11 @@
                   @apply text-white;
                 }
                 &:hover {
-                  @apply bg-yellow-600;
+                  @apply bg-yellow-700;
                 }
                 &:active,
                 &:focus {
-                  @apply bg-yellow-700;
+                  @apply bg-yellow-800;
                 }
                 &:disabled {
                   @apply pointer-events-none;

--- a/packages/shared/components/ButtonCheckbox.svelte
+++ b/packages/shared/components/ButtonCheckbox.svelte
@@ -20,13 +20,11 @@
     on:click={() => (value = !value)}
     bind:this={buttonElement}
     type="button"
-    class="w-full h-auto flex flex-row p-4 pt-10 pb-10 mb-4 rounded-xl border border-1 border-solid items-center justify-between border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-gray-500 focus:hover:border-gray-700"
+    class="w-full h-auto flex flex-row p-4 pt-10 pb-10 mb-4 rounded-xl border border-1 border-solid items-center space-x-4 border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-gray-500 focus:hover:border-gray-700"
     style="height: 72px">
     <Checkbox bind:checked={value} {round} classes="ml-1 mr-1 pointer-events-none" tabindex={-1} />
-    <div class="flex flex-row items-center">
-        <Text smaller classes="mr-3">
-            <slot />
-        </Text>
-        <Icon {icon} classes="text-blue-500" />
-    </div>
+    <Text smaller classes="mr-3 flex-grow">
+        <slot />
+    </Text>
+    <Icon {icon} classes="text-blue-500" />
 </button>

--- a/packages/shared/components/StakingAirdropIndicator.svelte
+++ b/packages/shared/components/StakingAirdropIndicator.svelte
@@ -38,10 +38,11 @@
 {#if showIndicator}
     <div class="rounded-2xl bg-white bg-opacity-20 px-2 py-1 flex flex-row space-x-2 items-center">
         <span class="relative flex justify-center items-center h-3 w-3">
-            <span
-                class:pulse={isStaked}
-                class="absolute inline-flex h-full w-full rounded-full bg-{isStaked ? 'green' : 'red'}-400
+            {#if isStaked}
+                <span
+                    class="pulse absolute inline-flex h-full w-full rounded-full bg-green-400
                     opacity-75" />
+            {/if}
             <span class="relative inline-flex rounded-full h-2 w-2 bg-{isStaked ? 'green' : 'red'}-600" />
         </span>
         <Text type="p" classes="text-white dark:text-white">

--- a/packages/shared/components/icon/Index.svelte
+++ b/packages/shared/components/icon/Index.svelte
@@ -14,6 +14,10 @@
 <style type="text/scss">
     .boxed {
         border-radius: 0.625rem; // TODO: add to tailwind
+    } 
+    /* Hotfix to avoid the SVG slow transition */
+    svg, svg path {
+        transition: background 0.05s, color 0.05s, border-color 0.05s, opacity 0.05s;
     }
 </style>
 

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -149,9 +149,7 @@
 
     onMount(() => {
         const elems = focusableElements()
-        if (elems && elems.length > 0) {
-            elems[hideClose || elems.length === 1 ? 0 : 1].focus()
-        }
+        elems?.[0]?.focus()
     })
 </script>
 

--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -104,7 +104,7 @@
 <Text type="p" secondary classes="text-center mt-5 mb-6">
     {locale('popups.stakingConfirmation.body')}
 </Text>
-<div class="flex flex-row justify-between items-center mb-6 space-x-2">
+<div class="flex flex-row mb-6 space-x-2 flex-1">
     {#each Object.keys(StakingAirdrop).map((sa) => sa.toLowerCase()) as airdrop}
         <div
             on:click={(activeAirdrops.length > 0 && activeAirdrops.includes(airdrop)) ? () => {} : () => toggleAirdropSelection(airdrop)}
@@ -116,7 +116,7 @@
             </div>
             <Text type="p" secondary>{locale('popups.stakingConfirmation.estimatedAirdrop')}:</Text>
             <Checkbox round bind:checked={airdropSelections[airdrop]} onClick={() => toggleAirdropSelection(airdrop)} disabled={(activeAirdrops.length > 0 && activeAirdrops.includes(airdrop))} classes="my-5" />
-            <Text type="p" classes="font-bold text-lg">
+            <Text type="p" classes="font-bold text-lg w-full break-all">
                 {(airdropSelections[airdrop] ? getRewards(capitalize(airdrop)) : estimateStakingAirdropReward(airdrop, 0, true, 0)).split(' ')[0]}
             </Text>
             <Text type="p" secondary classes="font-bold text-lg">

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -224,7 +224,7 @@
     {#each accounts as account}
         {#if canAccountParticipate(account)}
             <div
-                class="w-full mt-4 flex flex-col rounded-xl border border-1 border-solid border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-gray-500 focus:hover:border-gray-700">
+                class="w-full mt-4 flex flex-col rounded-xl border-2 border-solid border-yellow-600">
                 <div class="w-full space-x-4 px-5 py-3 flex flex-row justify-between items-center">
                     {#if isAccountStaked(account?.id)}
                         <div class="bg-green-100 rounded-2xl">
@@ -286,10 +286,10 @@
                 </div>
                 {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id}
                     <div
-                        class="space-x-4 mx-1 mb-1 px-4 py-3 flex flex-row justify-between items-center rounded-lg bg-yellow-50">
+                        class="space-x-4 mx-2 mb-2 px-4 py-3 flex flex-row justify-between items-center rounded-lg border-2 border-solid border-gray-200 dark:border-gray-600">
                         <Icon icon="exclamation" width="24" height="24" classes="fill-current text-yellow-600" />
                         <div class="flex flex-col w-3/4">
-                            <Text type="p" classes="text-gray-800 font-extrabold" overrideColor>
+                            <Text type="p" classes="font-extrabold">
                                 {locale('general.unstakedFunds')}
                             </Text>
                             <Text type="p" secondary classes="font-extrabold">
@@ -300,7 +300,10 @@
                                 </Text>
                             </Text>
                         </div>
-                        <Button disabled={$isPerformingParticipation} onClick={() => handleStakeClick(account)}>
+                        <Button
+                            caution={isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id}
+                            disabled={$isPerformingParticipation}
+                            onClick={() => handleStakeClick(account)}>
                             {locale('actions.stake')}
                         </Button>
                     </div>

--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -66,7 +66,7 @@
 <Text type="h4" classes="mb-6">{locale('popups.transaction.title')}</Text>
 <div class="flex w-full flex-row flex-wrap">
     {#if mustAcknowledgeParticipationWarning}
-        <div class="relative flex flex-col items-center bg-red-500 bg-opacity-10 rounded-2xl mt-6 mb-9 p-3">
+        <div class="relative flex flex-col items-center bg-red-500 dark:bg-gray-800 bg-opacity-10 rounded-2xl mt-6 mb-9 p-3">
             <div class="bg-red-500 rounded-2xl absolute -top-6 w-12 h-12 flex items-center justify-center">
                 <Icon icon="warning" classes="text-white" />
             </div>

--- a/packages/shared/routes/dashboard/staking/Staking.svelte
+++ b/packages/shared/routes/dashboard/staking/Staking.svelte
@@ -152,7 +152,7 @@
     <StakingHeader />
     <div class="w-full h-full grid grid-cols-3 gap-x-4 min-h-0">
         <div class="h-full flex flex-col space-y-3 overflow-hidden">
-            <DashboardPane classes="w-full">
+            <DashboardPane classes="w-full flex-shrink-0">
                 <StakingSummary />
             </DashboardPane>
             <DashboardPane classes="w-full flex-grow">

--- a/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
@@ -114,6 +114,19 @@
         <div class="flex flex-row justify-between space-x-4">
             <div class="flex flex-col">
                 <div>
+                    <Text type="p" classes="font-bold text-lg inline text-white dark:text-gray-400 break-all">
+                        {formatStakingAirdropReward(airdrop, isAssembly() ? $assemblyStakingRewards : $shimmerStakingRewards, 6).split(' ')[0]}
+                    </Text>
+                    <Text type="p" secondary classes="text-sm inline">
+                        {formatStakingAirdropReward(airdrop, isAssembly() ? $assemblyStakingRewards : $shimmerStakingRewards, 6).split(' ')[1]}
+                    </Text>
+                </div>
+                <Text type="p" smaller overrideColor classes="font-normal mt-0.5 text-gray-400 dark:text-gray-400">
+                    {localize('views.staking.airdrops.collectedRewards')}
+                </Text>
+            </div>
+            <div class="flex flex-col text-right">
+                <div>
                     <Text type="p" classes="font-bold text-lg inline text-white dark:text-white">
                         {remainingTimeAmount}
                     </Text>
@@ -125,19 +138,6 @@
                     overrideColor
                     classes="font-normal text-sm mt-0.5 text-gray-400 dark:text-gray-400">
                     {localize('views.staking.airdrops.remaining')}
-                </Text>
-            </div>
-            <div class="flex flex-col">
-                <div>
-                    <Text type="p" classes="font-bold text-lg inline text-white dark:text-gray-400 break-all">
-                        {formatStakingAirdropReward(airdrop, isAssembly() ? $assemblyStakingRewards : $shimmerStakingRewards, 6).split(' ')[0]}
-                    </Text>
-                    <Text type="p" secondary classes="text-sm inline">
-                        {formatStakingAirdropReward(airdrop, isAssembly() ? $assemblyStakingRewards : $shimmerStakingRewards, 6).split(' ')[1]}
-                    </Text>
-                </div>
-                <Text type="p" smaller overrideColor classes="font-normal mt-0.5 text-gray-400 dark:text-gray-400">
-                    {localize('views.staking.airdrops.collectedRewards')}
                 </Text>
             </div>
         </div>

--- a/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
@@ -84,7 +84,7 @@
         bind:this={video[airdrop]}>
         <source src="assets/videos/airdrop-{airdrop}.mp4" type="video/mp4" />
     </video>
-    <div class="px-8 h-full pb-10 flex flex-col justify-end space-y-5 z-0">
+    <div class="w-full h-full px-8 pb-10 flex flex-col justify-end space-y-5 z-0">
         <div class="flex flex-col">
             <div class="flex flex-row flex-wrap mb-2">
                 {#each stakedAccountsInCurrentAirdrop as acc}

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -12,21 +12,20 @@
     import { ParticipationEventState, ParticipationOverview } from 'shared/lib/participation/types'
     import { getBestTimeDuration } from 'shared/lib/time'
 
-    const handleExternalLinkClick = (): void => {
-        Electron.openUrl('https://firefly.iota.org')
-    }
-
     const updateAnimation = (state: ParticipationEventState, overview: ParticipationOverview): string => {
         const prefix = 'staking-info'
         if (!state || !overview) return `${prefix}-upcoming`
 
-        if (state === ParticipationEventState.Holding) {
+        if (state === ParticipationEventState.Inactive) {
+            return null
+        }
+        else if (state === ParticipationEventState.Holding) {
             let numParticipations = 0
 
             if (overview.some((apo) => apo.shimmerStakedFunds > 0 && apo.assemblyStakedFunds > 0)) {
-                numParticipations = 2;
+                numParticipations = 2
             } else if (overview.some((apo) => apo.shimmerStakedFunds > 0 || apo.assemblyStakedFunds > 0)) {
-                numParticipations = 1;
+                numParticipations = 1
             }
 
             let fileNumber
@@ -44,10 +43,8 @@
         }
     }
 
-    let animation = 'staking-info-holding-0'
     $: animation = updateAnimation($stakingEventState, $participationOverview)
 
-    let localePath
     $: localePath = `views.staking.info.${$stakingEventState}`
     $: $assemblyStakingRemainingTime, $shimmerStakingRemainingTime
 
@@ -77,20 +74,19 @@
 </script>
 
 <style type="text/scss">
-    ul {
-        display: block;
-        list-style-type: disc;
-        margin-block-start: 0.5em;
-        margin-block-end: 1em;
-        margin-inline-start: 0px;
-        margin-inline-end: 0px;
-        padding-inline-start: 20px;
+    .animation-wrapper {
+        max-height: calc(100% - 80px);
+        max-width: 700px;
+        padding-bottom: 50%;
     }
 </style>
 
-<div
-    class="p-8 flex flex-col justify-center items-center w-full h-full bg-blue-100 dark:bg-gray-800">
-    <Animation animation={animation} />
+<div class="p-8 flex flex-col justify-center items-center w-full h-full bg-blue-100 dark:bg-gray-800">
+    {#if animation}
+        <div class="animation-wrapper relative w-full">
+            <Animation {animation} classes="h-full absolute transform left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
+        </div>
+    {/if}
     <div class="w-full mt-4 flex flex-col items-center text-center">
         <Text type="p" bigger classes="mb-1">{subHeader}</Text>
         <Text type="h2" classes="mb-2">{header}</Text>

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -77,7 +77,7 @@
     .animation-wrapper {
         max-height: calc(100% - 80px);
         max-width: 700px;
-        padding-bottom: 50%;
+        padding-bottom: 66.56%;
     }
 </style>
 

--- a/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
@@ -90,7 +90,7 @@
     </div>
     <!-- Action -->
     {#if isBusy && !error}
-        <Text secondary classes="mb-3">{locale('general.updatingAccount')}</Text>
+        <Text secondary classes="mb-3 text-center">{locale('general.updatingAccount')}</Text>
     {/if}
     {#if !isBusy}
         <div class="flex flex-row justify-between px-2">


### PR DESCRIPTION
# Description of change

- Improve staking view for very wide screens
- General CSS polish on the staking project panes
- Avoid staking animation jump
- Bugfix SVG slow CSS color transition
- Refactor CSS in `AcountTile`: moved from inline to tailwind scss
- Set `yellow-600` for warning and `orange-500` for staking tx
- Update account tile colors and partial staking manager according to latest UI
- Fix account tile name overflow
- Fix text overflows in airdrop selection
- Align updating wallet text on manage Account view 
- Move autofocus on popup to first element to avoid selecting content buttons

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality): UI

## How the change has been tested

Ubuntu 20.04. Desktop. Test on resolutions from minimum (1280x720px) up to 4k (3840x2160px)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
