### PR TITLE
fix: minimum reward time

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -2868,11 +2868,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -2885,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2 1.0.34",
  "quote 1.0.10",

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -21,7 +21,6 @@
     import {
         AccountParticipationAbility,
         ParticipationEventState,
-        ParticipationOverview,
         StakingAirdrop,
     } from 'shared/lib/participation/types'
     import { openPopup } from 'shared/lib/popup'
@@ -139,7 +138,6 @@
                 const timeNeeded = <number>getTimeUntilMinimumAirdropReward(account)
                 const remainingTime =
                     airdrop === StakingAirdrop.Assembly ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
-
                 if (timeNeeded > remainingTime) {
                     return {
                         title: localize('tooltips.stakingMinRewards.title'),

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -2,9 +2,9 @@
     import { Icon, Text, Tooltip } from 'shared/components'
     import { appSettings } from 'shared/lib/appSettings'
     import { localize } from 'shared/lib/i18n'
+    import { getAccountParticipationAbility } from 'shared/lib/participation'
     import {
         formatStakingAirdropReward,
-        getAccountParticipationAbility,
         getMinimumAirdropRewardInfo,
         getStakingEventFromAirdrop,
         getTimeUntilMinimumAirdropReward,

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -69,7 +69,7 @@
          * accounts on the wallet Svelte store.
          */
         const account = _getAccount($stakedAccounts)
-        if (account && getAccountParticipationAbility(account) !== AccountParticipationAbility.NoHasDustAmount) {
+        if (account && getAccountParticipationAbility(account) !== AccountParticipationAbility.HasDustAmount) {
             /**
              * NOTE: If the account has reached minimum airdrop already (on another address) and staking is NOT
              * possible then we won't display the tooltip.

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -8,7 +8,8 @@
         getMinimumAirdropRewardInfo,
         getStakingEventFromAirdrop,
         getTimeUntilMinimumAirdropReward,
-        getUnstakedFunds, hasAccountReachedMinimumAirdrop,
+        getUnstakedFunds,
+        hasAccountReachedMinimumAirdrop,
         isStakingPossible,
     } from 'shared/lib/participation'
     import {

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -7,7 +7,7 @@
         getMinimumAirdropRewardInfo,
         getStakingEventFromAirdrop,
         getTimeUntilMinimumAirdropReward,
-        getUnstakedFunds,
+        getUnstakedFunds, hasAccountReachedMinimumAirdrop,
         isStakingPossible,
     } from 'shared/lib/participation'
     import {
@@ -66,9 +66,17 @@
          */
         const account = _getAccount($stakedAccounts)
         if (account && getAccountParticipationAbility(account) !== AccountParticipationAbility.NoHasDustAmount) {
-            const accountOverview = $participationOverview.find((apo) => apo.accountIndex === account?.index)
-            isBelowMinimumStakingRewards =
-                accountOverview?.assemblyRewardsBelowMinimum > 0 || accountOverview?.shimmerRewardsBelowMinimum > 0
+            /**
+             * NOTE: If the account has reached minimum airdrop already (on another address) and staking is NOT
+             * possible then we won't display the tooltip.
+             */
+            if (hasAccountReachedMinimumAirdrop(account) && !isStakingPossible($stakingEventState)) {
+                isBelowMinimumStakingRewards = false
+            } else {
+                const accountOverview = $participationOverview.find((apo) => apo.accountIndex === account?.index)
+                isBelowMinimumStakingRewards =
+                    accountOverview?.assemblyRewardsBelowMinimum > 0 || accountOverview?.shimmerRewardsBelowMinimum > 0
+            }
         }
     }
 

--- a/packages/shared/components/StakingAirdropIndicator.svelte
+++ b/packages/shared/components/StakingAirdropIndicator.svelte
@@ -36,7 +36,7 @@
 </style>
 
 {#if showIndicator}
-    <div class="rounded-2xl bg-white bg-opacity-20 px-2 py-1 flex flex-row space-x-2 items-center">
+    <div class="rounded-2xl bg-white bg-opacity-20 px-3 py-1 flex flex-row space-x-2 items-center">
         <span class="relative flex justify-center items-center h-3 w-3">
             {#if isStaked}
                 <span

--- a/packages/shared/components/StakingIndicator.svelte
+++ b/packages/shared/components/StakingIndicator.svelte
@@ -3,6 +3,7 @@
     import { localize } from 'shared/lib/i18n'
     import { stakedAccounts, stakingEventState } from 'shared/lib/participation/stores'
     import { ParticipationEventState } from 'shared/lib/participation/types'
+    import { hasAnAccountReachedMinimumAirdrop } from '../lib/participation'
 
     $: indicatorIcon = getIndicatorIcon($stakingEventState, $stakedAccounts.length > 0)
 
@@ -69,7 +70,7 @@
         const localePath = `${stateText}${isHoldingPhase ? 'Holding' : ''}`
         return {
             title: localize(`tooltips.stakingIndicator.${localePath}.title`),
-            body: localize(`tooltips.stakingIndicator.${localePath}.body`),
+            body: localize(`tooltips.stakingIndicator.${localePath}.body${localePath === 'ended' ? (hasAnAccountReachedMinimumAirdrop() ? 'Above' : 'Below') + 'RewardMin' : ''}`),
         }
     }
 </script>

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -247,7 +247,7 @@
 </style>
 
 <Text type="h5">{locale('popups.stakingManager.title')}</Text>
-<Text type="p" secondary classes="mt-6 mb-2">{locale('popups.stakingManager.description')}</Text>
+<Text type="p" secondary classes="mt-6 mb-4">{locale('popups.stakingManager.description')}</Text>
 <div class="staking flex flex-col scrollable-y">
     {#each $accounts as account}
         {#if getAccountParticipationAbility(account) === AccountParticipationAbility.Yes || getAccountParticipationAbility(account) === AccountParticipationAbility.NoHasPendingTransaction}

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -247,8 +247,7 @@
                         <div class="bg-green-100 rounded-2xl">
                             <Icon icon="success-check" width="19" height="19" classes="text-white" />
                         </div>
-                    <!--{:else if getAccountParticipationAbility(account) === AccountParticipationAbility.NoWillNotReachMinAirdrop}-->
-                    {:else if true}
+                    {:else if getAccountParticipationAbility(account) === AccountParticipationAbility.NoWillNotReachMinAirdrop}
                         <div
                             bind:this={tooltipAnchors[account?.index]}
                             on:mouseenter={() => toggleTooltip(account?.index)}

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -11,7 +11,7 @@
         getStakedFunds,
         getUnstakedFunds,
         isAccountPartiallyStaked,
-        isAccountStaked,
+        isAccountStaked, getIotasUntilMinimumAirdropReward,
     } from 'shared/lib/participation'
     import { getParticipationOverview, participate, stopParticipating } from 'shared/lib/participation/api'
     import { STAKING_EVENT_IDS } from 'shared/lib/participation/constants'
@@ -212,16 +212,19 @@
     })
 
     let showTooltip = false
-    let tooltipAnchor
+    let tooltipAnchor: unknown
     const tooltipAnchors: { [accountIndex: number]: unknown } = {}
+    let tooltipMinBalance: string = ''
 
-    const toggleTooltip = (accountIndex: string): void => {
+    const toggleTooltip = (account: WalletAccount): void => {
         showTooltip = !showTooltip
 
         if(showTooltip) {
-            tooltipAnchor = tooltipAnchors[accountIndex]
+            tooltipAnchor = tooltipAnchors[account?.index]
+            tooltipMinBalance = <string>getIotasUntilMinimumAirdropReward(account, true)
         } else {
             tooltipAnchor = undefined
+            tooltipMinBalance = ''
         }
     }
 </script>
@@ -244,7 +247,8 @@
                         <div class="bg-green-100 rounded-2xl">
                             <Icon icon="success-check" width="19" height="19" classes="text-white" />
                         </div>
-                    {:else if getAccountParticipationAbility(account) === AccountParticipationAbility.NoWillNotReachMinAirdrop}
+                    <!--{:else if getAccountParticipationAbility(account) === AccountParticipationAbility.NoWillNotReachMinAirdrop}-->
+                    {:else if true}
                         <div
                             bind:this={tooltipAnchors[account?.index]}
                             on:mouseenter={() => toggleTooltip(account?.index)}
@@ -343,7 +347,7 @@
 {#if showTooltip}
     <Tooltip anchor={tooltipAnchor} position="right">
         <Text type="p" classes="text-gray-900 bold mb-1 text-left">
-            {locale('tooltips.stakingMinRewards.titleMinBalance', { valuse: { amount: '' } })}
+            {locale('tooltips.stakingMinRewards.titleMinBalance', { values: { amount: tooltipMinBalance } })}
         </Text>
         <Text type="p" secondary classes="text-left">
             {locale('tooltips.stakingMinRewards.bodyMinBalance')}

--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -273,9 +273,6 @@ export const updateClientOptions = (config: NetworkConfig): void => {
 
     api.setClientOptions(clientOptions, {
         onSuccess() {
-            // On a successful node change message, reinitialise polling for getting participation overview
-            void pollParticipationOverview()
-
             const { accounts } = get(wallet)
             accounts.set(get(accounts).map((a) => ({ ...a, clientOptions })))
         },

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -13,7 +13,7 @@ import {
     participationOverview,
     pendingParticipations,
 } from './stores'
-import { AccountParticipationAbility, Participation, ParticipationEventState } from './types'
+import { AccountParticipationAbility, Participation, ParticipationEventState, StakingAirdrop } from './types'
 
 let participationPollInterval
 
@@ -96,13 +96,13 @@ export const canParticipate = (eventState: ParticipationEventState): boolean => 
  */
 export const getAccountParticipationAbility = (account: WalletAccount): AccountParticipationAbility => {
     if (account?.rawIotaBalance < DUST_THRESHOLD) {
-        return AccountParticipationAbility.NoHasDustAmount
+        return AccountParticipationAbility.HasDustAmount
     } else if (account?.messages.some((message) => !message.confirmed)) {
-        return AccountParticipationAbility.NoHasPendingTransaction
-    } else if (!canAccountReachMinimumAirdrop(account)) {
-        return AccountParticipationAbility.NoWillNotReachMinAirdrop
+        return AccountParticipationAbility.HasPendingTransaction
+    } else if (!canAccountReachMinimumAirdrop(account, StakingAirdrop.Assembly)) {
+        return AccountParticipationAbility.WillNotReachMinAirdrop
     } else {
-        return AccountParticipationAbility.Yes
+        return AccountParticipationAbility.Ok
     }
 }
 

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -4,14 +4,16 @@ import type { WalletAccount } from '../typings/wallet'
 
 import { getParticipationOverview } from './api'
 import { PARTICIPATION_POLL_DURATION } from './constants'
+import { canAccountReachMinimumAirdrop } from './staking'
 import {
     accountToParticipate,
+    isPerformingParticipation,
     participationAction,
     participationEvents,
     participationOverview,
     pendingParticipations,
 } from './stores'
-import { ParticipationEventState, Participation, AccountParticipationAbility } from './types'
+import { AccountParticipationAbility, Participation, ParticipationEventState } from './types'
 
 let participationPollInterval
 
@@ -54,6 +56,7 @@ export function clearPollParticipationOverviewInterval(): void {
  */
 export const resetParticipation = (): void => {
     accountToParticipate.set(null)
+    isPerformingParticipation.set(false)
     participationAction.set(null)
     participationEvents.set([])
     participationOverview.set([])
@@ -96,6 +99,8 @@ export const getAccountParticipationAbility = (account: WalletAccount): AccountP
         return AccountParticipationAbility.NoHasDustAmount
     } else if (account?.messages.some((message) => !message.confirmed)) {
         return AccountParticipationAbility.NoHasPendingTransaction
+    } else if (!canAccountReachMinimumAirdrop(account)) {
+        return AccountParticipationAbility.NoWillNotReachMinAirdrop
     } else {
         return AccountParticipationAbility.Yes
     }

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -25,6 +25,7 @@ let participationPollInterval
  * @returns {Promise<void>}
  */
 export async function pollParticipationOverview(): Promise<void> {
+    clearPollParticipationOverviewInterval()
     try {
         await getParticipationOverview()
         /* eslint-disable @typescript-eslint/no-misused-promises */

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -22,6 +22,7 @@ import {
 } from './stores'
 import { Participation, ParticipationEvent, ParticipationEventState, StakingAirdrop } from './types'
 import { formatUnitBestMatch } from '../units'
+import { wallet } from '../wallet'
 
 /**
  * Determines whether an account is currently being staked or not.
@@ -448,7 +449,7 @@ export const canAccountReachMinimumAirdrop = (account: WalletAccount): boolean =
 }
 
 /**
- * Determines whether an account has reached the reward minimum
+ * Determines whether a given account has reached the reward minimum
  * for either airdrop.
  *
  * @method hasAccountReachedMinimumAirdrop
@@ -465,3 +466,14 @@ export const hasAccountReachedMinimumAirdrop = (account: WalletAccount): boolean
 
     return overview.assemblyRewards > 0 || overview.shimmerRewards > 0
 }
+
+/**
+ * Determines whether any account has reached the reward minimum
+ * for either airdrop.
+ *
+ * @method hasAnAccountReachedMinimumAirdrop
+ *
+ * @returns {boolean}
+ */
+export const hasAnAccountReachedMinimumAirdrop = (): boolean =>
+    get(get(wallet).accounts).some((a) => hasAccountReachedMinimumAirdrop(a))

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -51,7 +51,7 @@ export const isAccountStakedForAirdrop = (accountId: string, airdrop: StakingAir
     const account = get(stakedAccounts).find((sa) => sa.id === accountId)
     if (!account) return false
 
-    const accountOverview = get(participationOverview).find((apo) => apo.accountIndex === account.index)
+    const accountOverview = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
     if (!accountOverview) return false
 
     return accountOverview.participations.find((p) => p.eventId === getAirdropEventId(airdrop)) !== undefined
@@ -289,7 +289,7 @@ export const isStakingPossible = (stakingEventState: ParticipationEventState): b
 type MinimumRewardInfo = [number, StakingAirdrop, number]
 
 export const getMinimumAirdropRewardInfo = (account: WalletAccount): MinimumRewardInfo => {
-    const overview = get(participationOverview).find((apo) => apo.accountIndex === account.index)
+    const overview = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
     if (!overview) return [0, undefined, 0]
 
     /**
@@ -301,8 +301,8 @@ export const getMinimumAirdropRewardInfo = (account: WalletAccount): MinimumRewa
     let smallestMinAirdrop: StakingAirdrop = undefined
     let amountStaked: number = 0
 
-    const { assemblyRewards, assemblyRewardsBelowMinimum, assemblyStakedFunds } = overview
-    if (assemblyRewardsBelowMinimum > 0 && assemblyRewards <= 0) {
+    const { assemblyRewardsBelowMinimum, assemblyStakedFunds } = overview
+    if (assemblyRewardsBelowMinimum > 0) {
         if (assemblyRewardsBelowMinimum < smallestMinRewards) {
             smallestMinRewards = assemblyRewardsBelowMinimum
             smallestMinAirdrop = StakingAirdrop.Assembly
@@ -310,8 +310,8 @@ export const getMinimumAirdropRewardInfo = (account: WalletAccount): MinimumRewa
         }
     }
 
-    const { shimmerRewards, shimmerRewardsBelowMinimum, shimmerStakedFunds } = overview
-    if (shimmerRewardsBelowMinimum > 0 && shimmerRewards <= 0) {
+    const { shimmerRewardsBelowMinimum, shimmerStakedFunds } = overview
+    if (shimmerRewardsBelowMinimum > 0) {
         if (shimmerRewardsBelowMinimum < smallestMinRewards) {
             smallestMinRewards = shimmerRewardsBelowMinimum
             smallestMinAirdrop = StakingAirdrop.Shimmer

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -403,3 +403,22 @@ export const canAccountReachMinimumAirdrop = (account: WalletAccount): boolean =
 
     return timeRequired <= timeLeft
 }
+
+/**
+ * Determines whether an account has reached the reward minimum
+ * for either airdrop.
+ *
+ * @method hasAccountReachedMinimumAirdrop
+ *
+ * @param {WalletAccount} account
+ *
+ * @returns {boolean}
+ */
+export const hasAccountReachedMinimumAirdrop = (account: WalletAccount): boolean => {
+    if (!account) return false
+
+    const overview = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
+    if (!overview) return false
+
+    return overview.assemblyRewards > 0 || overview.shimmerRewards > 0
+}

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -5,11 +5,7 @@ import { localize } from '../i18n'
 import { networkStatus } from '../networkStatus'
 import { showAppNotification } from '../notifications'
 import { activeProfile } from '../profile'
-import {
-    getBestTimeDuration,
-    MILLISECONDS_PER_SECOND,
-    SECONDS_PER_MILESTONE,
-} from '../time'
+import { getBestTimeDuration, MILLISECONDS_PER_SECOND, SECONDS_PER_MILESTONE } from '../time'
 import { clamp, delineateNumber } from '../utils'
 import type { WalletAccount } from '../typings/wallet'
 
@@ -403,14 +399,16 @@ const getNumRemainingMilestones = (airdrop: StakingAirdrop): number => {
     const isInHolding = event?.status?.status === ParticipationEventState.Holding
     const { milestoneIndexStart, milestoneIndexEnd } = event?.information
 
-    return isInHolding ? timeLeft / MILLISECONDS_PER_SECOND / SECONDS_PER_MILESTONE : milestoneIndexEnd - milestoneIndexStart
+    return isInHolding
+        ? timeLeft / MILLISECONDS_PER_SECOND / SECONDS_PER_MILESTONE
+        : milestoneIndexEnd - milestoneIndexStart
 }
 
 const calculateIotasUntilMinimumReward = (rewards: number, airdrop: StakingAirdrop): number => {
     const minRewardsRequired = getMinimumRewardsRequired(rewards, airdrop)
     const numRemainingMilestones = getNumRemainingMilestones(airdrop)
 
-    return minRewardsRequired / (getAirdropRewardMultipler(airdrop) / 1_000_000 * numRemainingMilestones)
+    return minRewardsRequired / ((getAirdropRewardMultipler(airdrop) / 1_000_000) * numRemainingMilestones)
 }
 
 /**
@@ -425,7 +423,11 @@ const calculateIotasUntilMinimumReward = (rewards: number, airdrop: StakingAirdr
  *
  * @returns {number | string}
  */
-export const getIotasUntilMinimumAirdropReward = (account: WalletAccount, airdrop: StakingAirdrop, format: boolean = false): number | string => {
+export const getIotasUntilMinimumAirdropReward = (
+    account: WalletAccount,
+    airdrop: StakingAirdrop,
+    format: boolean = false
+): number | string => {
     if (!account) return format ? formatUnitBestMatch(0) : 0
 
     const currentRewards = getCurrentRewardsForAirdrop(account, airdrop)
@@ -467,6 +469,7 @@ export const canAccountReachMinimumAirdrop = (account: WalletAccount, airdrop: S
  */
 export const getCurrentRewardsForAirdrop = (account: WalletAccount, airdrop: StakingAirdrop): number => {
     const overview = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
+    if (!overview) return 0
 
     return airdrop === StakingAirdrop.Assembly ? overview.assemblyRewards : overview.shimmerRewards
 }
@@ -483,14 +486,9 @@ export const getCurrentRewardsForAirdrop = (account: WalletAccount, airdrop: Sta
  */
 export const getCurrentStakeForAccount = (account: WalletAccount, airdrop: StakingAirdrop): number => {
     const overview = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
+    if (!overview) return 0
 
     return airdrop === StakingAirdrop.Assembly ? overview.assemblyStakedFunds : overview.shimmerUnstakedFunds
-}
-
-    const timeRequired = calculateTimeUntilMinimumReward(overview.assemblyRewards, airdrop, account.rawIotaBalance)
-    const timeLeft = get(assemblyStakingRemainingTime)
-
-    return timeRequired <= timeLeft
 }
 
 /**

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -9,13 +9,14 @@ import type { WalletAccount } from '../typings/wallet'
 
 import { ASSEMBLY_EVENT_ID, SHIMMER_EVENT_ID, STAKING_EVENT_IDS } from './constants'
 import {
+    AccountParticipationOverview,
+    ParticipateResponsePayload,
     ParticipationAction,
     ParticipationEvent,
     ParticipationEventState,
     ParticipationOverview,
     PendingParticipation,
-    ParticipateResponsePayload,
-    AccountParticipationOverview,
+    StakingAirdrop,
 } from './types'
 
 /**
@@ -166,6 +167,34 @@ export const partiallyUnstakedAmount: Readable<number> = derived(
     }
 )
 
+const sumStakingRewards = (airdrop: StakingAirdrop, overview: ParticipationOverview): number => {
+    if (!overview || overview?.length < 1) return 0
+
+    const rewardsKey = `${airdrop}Rewards`
+    const rewardsBelowMinimumKey = `${airdrop}RewardsBelowMinimum`
+
+    const rewards = overview.reduce(
+        (total, accountOverview) => total + (rewardsKey in accountOverview ? accountOverview[rewardsKey] : 0),
+        0
+    )
+    const rewardsBelowMinimum = overview.reduce(
+        (total, accountOverview) =>
+            total + (rewardsBelowMinimumKey in accountOverview ? accountOverview[rewardsBelowMinimumKey] : 0),
+        0
+    )
+
+    if (rewards <= 0) {
+        return rewardsBelowMinimum
+    } else {
+        /**
+         * NOTE: We return the sum of rewards and rewardsBelowMinimum here because it is possible that an
+         * account has accumulated more than min rewards for an airdrop, but has unstaked and moved the funds
+         * to another address that has NOT reach the minimum.
+         */
+        return rewards + rewardsBelowMinimum
+    }
+}
+
 /**
  * The total accumulated Assembly rewards for all
  * accounts that have been staked at some point (even
@@ -173,24 +202,18 @@ export const partiallyUnstakedAmount: Readable<number> = derived(
  *
  * Be cautious that this value is in microASMB, so it is likely to be larger.
  */
-export const assemblyStakingRewards: Readable<number> = derived(participationOverview, (overview) => {
-    const rewards = overview.reduce((total, accountOverview) => total + accountOverview.assemblyRewards, 0)
-    if (rewards <= 0)
-        return overview.reduce((total, accountOverview) => total + accountOverview.assemblyRewardsBelowMinimum, 0)
-    else return rewards
-})
+export const assemblyStakingRewards: Readable<number> = derived(participationOverview, (overview) =>
+    sumStakingRewards(StakingAirdrop.Assembly, overview)
+)
 
 /**
  * The total accumulated Shimmer rewards for all
  * accounts that have been staked at some point (even
  * if they are currently unstaked).
  */
-export const shimmerStakingRewards: Readable<number> = derived(participationOverview, (overview) => {
-    const rewards = overview.reduce((total, accountOverview) => total + accountOverview.shimmerRewards, 0)
-    if (rewards <= 0)
-        return overview.reduce((total, accountOverview) => total + accountOverview.shimmerRewardsBelowMinimum, 0)
-    else return rewards
-})
+export const shimmerStakingRewards: Readable<number> = derived(participationOverview, (overview) =>
+    sumStakingRewards(StakingAirdrop.Shimmer, overview)
+)
 
 /**
  * The available participation events (staking AND voting).

--- a/packages/shared/lib/participation/types.ts
+++ b/packages/shared/lib/participation/types.ts
@@ -1,10 +1,10 @@
 import type { Message } from '../typings/message'
 
 export enum AccountParticipationAbility {
-    Yes = 'yes',
-    NoHasDustAmount = 'noHasDustAmount',
-    NoHasPendingTransaction = 'noHasPendingTransaction',
-    NoWillNotReachMinAirdrop = 'noWillNotReachMinAirdrop',
+    Ok = 'ok',
+    HasDustAmount = 'hasDustAmount',
+    HasPendingTransaction = 'hasPendingTransaction',
+    WillNotReachMinAirdrop = 'willNotReachMinAirdrop',
 }
 
 /**

--- a/packages/shared/lib/participation/types.ts
+++ b/packages/shared/lib/participation/types.ts
@@ -4,6 +4,7 @@ export enum AccountParticipationAbility {
     Yes = 'yes',
     NoHasDustAmount = 'noHasDustAmount',
     NoHasPendingTransaction = 'noHasPendingTransaction',
+    NoWillNotReachMinAirdrop = 'noWillNotReachMinAirdrop',
 }
 
 /**

--- a/packages/shared/lib/units.ts
+++ b/packages/shared/lib/units.ts
@@ -20,7 +20,7 @@ export const UNIT_MAP: { [unit in Unit]: { val: number; dp: number } } = {
 /**
  * The maximum number of IOTA tokens in the network.
  */
-export const MAX_NUM_IOTAS = 2_779_530_283_000_000
+export const MAX_NUM_IOTAS = 2_779_530_283_277_761
 
 /**
  * Formats IOTA value

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1220,7 +1220,8 @@
             },
             "ended": {
                 "title": "Staking has now ended",
-                "body": "Assembly and Shimmer rewards will be distributed to your wallets when each of the respective networks launch."
+                "bodyAboveRewardMin": "Assembly and Shimmer rewards will be distributed to your wallets when each of the respective networks launch.",
+                "bodyBelowRewardMin": "You did not stake enough IOTA to reach the minimum airdrop rewards."
             }
         },
         "partiallyStakedFunds": {

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1242,7 +1242,7 @@
         "stakingMinRewards": {
             "title": "Minimum rewards not met",
             "titleMinBalance": "{amount} minimum balance required",
-            "bodyMinBalace": "Due to low funds, this wallet will not reach the minimum airdrop reward and is unavailable for staking.",
+            "bodyMinBalance": "Due to low funds, this wallet will not reach the minimum airdrop reward and is unavailable for staking.",
             "continue": "Please continue staking for another {duration}.",
             "bodyAboveAndBelowMin": "An address in this wallet has already met the minimum airdrop for {airdrop} ({airdropRewardMin}), but is currently staking on an address that has not met the minimum.",
             "bodyBelowMin": "This wallet is below the minimum airdrop for {airdrop} ({airdropRewardMin}).",

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1242,6 +1242,7 @@
         "stakingMinRewards": {
             "title": "Minimum rewards not met",
             "continue": "Please continue staking for another {duration}.",
+            "bodyAboveAndBelowMin": "An address in this wallet has already met the minimum airdrop for {airdrop} ({airdropRewardMin}), but is currently staking on an address that has not met the minimum.",
             "bodyBelowMin": "This wallet is below the minimum airdrop for {airdrop} ({airdropRewardMin}).",
             "bodyWillReachMin": "You must stake for another {duration} to reach the minimum.",
             "bodyWillNotReachMin": "You will not be able to reach the minimum during the remaining staking period unless you stake more IOTA.",

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -1,5 +1,4 @@
 <script lang="typescript">
-    import { get } from 'svelte/store'
     import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -29,7 +29,7 @@
     $: canParticipateInEvent = isStakingPossible($stakingEventState)
 
     let { accounts } = $wallet
-    $: canStakeAnAccount = $accounts.some((wa) => getAccountParticipationAbility(wa) === AccountParticipationAbility.Yes)
+    $: cannotStakeAnAccount = $accounts.every((wa) => getAccountParticipationAbility(wa) === AccountParticipationAbility.HasDustAmount)
 
     $: isStaked = $stakedAmount > 0 && canParticipateInEvent
 
@@ -51,7 +51,7 @@
     }
 
     const handleStakeFundsClick = (): void => {
-        if (!canStakeAnAccount) {
+        if (cannotStakeAnAccount) {
             showAppNotification({
                 type: 'warning',
                 message: localize('warning.participation.noAccounts'),


### PR DESCRIPTION
# Description of change
- Adds safe object property access with optional chaining (fixed `ReferenceError` bug with `Cannot read property index of undefined`)
- Adds tooltip in `StakingManager` if account will not reach min rewards for either airdrop (with calculated amount of IOTAs still needed to stake to reach min)
- Changes tooltip text for `StakingIndicator` if events are ended and no account has reached minimum
- Fixes missing store variable reset statements inside `resetParticipation()`
- Cleans up some empty `import` statements

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on: 
- MacOS (10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes