### PR TITLE
fix: Restore functionality for button to documentation

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -124,6 +124,7 @@ function isUrlAllowed(targetUrl) {
         'firefly.iota.org',
         'iota.org',
         'privacy@iota.org',
+        'wiki.iota.org',
 
         // Assembly / Shimmer
         'assembly.sc',


### PR DESCRIPTION
# Description of change

Added `wiki.iota.org` to the allow list. Hopefully fixes the "Read the documentation" button in the `Help & Information` section.

## Type of change

- Fix (a change which fixes an issue)

<img width="418" alt="Bildschirmfoto 2021-12-15 um 20 32 54" src="https://user-images.githubusercontent.com/17240275/146252809-e001e310-4988-4b58-8085-340e6dba73ad.png">