### PR TITLE
fix: close popup on inactive state

### DIFF
--- a/packages/shared/routes/dashboard/staking/Staking.svelte
+++ b/packages/shared/routes/dashboard/staking/Staking.svelte
@@ -2,8 +2,13 @@
     import { DashboardPane } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { accountToParticipate, isStakingFeatureNew, participationAction } from 'shared/lib/participation/stores'
-    import { StakingAirdrop as _StakingAirdrop } from 'shared/lib/participation/types'
+    import {
+        accountToParticipate,
+        isStakingFeatureNew,
+        participationAction,
+        stakingEventState,
+    } from 'shared/lib/participation/stores'
+    import { ParticipationEventState, StakingAirdrop as _StakingAirdrop } from 'shared/lib/participation/types'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
     import { isSoftwareProfile } from 'shared/lib/profile'
     import {
@@ -118,6 +123,10 @@
     }
 
     $: if (!$participationAction && ledgerAwaitingConfirmation && $popupState.type === 'ledgerTransaction') {
+        closePopup(true)
+    }
+
+    $: if ($popupState.type === 'stakingManager' && $stakingEventState === ParticipationEventState.Inactive) {
         closePopup(true)
     }
 


### PR DESCRIPTION
# Description of change

If the node does not return the participation overview while the staking manager is open it can lead to unexpected behaviour when you e.g. hit stake. This PR will automatically close the popup if we enter the inactive staking event (i.e. where a connection to the node couldn't be made)

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested by disconnecting internet while staking manager is open

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
