### PR TITLE
fix: default client options

### DIFF
--- a/packages/shared/lib/network.ts
+++ b/packages/shared/lib/network.ts
@@ -302,6 +302,12 @@ export const getDefaultClientOptions = (): ClientOptions => {
         getOfficialNetwork(isDevProfile ? NetworkType.ChrysalisDevnet : NetworkType.ChrysalisMainnet)
 
     const node = pick<Node>(getOfficialNodes(type))
+    if (!node) {
+        showAppNotification({
+            type: 'error',
+            message: localize('error.node.unableToFindNode'),
+        })
+    }
     node.isPrimary = true
 
     /**

--- a/packages/shared/lib/typings/network.ts
+++ b/packages/shared/lib/typings/network.ts
@@ -7,7 +7,7 @@ export enum NetworkType {
 }
 
 /**
- * The specific ID of an IOTA network or Tangle.
+ * The specific ID of an IOTA network.
  */
 export type NetworkId = string
 

--- a/packages/shared/lib/typings/node.ts
+++ b/packages/shared/lib/typings/node.ts
@@ -1,4 +1,4 @@
-import type { Network } from './network'
+import type { Network, NetworkId } from './network'
 
 export interface NodeAuth {
     jwt?: string
@@ -9,7 +9,7 @@ export interface NodeAuth {
 export interface Node {
     url: string
     auth?: NodeAuth
-    network?: Network
+    network?: Network | NetworkId
     isPrimary?: boolean
     isDisabled?: boolean
 }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1129,7 +1129,8 @@
             "noSynced": "No synced nodes are available.",
             "answer": "Failed to get an answer from all nodes.",
             "forbidden": "This node connection is forbidden.",
-            "pluginNotAvailable": "The \"{nodePlugin}\" plugin is not available on the current node."
+            "pluginNotAvailable": "The \"{nodePlugin}\" plugin is not available on the current node.",
+            "unableToFindNode": "Unable to find node for client options."
         },
         "network": {
             "mismatch": "The network ID for this node is \"{networkId}\", which does not match the current network.",


### PR DESCRIPTION
# Description of change
- Adds logic to account for if users selected to create a developer profile to `getDefaultClientOptions` function
- Changes `network` type of `ClientOptions` and `Node` to be _either_ a network ID (useful for `wallet.rs`) or a network object (useful for Firefly)*

\* We should look at adjusting `wallet.rs` to send / receive for data in its network-relevant structs.

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Tested on:
- MacOS (10.15.7)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes