### PR TITLE
update: block staking if wallets are currently syncing

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -2,12 +2,7 @@
     import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'
-    import { NodePlugin } from 'shared/lib/typings/node'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { openPopup, popupState } from 'shared/lib/popup'
-    import { formatUnitBestMatch } from 'shared/lib/units'
-    import { wallet } from 'shared/lib/wallet'
-
     import { getAccountParticipationAbility, isStakingPossible } from 'shared/lib/participation'
     import {
         accountToParticipate,
@@ -20,28 +15,37 @@
         stakingEventState,
         unstakedAmount,
     } from 'shared/lib/participation/stores'
-    import { AccountParticipationAbility, ParticipationAction, ParticipationEventState } from 'shared/lib/participation/types'
+    import {
+        AccountParticipationAbility,
+        ParticipationAction,
+        ParticipationEventState,
+    } from 'shared/lib/participation/types'
+    import { openPopup, popupState } from 'shared/lib/popup'
+    import { NodePlugin } from 'shared/lib/typings/node'
+    import { formatUnitBestMatch } from 'shared/lib/units'
+    import { isSyncing, wallet } from 'shared/lib/wallet'
 
     $: $participationOverview, $stakedAccounts, $partiallyStakedAccounts
 
-    $: showSpinner = !$popupState.active && $participationAction && $accountToParticipate
+    $: showSpinner = (!$popupState.active && $participationAction && $accountToParticipate) || $isSyncing
 
     $: canParticipateInEvent = isStakingPossible($stakingEventState)
 
     let { accounts } = $wallet
-    $: cannotStakeAnAccount = $accounts.every((wa) => getAccountParticipationAbility(wa) === AccountParticipationAbility.HasDustAmount)
+    $: cannotStakeAnAccount = $accounts.every(
+        (wa) => getAccountParticipationAbility(wa) === AccountParticipationAbility.HasDustAmount
+    )
 
     $: isStaked = $stakedAmount > 0 && canParticipateInEvent
 
     $: isPartiallyStaked = $partiallyStakedAccounts.length > 0 && canParticipateInEvent
 
     let canParticipateWithNode = false
-    $: $networkStatus, canParticipateWithNode = hasNodePlugin(NodePlugin.Participation)
+    $: $networkStatus, (canParticipateWithNode = hasNodePlugin(NodePlugin.Participation))
 
     let showTooltip = false
     $: {
-        if (!isPartiallyStaked)
-            showTooltip = false
+        if (!isPartiallyStaked) showTooltip = false
     }
 
     let tooltipAnchor
@@ -60,10 +64,20 @@
             return
         }
 
-        const showNotice = $stakingEventState === ParticipationEventState.Upcoming || $stakingEventState === ParticipationEventState.Commencing
+        const showNotice =
+            $stakingEventState === ParticipationEventState.Upcoming ||
+            $stakingEventState === ParticipationEventState.Commencing
         const type = !isStaked && showNotice ? 'stakingNotice' : 'stakingManager'
 
         openPopup({ type, hideClose: false })
+    }
+
+    const getSpinnerMessage = (): string => {
+        if ($participationAction) {
+            return $participationAction === ParticipationAction.Stake ? 'general.staking' : 'general.unstaking'
+        } else if ($isSyncing) {
+            return 'general.syncingAccounts'
+        }
     }
 </script>
 
@@ -74,11 +88,7 @@
                 {localize('views.staking.summary.stakedFunds')}
             </Text>
             {#if isPartiallyStaked}
-                <div
-                    bind:this={tooltipAnchor}
-                    on:mouseenter={toggleTooltip}
-                    on:mouseleave={toggleTooltip}
-                >
+                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
                     <Icon icon="exclamation" classes="fill-current text-yellow-600" />
                 </div>
             {/if}
@@ -96,29 +106,22 @@
         disabled={showSpinner || !canParticipateInEvent}
         caution={isStaked && isPartiallyStaked}
         secondary={isStaked && !isPartiallyStaked}
-        onClick={() => canParticipateWithNode ? handleStakeFundsClick() : showAppNotification({ type: 'warning', message: localize('error.node.pluginNotAvailable', { values: { nodePlugin: NodePlugin.Participation } }) })}
-    >
+        onClick={() => (canParticipateWithNode ? handleStakeFundsClick() : showAppNotification({
+                      type: 'warning',
+                      message: localize('error.node.pluginNotAvailable', {
+                          values: { nodePlugin: NodePlugin.Participation },
+                      }),
+                  }))}>
         {#if showSpinner}
-            <Spinner
-                busy
-                message={localize(`general.${$participationAction === ParticipationAction.Stake ? 'staking' : 'unstaking'}`)}
-                classes="mx-2 justify-center"
-            />
-        {:else}
-            {localize(`actions.${isStaked ? 'manageStake' : 'stakeFunds'}`)}
-        {/if}
+            <Spinner busy message={localize(getSpinnerMessage())} classes="mx-2 justify-center" />
+        {:else}{localize(`actions.${isStaked ? 'manageStake' : 'stakeFunds'}`)}{/if}
     </Button>
 </div>
 {#if showTooltip}
     <Tooltip anchor={tooltipAnchor} position="right">
         {#if isPartiallyStaked}
             <Text type="p" classes="text-gray-900 bold mb-1 text-left">
-                {localize(
-                    `tooltips.partiallyStakedFunds.title${$partiallyStakedAccounts.length > 0 ? '' : 'NoFunds'}`,
-                    $partiallyStakedAccounts.length > 0
-                        ? { values: { amount: formatUnitBestMatch($partiallyUnstakedAmount) } }
-                        : { }
-                )}
+                {localize(`tooltips.partiallyStakedFunds.title${$partiallyStakedAccounts.length > 0 ? '' : 'NoFunds'}`, $partiallyStakedAccounts.length > 0 ? { values: { amount: formatUnitBestMatch($partiallyUnstakedAmount) } } : {})}
             </Text>
             <Text type="p" secondary classes="text-left">
                 {localize('tooltips.partiallyStakedFunds.preBody')}


### PR DESCRIPTION
# Description of change

Block staking if the wallets are currently being synced (either through manual sync or from initial load, not background syncing)

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested manually on Mac

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
