### PR TITLE
fix: use account ID instead of index when getting migration address for ledger

### DIFF
--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -309,7 +309,7 @@ export const api = {
     },
     getMigrationAddress: function (
         prompt: boolean,
-        accountIndex: number
+        accountIndex: string | number
     ): (__ids: CommunicationIds) => Promise<string> {
         return (__ids: CommunicationIds) => _getMigrationAddreess(sendMessage, __ids, prompt, accountIndex)
     },

--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -309,7 +309,7 @@ export const api = {
     },
     getMigrationAddress: function (
         prompt: boolean,
-        accountIdentifier: string | number
+        accountIdentifier: AccountIdentifier
     ): (__ids: CommunicationIds) => Promise<string> {
         return (__ids: CommunicationIds) => _getMigrationAddreess(sendMessage, __ids, prompt, accountIdentifier)
     },

--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -309,9 +309,9 @@ export const api = {
     },
     getMigrationAddress: function (
         prompt: boolean,
-        accountIndex: string | number
+        accountIdentifier: string | number
     ): (__ids: CommunicationIds) => Promise<string> {
-        return (__ids: CommunicationIds) => _getMigrationAddreess(sendMessage, __ids, prompt, accountIndex)
+        return (__ids: CommunicationIds) => _getMigrationAddreess(sendMessage, __ids, prompt, accountIdentifier)
     },
     mineBundle: function (
         bundle: string[],

--- a/packages/shared/lib/migration.ts
+++ b/packages/shared/lib/migration.ts
@@ -21,7 +21,7 @@ import type {
 } from 'shared/lib/typings/migration'
 import { AppRoute, SetupType } from 'shared/lib/typings/routes'
 import Validator from 'shared/lib/validator'
-import { api } from 'shared/lib/wallet'
+import { api, wallet } from 'shared/lib/wallet'
 import { derived, get, writable } from 'svelte/store'
 import { localize } from './i18n'
 import { showAppNotification } from './notifications'
@@ -360,7 +360,11 @@ export const findMigrationBundle = (bundleIndex: number): Bundle => {
  */
 export const mineLedgerBundle = (bundleIndex: number, offset: number): Promise<void> =>
     new Promise((resolve, reject) => {
-        api.getMigrationAddress(false, get(activeProfile).ledgerMigrationCount, {
+        const { accounts } = get(wallet)
+
+        const accountId = get(accounts).find((account) => account.index === get(activeProfile).ledgerMigrationCount).id
+
+        api.getMigrationAddress(false, accountId, {
             onSuccess(response) {
                 resolve(response.payload)
             },
@@ -482,7 +486,11 @@ export const createLedgerMigrationBundle = (
     callback: () => void
 ): Promise<MigrationBundle> =>
     new Promise((resolve, reject) => {
-        api.getMigrationAddress(false, get(activeProfile).ledgerMigrationCount, {
+        const { accounts } = get(wallet)
+
+        const accountId = get(accounts).find((account) => account.index === get(activeProfile).ledgerMigrationCount).id
+
+        api.getMigrationAddress(false, accountId, {
             onSuccess(response) {
                 resolve(response.payload)
             },

--- a/packages/shared/lib/typings/migration.ts
+++ b/packages/shared/lib/typings/migration.ts
@@ -224,7 +224,7 @@ export function getMigrationAddress(
     bridge: Bridge,
     __ids: CommunicationIds,
     ledgerPrompt: boolean,
-    accountIndex: string | number
+    accountIdentifier: string | number
 ): Promise<string> {
     return bridge({
         actorId: __ids.actorId,
@@ -232,7 +232,7 @@ export function getMigrationAddress(
         cmd: 'GetMigrationAddress',
         payload: {
             ledger_prompt: ledgerPrompt,
-            account_id: accountIndex,
+            account_id: accountIdentifier,
         },
     })
 }

--- a/packages/shared/lib/typings/migration.ts
+++ b/packages/shared/lib/typings/migration.ts
@@ -1,5 +1,6 @@
 import type { Bridge, CommunicationIds } from './bridge'
 import type { Writable } from 'svelte/store'
+import type { AccountIdentifier } from './account'
 
 export interface MigrationAddress {
     bech32: string
@@ -224,7 +225,7 @@ export function getMigrationAddress(
     bridge: Bridge,
     __ids: CommunicationIds,
     ledgerPrompt: boolean,
-    accountIdentifier: string | number
+    accountIdentifier: AccountIdentifier
 ): Promise<string> {
     return bridge({
         actorId: __ids.actorId,

--- a/packages/shared/lib/typings/migration.ts
+++ b/packages/shared/lib/typings/migration.ts
@@ -224,7 +224,7 @@ export function getMigrationAddress(
     bridge: Bridge,
     __ids: CommunicationIds,
     ledgerPrompt: boolean,
-    accountIndex: number
+    accountIndex: string | number
 ): Promise<string> {
     return bridge({
         actorId: __ids.actorId,

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -357,7 +357,7 @@ interface IWalletApi {
     )
     getMigrationAddress(
         prompt: boolean,
-        accountIndex: number,
+        accountIndex: string | number,
         callbacks: {
             onSuccess: (response: Event<GetMigrationAddressResponse>) => void
             onError: (err: ErrorEventPayload) => void

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -38,6 +38,7 @@ import type {
     SignerType,
     SyncAccountOptions,
     SyncedAccount,
+    AccountIdentifier,
 } from './typings/account'
 import type { Address } from './typings/address'
 import type { Actor, GetMigrationAddressResponse } from './typings/bridge'
@@ -357,7 +358,7 @@ interface IWalletApi {
     )
     getMigrationAddress(
         prompt: boolean,
-        accountIdentifier: string | number,
+        accountIdentifier: AccountIdentifier,
         callbacks: {
             onSuccess: (response: Event<GetMigrationAddressResponse>) => void
             onError: (err: ErrorEventPayload) => void

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -357,7 +357,7 @@ interface IWalletApi {
     )
     getMigrationAddress(
         prompt: boolean,
-        accountIndex: string | number,
+        accountIdentifier: string | number,
         callbacks: {
             onSuccess: (response: Event<GetMigrationAddressResponse>) => void
             onError: (err: ErrorEventPayload) => void

--- a/packages/shared/routes/setup/ledger/views/GenerateNewAddress.svelte
+++ b/packages/shared/routes/setup/ledger/views/GenerateNewAddress.svelte
@@ -45,7 +45,7 @@
                     onSuccess(createAccountResponse) {
                         newAddress = createAccountResponse.payload.addresses[0].address
 
-                        displayAddress()
+                        displayAddress(createAccountResponse.payload.id)
                     },
                     onError(error) {
                         busy = false
@@ -64,7 +64,7 @@
                     if (getAccountsResponse.payload.length > 0) {
                         if (getAccountsResponse.payload[$activeProfile.ledgerMigrationCount]) {
                             newAddress = getAccountsResponse.payload[$activeProfile.ledgerMigrationCount].addresses[0].address
-                            displayAddress()
+                            displayAddress(getAccountsResponse.payload[$activeProfile.ledgerMigrationCount].id)
                         } else {
                             _createAccount($activeProfile.ledgerMigrationCount + 1)
                         }
@@ -83,8 +83,8 @@
         promptUserToConnectLedger(false, _onConnected, _onCancel)
     }
 
-    function displayAddress() {
-        api.getMigrationAddress(true, $activeProfile.ledgerMigrationCount, {
+    function displayAddress(accountId: string) {
+        api.getMigrationAddress(true, accountId, {
             onSuccess() {
                 busy = false
 


### PR DESCRIPTION
# Description of change

Generating migration address for ledger was erroring out. This PR fixes the issue. 

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

- Tested manually by generating migration address. 
- Did not test generating migration address during the bundle mining & bundle creation process (but it still is passing id so it should work fine)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
