### PR TITLE
fix: decimal separator in amount

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -6,7 +6,7 @@
         convertFromFiat,
         convertToFiat,
         currencies,
-        exchangeRates,
+        exchangeRates, formatCurrency,
         isFiatCurrency,
         parseCurrency,
     } from 'shared/lib/currency'
@@ -439,7 +439,7 @@
 
     const handleMaxClick = () => {
         amount = isFiatCurrency(unit)
-            ? convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]).toString()
+            ? formatCurrency(convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]))
             : formatUnitPrecision(from.balance, unit, false)
     }
 

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -6,7 +6,8 @@
         convertFromFiat,
         convertToFiat,
         currencies,
-        exchangeRates, formatCurrency,
+        exchangeRates,
+        formatNumber,
         isFiatCurrency,
         parseCurrency,
     } from 'shared/lib/currency'
@@ -439,7 +440,7 @@
 
     const handleMaxClick = () => {
         amount = isFiatCurrency(unit)
-            ? formatCurrency(convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]))
+            ? formatNumber(convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]))
             : formatUnitPrecision(from.balance, unit, false)
     }
 


### PR DESCRIPTION
# Description of change
This PR fixes the bug where if a user is in a locale that uses "," as the decimal separator, the `Amount.svelte` component displays the number using "." upon MAX click.

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Test cases:
- Enter zero and non-zero (including near-zero like `1i`) amounts
- Enter amounts / click MAX for IOTA denominations _and_ profile's selected fiat currency.
- Select different languages and currencies to use for a profile and test the above cases ^

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes