### PR TITLE
fix: electron settings menu saves previous tab

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -11,7 +11,7 @@
     import { showAppNotification } from 'shared/lib/notifications';
     import { openPopup,popupState } from 'shared/lib/popup';
     import { cleanupEmptyProfiles,cleanupInProgressProfiles } from 'shared/lib/profile';
-    import { dashboardRoute,initRouter,routerNext,routerPrevious,walletRoute } from 'shared/lib/router';
+    import { dashboardRoute,initRouter,openSettings,routerNext,routerPrevious,walletRoute } from 'shared/lib/router';
     import type { Locale } from 'shared/lib/typings/i18n';
     import { AppRoute,Tabs } from 'shared/lib/typings/routes';
     import {
@@ -80,7 +80,7 @@
         Electron.onEvent('menu-navigate-settings', () => {
             if ($loggedIn) {
                 if (get(dashboardRoute) !== Tabs.Settings) {
-                    dashboardRoute.set(Tabs.Settings)
+                    openSettings()
                 }
             } else {
                 settings = true

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -1,14 +1,14 @@
 <script lang="typescript">
     import { onDestroy } from 'svelte'
     import { get } from 'svelte/store'
-    import { Icon, Logo, NetworkIndicator, ProfileActionsModal, Text } from 'shared/components'
+    import { Icon, Logo, NetworkIndicator, ProfileActionsModal } from 'shared/components'
     import { getInitials } from 'shared/lib/helpers'
     import type { Locale } from 'shared/lib/typings/i18n'
     import { NETWORK_HEALTH_COLORS, networkStatus } from 'shared/lib/networkStatus'
     import { isStakingFeatureNew } from 'shared/lib/participation/stores'
     import { activeProfile } from 'shared/lib/profile'
-    import { dashboardRoute, settingsRoute, resetWalletRoute, previousDashboardRoute } from 'shared/lib/router'
-    import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
+    import { dashboardRoute, resetWalletRoute } from 'shared/lib/router'
+    import { Tabs } from 'shared/lib/typings/routes'
 
     export let locale: Locale
 
@@ -28,12 +28,6 @@
     onDestroy(() => {
         unsubscribe()
     })
-
-    function openSettings() {
-        previousDashboardRoute.set(get(dashboardRoute))
-        dashboardRoute.set(Tabs.Settings)
-        settingsRoute.set(SettingsRoutes.Init)
-    }
 
     function openWallet() {
         resetWalletRoute()
@@ -83,5 +77,5 @@
         </span>
     </nav>
     <NetworkIndicator bind:isActive={showNetwork} {locale} />
-    <ProfileActionsModal bind:isActive={showProfile} {locale} {openSettings} />
+    <ProfileActionsModal bind:isActive={showProfile} {locale} />
 </aside>

--- a/packages/shared/components/modals/ProfileActions.svelte
+++ b/packages/shared/components/modals/ProfileActions.svelte
@@ -5,13 +5,12 @@
     import { activeProfile } from 'shared/lib/profile'
     import { get } from 'svelte/store'
     import { fade } from 'svelte/transition'
-    import { Locale } from 'shared/lib/typings/i18n'
+    import type { Locale } from 'shared/lib/typings/i18n'
+    import { openSettings } from 'shared/lib/router';
 
     export let locale: Locale
 
     export let isActive
-
-    export let openSettings = (): void => {}
 
     const profileColor = 'blue' // TODO: each profile has a different color
     const profileName = get(activeProfile)?.name

--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -310,3 +310,9 @@ export const resetLedgerRoute = (): void => {
     ledgerRoute.set(LedgerRoutes.LegacyIntro)
     ledgerRouteHistory.set([])
 }
+
+export const openSettings = (): void => {
+    previousDashboardRoute.set(get(dashboardRoute))
+    dashboardRoute.set(Tabs.Settings)
+    settingsRoute.set(SettingsRoutes.Init)
+}


### PR DESCRIPTION
# Description of change

Refactor openSettings function into router lib
use new function for the electron event handler for clicking the settings button.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

Manually on MacOS

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
