### PR TITLE
Feat: Show staking sidebar notification per profile and on partial stake

### DIFF
--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -23,28 +23,27 @@
 
     const profileInitial = getInitials(get(activeProfile)?.name, 1)
 
-    const unsubscribeNetworkStatus = networkStatus.subscribe((data) => {
+    const unsubscribe = networkStatus.subscribe((data) => {
         healthStatus = data.health ?? 0
     })
 
-    const unSubscribePartialStaking = unstakedAmount.subscribe((_unstakedAmount) => {
-        if (
-            isStakingPossible($stakingEventState) &&
-            _unstakedAmount > _prevUnstakedAmount &&
-            $dashboardRoute !== Tabs.Staking
-        ) {
-            showStakingNotification = true
+    $: $dashboardRoute, $stakingEventState, $unstakedAmount, manageUnstakedAmountNotification()
+
+    function manageUnstakedAmountNotification() {
+        if (isStakingPossible($stakingEventState)) {
+            if ($dashboardRoute !== Tabs.Staking && $unstakedAmount > _prevUnstakedAmount) {
+                showStakingNotification = true
+            } else {
+                showStakingNotification = false
+            }
+            _prevUnstakedAmount = $unstakedAmount
         } else {
             showStakingNotification = false
         }
-        _prevUnstakedAmount = _unstakedAmount
-    })
-
-    $: if ($dashboardRoute === Tabs.Staking) showStakingNotification = false
+    }
 
     onDestroy(() => {
-        unsubscribeNetworkStatus()
-        unSubscribePartialStaking()
+        unsubscribe()
     })
 
     function openSettings() {

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -1,29 +1,43 @@
 <script lang="typescript">
+    import { Icon, Logo, NetworkIndicator, ProfileActionsModal } from 'shared/components'
+    import { getInitials } from 'shared/lib/helpers'
+    import { networkStatus, NETWORK_HEALTH_COLORS } from 'shared/lib/networkStatus'
+    import { unstakedAmount } from 'shared/lib/participation/stores'
+    import { activeProfile } from 'shared/lib/profile'
+    import { dashboardRoute, previousDashboardRoute, resetWalletRoute, settingsRoute } from 'shared/lib/router'
+    import type { Locale } from 'shared/lib/typings/i18n'
+    import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
     import { onDestroy } from 'svelte'
     import { get } from 'svelte/store'
-    import { Icon, Logo, NetworkIndicator, ProfileActionsModal, Text } from 'shared/components'
-    import { getInitials } from 'shared/lib/helpers'
-    import type { Locale } from 'shared/lib/typings/i18n'
-    import { NETWORK_HEALTH_COLORS, networkStatus } from 'shared/lib/networkStatus'
-    import { activeProfile } from 'shared/lib/profile'
-    import { dashboardRoute, settingsRoute, resetWalletRoute, previousDashboardRoute } from 'shared/lib/router'
-    import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
 
     export let locale: Locale
 
     let showNetwork = false
     let healthStatus = 2
     let showProfile = false
+    let showStakingNotification = false
+
     const profileColor = 'blue' // TODO: each profile has a different color
 
     const profileInitial = getInitials(get(activeProfile)?.name, 1)
 
-    const unsubscribe = networkStatus.subscribe((data) => {
+    const unsubscribeNetworkStatus = networkStatus.subscribe((data) => {
         healthStatus = data.health ?? 0
     })
 
+    const unSubscribePartialStaking = unstakedAmount.subscribe((_unstakedAmount) => {
+        if (_unstakedAmount > 0 && $dashboardRoute !== Tabs.Staking) {
+            showStakingNotification = true
+        } else {
+            showStakingNotification = false
+        }
+    })
+
+    $: if ($dashboardRoute === Tabs.Staking) showStakingNotification = false
+
     onDestroy(() => {
-        unsubscribe()
+        unsubscribeNetworkStatus()
+        unSubscribePartialStaking()
     })
 
     function openSettings() {
@@ -55,15 +69,20 @@
     <Logo classes="logo mb-9 {hasTitleBar ? 'mt-3' : ''}" width="48px" logo="logo-firefly" />
     <nav class="flex flex-grow flex-col items-center justify-between">
         <div class="flex flex-col">
-            <button class="mb-8 {$dashboardRoute === Tabs.Wallet ? 'text-blue-500' : 'text-gray-500'}" on:click={openWallet}>
+            <button
+                class="mb-8 {$dashboardRoute === Tabs.Wallet ? 'text-blue-500' : 'text-gray-500'}"
+                on:click={openWallet}>
                 <Icon width="24" height="24" icon="wallet" />
             </button>
-            <button class="{$dashboardRoute === Tabs.Staking ? 'text-blue-500' : 'text-gray-500'} relative" on:click={openStaking}>
+            <button
+                class="{$dashboardRoute === Tabs.Staking ? 'text-blue-500' : 'text-gray-500'} relative"
+                on:click={openStaking}>
                 <Icon width="24" height="24" icon="tokens" />
-                {#if !$activeProfile?.hasVisitedStaking}
+                {#if !$activeProfile?.hasVisitedStaking || showStakingNotification}
                     <span class="absolute -top-2 -left-2 flex justify-center items-center h-3 w-3">
-                        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-75"></span>
-                        <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500"></span>
+                        <span
+                            class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-75" />
+                        <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
                     </span>
                 {/if}
             </button>

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -5,7 +5,6 @@
     import { getInitials } from 'shared/lib/helpers'
     import type { Locale } from 'shared/lib/typings/i18n'
     import { NETWORK_HEALTH_COLORS, networkStatus } from 'shared/lib/networkStatus'
-    import { isStakingFeatureNew } from 'shared/lib/participation/stores'
     import { activeProfile } from 'shared/lib/profile'
     import { dashboardRoute, settingsRoute, resetWalletRoute, previousDashboardRoute } from 'shared/lib/router'
     import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
@@ -16,8 +15,6 @@
     let healthStatus = 2
     let showProfile = false
     const profileColor = 'blue' // TODO: each profile has a different color
-
-    $: $isStakingFeatureNew
 
     const profileInitial = getInitials(get(activeProfile)?.name, 1)
 
@@ -63,7 +60,7 @@
             </button>
             <button class="{$dashboardRoute === Tabs.Staking ? 'text-blue-500' : 'text-gray-500'} relative" on:click={openStaking}>
                 <Icon width="24" height="24" icon="tokens" />
-                {#if $isStakingFeatureNew}
+                {#if !$activeProfile?.hasVisitedStaking}
                     <span class="absolute -top-2 -left-2 flex justify-center items-center h-3 w-3">
                         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-75"></span>
                         <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500"></span>

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -2,7 +2,8 @@
     import { Icon, Logo, NetworkIndicator, ProfileActionsModal } from 'shared/components'
     import { getInitials } from 'shared/lib/helpers'
     import { networkStatus, NETWORK_HEALTH_COLORS } from 'shared/lib/networkStatus'
-    import { unstakedAmount } from 'shared/lib/participation/stores'
+    import { isStakingPossible } from 'shared/lib/participation'
+    import { stakingEventState, unstakedAmount } from 'shared/lib/participation/stores'
     import { activeProfile } from 'shared/lib/profile'
     import { dashboardRoute, previousDashboardRoute, resetWalletRoute, settingsRoute } from 'shared/lib/router'
     import type { Locale } from 'shared/lib/typings/i18n'
@@ -15,6 +16,7 @@
     let showNetwork = false
     let healthStatus = 2
     let showProfile = false
+    let _prevUnstakedFunds = 0 // store the previous unstaked funds to avoid notifying when unstaked funds decrease
     let showStakingNotification = false
 
     const profileColor = 'blue' // TODO: each profile has a different color
@@ -26,11 +28,16 @@
     })
 
     const unSubscribePartialStaking = unstakedAmount.subscribe((_unstakedAmount) => {
-        if (_unstakedAmount > 0 && $dashboardRoute !== Tabs.Staking) {
+        if (
+            isStakingPossible($stakingEventState) &&
+            _unstakedAmount > _prevUnstakedFunds &&
+            $dashboardRoute !== Tabs.Staking
+        ) {
             showStakingNotification = true
         } else {
             showStakingNotification = false
         }
+        _prevUnstakedFunds = _unstakedAmount
     })
 
     $: if ($dashboardRoute === Tabs.Staking) showStakingNotification = false

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -16,7 +16,7 @@
     let showNetwork = false
     let healthStatus = 2
     let showProfile = false
-    let _prevUnstakedFunds = 0 // store the previous unstaked funds to avoid notifying when unstaked funds decrease
+    let _prevUnstakedAmount = 0 // store the previous unstaked funds to avoid notifying when unstaked funds decrease
     let showStakingNotification = false
 
     const profileColor = 'blue' // TODO: each profile has a different color
@@ -30,14 +30,14 @@
     const unSubscribePartialStaking = unstakedAmount.subscribe((_unstakedAmount) => {
         if (
             isStakingPossible($stakingEventState) &&
-            _unstakedAmount > _prevUnstakedFunds &&
+            _unstakedAmount > _prevUnstakedAmount &&
             $dashboardRoute !== Tabs.Staking
         ) {
             showStakingNotification = true
         } else {
             showStakingNotification = false
         }
-        _prevUnstakedFunds = _unstakedAmount
+        _prevUnstakedAmount = _unstakedAmount
     })
 
     $: if ($dashboardRoute === Tabs.Staking) showStakingNotification = false

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -25,13 +25,6 @@ import {
 export const pendingParticipations = writable<PendingParticipation[]>([])
 
 /**
- * The persisted store variable for if the staking feature is new for a Firefly installation.
- * Once the user navigates to the staking dashboard, this is set to false. This helps the UX
- * to highlight the new feature.
- */
-export const isStakingFeatureNew = persistent('isStakingFeatureNew', true)
-
-/**
  * The store for an account that is selected to participate in an event. This is
  * mostly useful for showing background participation progress, otherwise it can
  * just be shown within a designated component (i.e. popup or dashboard tile).

--- a/packages/shared/lib/typings/profile.ts
+++ b/packages/shared/lib/typings/profile.ts
@@ -30,6 +30,7 @@ export interface Profile {
     isDeveloperProfile: boolean
     hasVisitedDashboard?: boolean
     ledgerMigrationCount?: number
+    hasVisitedStaking?: boolean
 }
 
 /**

--- a/packages/shared/routes/dashboard/staking/Staking.svelte
+++ b/packages/shared/routes/dashboard/staking/Staking.svelte
@@ -4,13 +4,12 @@
     import { showAppNotification } from 'shared/lib/notifications'
     import {
         accountToParticipate,
-        isStakingFeatureNew,
         participationAction,
         stakingEventState,
     } from 'shared/lib/participation/stores'
     import { ParticipationEventState, StakingAirdrop as _StakingAirdrop } from 'shared/lib/participation/types'
     import { closePopup, openPopup, popupState } from 'shared/lib/popup'
-    import { isSoftwareProfile } from 'shared/lib/profile'
+    import { activeProfile, isSoftwareProfile, updateProfile } from 'shared/lib/profile'
     import {
         GeneratingRemainderDepositAddressEvent,
         PreparedTransactionEvent,
@@ -25,13 +24,13 @@
     import { StakingAirdrop, StakingHeader, StakingInfo, StakingSummary } from './views'
 
     const handleNewStakingFeature = (): void => {
-        if ($isStakingFeatureNew) {
+        if (!$activeProfile?.hasVisitedStaking) {
             showAppNotification({
                 type: 'info',
                 message: localize('views.staking.welcome'),
             })
 
-            isStakingFeatureNew.set(false)
+            updateProfile('hasVisitedStaking', true)
         }
     }
 
@@ -134,7 +133,7 @@
         await getParticipationEvents()
         await getParticipationOverview()
 
-        if ($isStakingFeatureNew) {
+        if (!$activeProfile?.hasVisitedStaking) {
             handleNewStakingFeature()
         }
     })

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -7,6 +7,7 @@
         convertToFiat,
         currencies,
         exchangeRates,
+        formatNumber,
         isFiatCurrency,
         parseCurrency,
     } from 'shared/lib/currency'
@@ -439,7 +440,7 @@
 
     const handleMaxClick = () => {
         amount = isFiatCurrency(unit)
-            ? convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]).toString()
+            ? formatNumber(convertToFiat(from.balance, $currencies[CurrencyTypes.USD], $exchangeRates[unit]))
             : formatUnitPrecision(from.balance, unit, false)
     }
 


### PR DESCRIPTION
# Description of change

This PR aims to:
- Store per profile the first visit on the staking view
- Display the staking sidebar notification when detecting partially staked accounts

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
