### PR TITLE
Feat: Patch persistent tooltip bug

### DIFF
--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -257,7 +257,8 @@
     <div class="mb-2 w-full flex flex-row justify-between items-start space-x-1.5">
         <div class="flex flex-row space-x-1.5 items-start w-full whitespace-nowrap">
             {#if showWarningState}
-                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
+                <!-- TODO: remove on:click when Tooltip destruction works as expected -->
+                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip} on:click={() => showTooltip = false}>
                     <Icon
                         icon="exclamation"
                         width="16"

--- a/packages/shared/components/Tooltip.svelte
+++ b/packages/shared/components/Tooltip.svelte
@@ -35,7 +35,6 @@
 
     onMount(() => {
         // Bugfix: Tooltip z-index was not being applied
-        tooltip?.parentNode?.removeChild(tooltip)
         document?.body?.appendChild(tooltip)
         //
         refreshPosition()


### PR DESCRIPTION
# Description of change

Fix persistent tooltip on `AccountTile` warning icon click.
⚠️  Please note this is only a patch. Svelte is not destroying the `Tooltip` when its parent `AccountTile` is destroyed and the `Tooltip` is being displayed. Will investigate further and find a better solution.

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
