### PR TITLE
Fix: Disable Save button on customise wallet if name has not been changed

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
@@ -97,7 +97,7 @@
             <Button secondary classes="-mx-2 w-1/2" onClick={() => handleCancelClick()} disbled={isBusy}>
                 {locale('actions.cancel')}
             </Button>
-            <Button classes="-mx-2 w-1/2" onClick={() => handleSaveClick()} disabled={!getTrimmedLength(accountAlias) || isBusy}>
+            <Button classes="-mx-2 w-1/2" onClick={() => handleSaveClick()} disabled={!getTrimmedLength(accountAlias) || isBusy || accountAlias === alias}>
                 {locale('actions.save')}
             </Button>
         </div>


### PR DESCRIPTION
# Description of change

A condition for disabled state of save button was added, now it will be disabled if the alias input value is equal to account existing alias

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

- Go to customize wallet screen
- Save button should be disabled
- Add any character at the input
- Save button should be enabled
- Delete the characters added
- Save button should be disabled

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
