### PR TITLE
fix(shared): Use ICU message syntax for staking duration messages

### DIFF
--- a/packages/shared/lib/tests/mocks/i18n.ts
+++ b/packages/shared/lib/tests/mocks/i18n.ts
@@ -7,13 +7,9 @@
 // TODO: Write a function later to flatten all of the object
 //  property paths in locales/en.json.
 const LOCALE_DATA = {
-    'general.time.day': 'day',
     'general.time.days': 'days',
-    'general.time.hour': 'hour',
     'general.time.hours': 'hours',
-    'general.time.minute': 'minute',
     'general.time.minutes': 'minutes',
-    'general.time.second': 'second',
     'general.time.seconds': 'seconds',
 }
 

--- a/packages/shared/lib/time.ts
+++ b/packages/shared/lib/time.ts
@@ -30,24 +30,28 @@ export const getBestTimeDuration = (
     millis: number,
     noDurationUnit: 'days' | 'hours' | 'minutes' | 'seconds' = 'days'
 ): string => {
-    const noDurationInLocale = localize(`general.time.${noDurationUnit}`)
-    if (Number.isNaN(millis)) return `0 ${noDurationInLocale}`
+    const noDurationInLocale = localize(`general.time.${noDurationUnit}`, { values: { [noDurationUnit]: '0' } })
+    if (Number.isNaN(millis)) return noDurationInLocale
 
     const inDays = millis / (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
-    if (inDays > 1) return `${Math.ceil(inDays)} ${localize('general.time.days')}`
-    else if (inDays === 1) return `1 ${localize('general.time.day')}`
+    if (inDays >= 1) {
+        return localize('general.time.days', { values: { days: Math.ceil(inDays).toString() } })
+    }
 
     const inHours = millis / (MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
-    if (inHours > 1) return `${Math.ceil(inHours)} ${localize('general.time.hours')}`
-    else if (inHours === 1) return `1 ${localize('general.time.hour')}`
+    if (inHours >= 1) {
+        return localize('general.time.hours', { values: { hours: Math.ceil(inHours).toString() } })
+    }
 
     const inMinutes = millis / (SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
-    if (inMinutes > 1) return `${Math.ceil(inMinutes)} ${localize('general.time.minutes')}`
-    else if (inMinutes === 1) return `1 ${localize('general.time.minute')}`
+    if (inMinutes >= 1) {
+        return localize('general.time.minutes', { values: { minutes: Math.ceil(inMinutes).toString() } })
+    }
 
     const inSeconds = millis / MILLISECONDS_PER_SECOND
-    if (inSeconds > 1) return `${Math.ceil(inSeconds)} ${localize('general.time.seconds')}`
-    else if (inSeconds === 1) return `1 ${localize('general.time.second')}`
+    if (inSeconds >= 1) {
+        return localize('general.time.seconds', { values: { seconds: Math.ceil(inSeconds).toString() } })
+    }
 
-    return `0 ${noDurationInLocale}`
+    return noDurationInLocale
 }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1000,16 +1000,11 @@
         "version": "Version {version}",
         "unknown": "Unknown",
         "none": "None",
-        "days": "day(s)",
         "time": {
-            "days": "days",
-            "day": "day",
-            "hours": "hours",
-            "hour": "hour",
-            "minutes": "minutes",
-            "minute": "minute",
-            "seconds": "seconds",
-            "second": "second"
+            "days": "{days, plural, one {1 day} other {# days}}",
+            "hours": "{hours, plural, one {1 hour} other {# hours}}",
+            "minutes": "{minutes, plural, one {1 minute} other {# minutes}}",
+            "seconds": "{seconds, plural, one {1 second} other {# seconds}}"
         },
         "staked": "Staked",
         "unstaked": "Unstaked",


### PR DESCRIPTION
# Description of change

Languages such as Polish and Ukrainian have 4 [plural categories](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html) (one, few, many, other) instead of 2 (one, other) in languages like English. The current logic in `getBestTimeDuration` assumes languages have 2 plural categories, which causes strings to show with incorrect grammar in languages that have more than 2 plural categories. 

This PR uses ICU message syntax (similar to #64) to handle plurals for the staking duration messages and refactors `getBestTimeDuration` accordingly.

## Links to any relevant issues

Mentioned by Beniz in Discord

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes