### PR TITLE
Fix: reactivity not working in wallet txs overview & below minimum account tile

### DIFF
--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -161,7 +161,7 @@
 <button
     on:click={onClick}
     data-label="transaction-row"
-    class="w-full text-left flex rounded-2xl items-center bg-gray-100 dark:bg-gray-900 dark:bg-opacity-50 p-4 {(!confirmed || hasCachedMigrationTx) && 'opacity-50'} {hasCachedMigrationTx && 'pointer-events-none'} overflow-hidden"
+    class="w-full text-left flex rounded-2xl items-center bg-gray-100 dark:bg-gray-900 dark:bg-opacity-50 p-4 {(!confirmed || hasCachedMigrationTx) ? 'opacity-50' : ''} {hasCachedMigrationTx ? 'pointer-events-none' : ''} overflow-hidden"
     disabled={hasCachedMigrationTx}
 >
     <div class="w-8 flex flex-row justify-center items-center">

--- a/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/WalletHistory.svelte
@@ -94,10 +94,6 @@
             $isFirstSessionSync && $walletSetupType && $walletSetupType !== SetupType.New && $transactions.length === 0
         )
     }
-
-    function getTransactions(): AccountMessage[] {
-        return $transactions
-    }
 </script>
 
 <div data-label="latest-transactions" class="h-full pt-6 pb-8 px-8 flex-grow flex flex-col">
@@ -113,7 +109,7 @@
                 <Text secondary>{locale('general.firstSync')}</Text>
             </div>
         {:else if $transactions?.length}
-            {#each getTransactions() as transaction}
+            {#each $transactions as transaction}
                 <ActivityRow
                     {...transaction}
                     onClick={() => handleTransactionClick(transaction)}


### PR DESCRIPTION
# Description of change

This PR aims to fix 2 reactivity issues:
- Transactions not showing as confirmed in the profile transactions overview. This reactivity issue must have had other effects like new transactions not being displayed in this view if they appear for the first time when you are on this view
- Unstake wallet kept showing in yellow with the below minimum warning.

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

- Unstake wallet by sending all its funds and wait in the dashboard profile overview until it shows unstaked
- Move funds between wallets and wait in the dashboard profile overview until it gets confirmed and is not greyed out

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
