### PR TITLE
fix: disable accounts with pending transactions

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -250,15 +250,15 @@
 <Text type="h5">{locale('popups.stakingManager.title')}</Text>
 <Text type="p" secondary classes="mt-6 mb-4">{locale('popups.stakingManager.description')}</Text>
 <div class="staking flex flex-col scrollable-y">
-    {#each $accounts as account}
-        {#if getAccountParticipationAbility(account) !== AccountParticipationAbility.HasDustAmount}
+    {#each $accounts.map((a) => [a, getAccountParticipationAbility(a)]) as [account, participationAbility]}
+        {#if participationAbility !== AccountParticipationAbility.HasDustAmount}
             <div class={`w-full mt-4 flex flex-col rounded-xl border-2 border-solid ${isAccountPartiallyStaked(account?.id) ? 'border-yellow-600' : 'border-gray-200 dark:border-gray-600'}`}>
                 <div class="w-full space-x-4 px-5 py-3 flex flex-row justify-between items-center">
                     {#if isAccountStaked(account?.id)}
                         <div class="bg-green-100 rounded-2xl">
                             <Icon icon="success-check" width="19" height="19" classes="text-white" />
                         </div>
-                    {:else if getAccountParticipationAbility(account) === AccountParticipationAbility.WillNotReachMinAirdrop}
+                    {:else if participationAbility === AccountParticipationAbility.WillNotReachMinAirdrop}
                         <div
                             bind:this={tooltipAnchors[account?.index]}
                             on:mouseenter={() => toggleTooltip(account)}
@@ -312,22 +312,21 @@
                         {/if}
                     </div>
                     <Button
-                        disabled={$isPerformingParticipation || getAccountParticipationAbility(account) !== AccountParticipationAbility.Ok}
+                        disabled={$isPerformingParticipation || participationAbility === AccountParticipationAbility.HasPendingTransaction}
                         secondary={isAccountStaked(account?.id)}
                         onClick={() => (isAccountStaked(account?.id) ? handleUnstakeClick(account) : handleStakeClick(account))}>
-                        {#if ($accountToParticipate?.id === account?.id && $accountToParticipate && $participationAction) || getAccountParticipationAbility(account) === AccountParticipationAbility.HasPendingTransaction}
-                            <Spinner
-                                busy={$isPerformingParticipation}
-                                message={locale(`general.${getAccountParticipationAbility(account) === AccountParticipationAbility.HasPendingTransaction ? 'syncing' : $participationAction === ParticipationAction.Stake ? 'staking' : 'unstaking'}`)}
-                                classes="mx-2 justify-center" />
+                        {#if $accountToParticipate?.id !== account?.id && participationAbility === AccountParticipationAbility.HasPendingTransaction}
+                            {locale('general.syncing')}
+                        {:else if $accountToParticipate && $accountToParticipate?.id === account?.id && $participationAction}
+                            <Spinner busy={$isPerformingParticipation} classes="mx-2 justify-center" />
                         {:else}
                             {locale(`actions.${isAccountStaked(account?.id) ? 'unstake' : 'stake'}`)}
                         {/if}
                     </Button>
                 </div>
-                {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id && getAccountParticipationAbility(account) !== AccountParticipationAbility.WillNotReachMinAirdrop}
+                {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id && participationAbility !== AccountParticipationAbility.WillNotReachMinAirdrop}
                     <div
-                        class="space-x-4 mx-2 mb-2 px-4 py-3 flex flex-row justify-between items-center rounded-lg border-2 border-solid border-gray-200 dark:border-gray-600">
+                        class="space-x-4 mx-2 mb-2 pl-4 pr-2.5 py-3 flex flex-row justify-between items-center rounded-lg border-2 border-solid border-gray-200 dark:border-gray-600">
                         <Icon icon="exclamation" width="24" height="24" classes="fill-current text-yellow-600" />
                         <div class="flex flex-col w-3/4">
                             <Text type="p" classes="font-extrabold">{locale('general.unstakedFunds')}</Text>
@@ -341,7 +340,7 @@
                         </div>
                         <Button
                             caution={isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id}
-                            disabled={$isPerformingParticipation || getAccountParticipationAbility(account) === AccountParticipationAbility.HasPendingTransaction}
+                            disabled={$isPerformingParticipation || participationAbility === AccountParticipationAbility.HasPendingTransaction}
                             onClick={() => handleStakeClick(account)}>
                             {locale('actions.merge')}
                         </Button>

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -312,12 +312,17 @@
                         {/if}
                     </div>
                     <Button
-                        disabled={$isPerformingParticipation || getAccountParticipationAbility(account) === AccountParticipationAbility.HasPendingTransaction || getAccountParticipationAbility(account) === AccountParticipationAbility.WillNotReachMinAirdrop}
+                        disabled={$isPerformingParticipation || getAccountParticipationAbility(account) !== AccountParticipationAbility.Ok}
                         secondary={isAccountStaked(account?.id)}
                         onClick={() => (isAccountStaked(account?.id) ? handleUnstakeClick(account) : handleStakeClick(account))}>
-                        {#if $accountToParticipate?.id === account?.id && $accountToParticipate && $participationAction}
-                            <Spinner busy={$isPerformingParticipation} classes="mx-2 justify-center" />
-                        {:else}{locale(`actions.${isAccountStaked(account?.id) ? 'unstake' : 'stake'}`)}{/if}
+                        {#if ($accountToParticipate?.id === account?.id && $accountToParticipate && $participationAction) || getAccountParticipationAbility(account) === AccountParticipationAbility.HasPendingTransaction}
+                            <Spinner
+                                busy={$isPerformingParticipation}
+                                message={locale(`general.${getAccountParticipationAbility(account) === AccountParticipationAbility.HasPendingTransaction ? 'syncing' : $participationAction === ParticipationAction.Stake ? 'staking' : 'unstaking'}`)}
+                                classes="mx-2 justify-center" />
+                        {:else}
+                            {locale(`actions.${isAccountStaked(account?.id) ? 'unstake' : 'stake'}`)}
+                        {/if}
                     </Button>
                 </div>
                 {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id && getAccountParticipationAbility(account) !== AccountParticipationAbility.WillNotReachMinAirdrop}

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -1,5 +1,5 @@
 import { toHexString } from '../utils'
-import { DUST_THRESHOLD } from '../wallet'
+import { DUST_THRESHOLD, hasPendingTransactions } from '../wallet'
 import type { WalletAccount } from '../typings/wallet'
 
 import { getParticipationOverview } from './api'
@@ -98,7 +98,7 @@ export const canParticipate = (eventState: ParticipationEventState): boolean => 
 export const getAccountParticipationAbility = (account: WalletAccount): AccountParticipationAbility => {
     if (account?.rawIotaBalance < DUST_THRESHOLD) {
         return AccountParticipationAbility.HasDustAmount
-    } else if (account?.messages.some((message) => !message.confirmed)) {
+    } else if (hasPendingTransactions(account)) {
         return AccountParticipationAbility.HasPendingTransaction
     } else if (!canAccountReachMinimumAirdrop(account, StakingAirdrop.Assembly)) {
         return AccountParticipationAbility.WillNotReachMinAirdrop

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -15,6 +15,7 @@ import {
     partiallyStakedAccounts,
     participationEvents,
     participationOverview,
+    pendingParticipations,
     shimmerStakingRemainingTime,
     stakedAccounts,
 } from './stores'
@@ -444,6 +445,7 @@ export const getIotasUntilMinimumAirdropReward = (
  * @method canAccountReachMinimumAirdrop
  *
  * @param {WalletAccount} account
+ * @param {StakingAirdrop} airdrop
  *
  * @returns {boolean}
  */

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -2018,3 +2018,18 @@ const calculateRegularSyncAccountOptions = (profileType: ProfileType, isManualSy
 
     return { gapLimit, accountDiscoveryThreshold }
 }
+
+/**
+ * Determines whether an account has any currently pending transactions.
+ *
+ * @method hasPendingTransactions
+ *
+ * @param {WalletAccount} account
+ *
+ * @returns {boolean}
+ */
+export const hasPendingTransactions = (account: WalletAccount): boolean => {
+    if (!account) return false
+
+    return account?.messages.some((m) => !m.confirmed)
+}

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -969,6 +969,7 @@
         "passwordUpdating": "Updating password...",
         "passwordSuccess": "Updated password successfully",
         "passwordFailed": "Updating password failed",
+        "syncing": "Syncing",
         "syncingAccounts": "Syncing wallets...",
         "exportingStronghold": "Exporting Stronghold...",
         "exportingStrongholdSuccess": "Exported Stronghold successfully",


### PR DESCRIPTION
# Description of change
This PR:
- Adds additional logic to disable UI for staking if an account has pending transactions and isn't currently being actioned to stake or unstake
- Fixes CSS to align "Merge" and "Unstake" buttons for partially staked accounts

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Cases:
- Sending internal transfer and staking / unstaking other accounts
- Sending internal transfer and merging partially staked funds

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes