### PR TITLE
fix: use locale agnostic UI logic

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
@@ -14,7 +14,7 @@
         stakedAccounts,
         stakingEventState,
     } from 'shared/lib/participation/stores'
-    import { ParticipationEventState, StakingAirdrop } from 'shared/lib/participation/types'
+    import { ParticipationEventState, ParticipationOverview, StakingAirdrop } from 'shared/lib/participation/types'
     import { getBestTimeDuration } from 'shared/lib/time'
     import { capitalize } from 'shared/lib/utils'
 
@@ -23,11 +23,16 @@
     const isAssembly = (): boolean => airdrop === StakingAirdrop.Assembly
     const isShimmer = (): boolean => airdrop === StakingAirdrop.Shimmer
 
+    const parseRemainingTime = (overview: ParticipationOverview): [string, string] => {
+        const formattedValue = getBestTimeDuration(isAssembly() ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime)
+        const timeAmount = parseFloat(formattedValue).toString()
+        const timeUnit = formattedValue.replace(timeAmount.toString(), '')
+
+        return [timeAmount, timeUnit]
+    }
+
     let remainingTimeAmount, remainingTimeUnit
-    $: $participationOverview,
-        ([remainingTimeAmount, remainingTimeUnit] = getBestTimeDuration(
-            isAssembly() ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
-        ).split(' '))
+    $: [remainingTimeAmount, remainingTimeUnit] = parseRemainingTime($participationOverview)
 
     $: stakedAccountsInCurrentAirdrop =
         $stakedAccounts?.filter((account) =>


### PR DESCRIPTION
# Description of change
Some UI logic to add extra styling for the remaining airdrop time display uses the existence of a whitespace whereas some locales may not include whitespaces between the number and counter (e.g. "50 Days" is "50日" in Japanese).

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Cases:
- View staking dashboard for locales that both use do NOT use whitespaces a number and counter (e.g. English vs. Japanese)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes