### PR TITLE
fix: zen guy for both airdrops

### DIFF
--- a/packages/shared/locales/ja.json
+++ b/packages/shared/locales/ja.json
@@ -310,16 +310,16 @@
                 "description": ""
             },
             "theme": {
-                "title": "テーマ：",
+                "title": "テーマ",
                 "description": "",
                 "advice": "Fireflyアプリケーションを再起動して、システムテーマの変更を有効にします"
             },
             "language": {
-                "title": "言語:",
+                "title": "言語",
                 "description": ""
             },
             "currency": {
-                "title": "通貨：",
+                "title": "通貨",
                 "description": "残高変換を調整し、チャートオプションを更新します"
             },
             "notifications": {

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -2,6 +2,7 @@
     import { Animation, Link, Text } from 'shared/components'
     import { Electron } from 'shared/lib/electron'
     import { localize } from 'shared/lib/i18n'
+    import { STAKING_EVENT_IDS } from 'shared/lib/participation/constants'
     import {
         assemblyStakingRemainingTime,
         participationOverview,
@@ -20,21 +21,20 @@
             return null
         }
         else if (state === ParticipationEventState.Holding) {
-            let numParticipations = 0
+            const stakingParticipationIds: string[] = []
+            overview.forEach((apo) => {
+                apo.participations.forEach((p) => {
+                    if (!stakingParticipationIds.includes(p.eventId) && STAKING_EVENT_IDS.includes(p.eventId)) {
+                        stakingParticipationIds.push(p.eventId)
+                    }
+                })
+            })
 
-            if (overview.some((apo) => apo.shimmerStakedFunds > 0 && apo.assemblyStakedFunds > 0)) {
-                numParticipations = 2
-            } else if (overview.some((apo) => apo.shimmerStakedFunds > 0 || apo.assemblyStakedFunds > 0)) {
-                numParticipations = 1
-            }
-
-            let fileNumber
-            if (numParticipations >= 2) {
+            let fileNumber = 0
+            if (stakingParticipationIds.length >= 2) {
                 fileNumber = 2
-            } else if (numParticipations === 1) {
+            } else if (stakingParticipationIds.length === 1) {
                 fileNumber = 1
-            } else {
-                fileNumber = 0
             }
 
             return `${prefix}-${state}-${fileNumber}`


### PR DESCRIPTION
# Description of change
This PR:
- Fixes the logic for determining which zen guy animation to display in the `StakingInfo` tile.
- Fixes punctuation typo in the Japanese locale (`shared/locales/ja.json`)

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Cases:
- Staking one account for both Assembly and Shimmer 
- Staking two accounts: one for Assembly and the other for Shimmer

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes