### PR TITLE
fix: consistent icon sizes

### DIFF
--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -160,7 +160,7 @@
                         bind:this={tooltipAnchors[airdrop]}
                         on:mouseenter={() => toggleTooltip(airdrop)}
                         on:mouseleave={() => toggleTooltip(airdrop)}>
-                        <Icon icon="exclamation" width="30" height="30" classes="text-orange-500" />
+                        <Icon icon="exclamation" width="26" height="26" classes="text-orange-500" />
                     </div>
                 {:else}
                     <Checkbox

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -256,7 +256,7 @@
                 <div class="w-full space-x-4 px-5 py-3 flex flex-row justify-between items-center">
                     {#if isAccountStaked(account?.id)}
                         <div class="bg-green-100 rounded-2xl">
-                            <Icon icon="success-check" width="19" height="19" classes="text-white" />
+                            <Icon icon="success-check" width="18" height="18" classes="text-white" />
                         </div>
                     {:else if participationAbility === AccountParticipationAbility.WillNotReachMinAirdrop}
                         <div
@@ -264,7 +264,7 @@
                             on:mouseenter={() => toggleTooltip(account)}
                             on:mouseleave={() => toggleTooltip(account)}
                         >
-                            <Icon icon="exclamation" width="18" height="18" classes="text-orange-500" />
+                            <Icon icon="exclamation" width="20" height="20" classes="text-orange-500" />
                         </div>
                     {:else}
                         <Icon
@@ -327,7 +327,7 @@
                 {#if isAccountPartiallyStaked(account?.id) && $accountToParticipate?.id !== account?.id && participationAbility !== AccountParticipationAbility.WillNotReachMinAirdrop}
                     <div
                         class="space-x-4 mx-2 mb-2 pl-4 pr-2.5 py-3 flex flex-row justify-between items-center rounded-lg border-2 border-solid border-gray-200 dark:border-gray-600">
-                        <Icon icon="exclamation" width="24" height="24" classes="fill-current text-yellow-600" />
+                        <Icon icon="exclamation" width="20" height="20" classes="fill-current text-yellow-600" />
                         <div class="flex flex-col w-3/4">
                             <Text type="p" classes="font-extrabold">{locale('general.unstakedFunds')}</Text>
                             <Text type="p" secondary classes="font-extrabold">


### PR DESCRIPTION
# Description of change

Icons on the StakingManager and StakingConfirmation popups where not consistent sizes relative to other icons on those components. This fix I have manually adjusted the sizes so they all appear to be the same size as the other ones on that popup.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)


## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
