### PR TITLE
Fix: Re-render account component only by selected account ID

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Account.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Account.svelte
@@ -1,10 +1,11 @@
 <script lang="typescript">
     import { AccountActionsModal, DashboardPane } from 'shared/components'
+    import { Locale } from 'shared/lib/typings/i18n'
+    import { AccountMessage, WalletAccount } from 'shared/lib/typings/wallet'
+    import { selectedAccountId } from 'shared/lib/wallet'
     import { getContext } from 'svelte'
     import type { Readable } from 'svelte/store'
     import { AccountActions, AccountBalance, AccountHistory, AccountNavigation, BarChart, LineChart } from '.'
-    import { Locale } from 'shared/lib/typings/i18n'
-    import { AccountMessage, WalletAccount } from 'shared/lib/typings/wallet'
 
     export let locale: Locale
 
@@ -35,7 +36,7 @@
 {#if $viewableAccounts && $account}
     <div class="w-full h-full flex flex-col flex-nowrap p-10 pt-0 relative flex-1 bg-gray-50 dark:bg-gray-900">
         <AccountNavigation {locale} accounts={navAccounts} />
-        {#key $account}
+        {#key $selectedAccountId}
             <div class="w-full h-full grid grid-cols-3 gap-x-4 min-h-0">
                 <DashboardPane classes=" h-full flex flex-auto flex-col flex-shrink-0">
                     <AccountBalance
@@ -45,7 +46,12 @@
                         balanceEquiv={$account.balanceEquiv}
                         onMenuClick={handleMenuClick} />
                     <DashboardPane classes="h-full -mt-5 z-0">
-                        <AccountActions {isGeneratingAddress} {onSend} {onInternalTransfer} {onGenerateAddress} {locale} />
+                        <AccountActions
+                            {isGeneratingAddress}
+                            {onSend}
+                            {onInternalTransfer}
+                            {onGenerateAddress}
+                            {locale} />
                     </DashboardPane>
                 </DashboardPane>
                 <DashboardPane>


### PR DESCRIPTION
# Description of change

All the components within the view `Account.svelte` were being re-mounted based on any current account change. This was causing things like the re-mounting the `Send.svelte` component if the account changed somehow, like finished syncing and pulled changes. 
This PR makes the components re-mount only if the selected account ID changes, which you can do by browsing on the top right account(wallet) navigator.  

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
