### PR TITLE
fix: staking notification badge logic and colour

### DIFF
--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -3,7 +3,7 @@
     import { getInitials } from 'shared/lib/helpers'
     import { networkStatus, NETWORK_HEALTH_COLORS } from 'shared/lib/networkStatus'
     import { isStakingPossible } from 'shared/lib/participation'
-    import { stakingEventState, unstakedAmount } from 'shared/lib/participation/stores'
+    import { partiallyUnstakedAmount, stakingEventState } from 'shared/lib/participation/stores'
     import { activeProfile } from 'shared/lib/profile'
     import { dashboardRoute, resetWalletRoute } from 'shared/lib/router'
     import type { Locale } from 'shared/lib/typings/i18n'
@@ -16,7 +16,7 @@
     let showNetwork = false
     let healthStatus = 2
     let showProfile = false
-    let _prevUnstakedAmount = 0 // store the previous unstaked funds to avoid notifying when unstaked funds decrease
+    let _prevPartiallyUnstakedAmount = 0 // store the previous unstaked funds to avoid notifying when unstaked funds decrease
     let showStakingNotification = false
 
     const profileColor = 'blue' // TODO: each profile has a different color
@@ -27,16 +27,16 @@
         healthStatus = data.health ?? 0
     })
 
-    $: $dashboardRoute, $stakingEventState, $unstakedAmount, manageUnstakedAmountNotification()
+    $: $dashboardRoute, $stakingEventState, $partiallyUnstakedAmount, manageUnstakedAmountNotification()
 
     function manageUnstakedAmountNotification() {
         if (isStakingPossible($stakingEventState)) {
-            if ($dashboardRoute !== Tabs.Staking && $unstakedAmount > _prevUnstakedAmount) {
+            if ($dashboardRoute !== Tabs.Staking && $partiallyUnstakedAmount > _prevPartiallyUnstakedAmount) {
                 showStakingNotification = true
             } else {
                 showStakingNotification = false
             }
-            _prevUnstakedAmount = $unstakedAmount
+            _prevPartiallyUnstakedAmount = $partiallyUnstakedAmount
         } else {
             showStakingNotification = false
         }

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -81,8 +81,8 @@
                 {#if !$activeProfile?.hasVisitedStaking || showStakingNotification}
                     <span class="absolute -top-2 -left-2 flex justify-center items-center h-3 w-3">
                         <span
-                            class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-75" />
-                        <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                            class="animate-ping absolute inline-flex h-full w-full rounded-full {showStakingNotification ? 'bg-yellow-400' : 'bg-red-300'} opacity-75" />
+                        <span class="relative inline-flex rounded-full h-2 w-2 {showStakingNotification ? 'bg-yellow-600' : 'bg-red-500'}" />
                     </span>
                 {/if}
             </button>

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -144,11 +144,13 @@ export const partiallyUnstakedAmount: Readable<number> = derived(
 
         const _eval = (overview: AccountParticipationOverview): number => {
             const assemblyPartialFunds =
-                overview.assemblyStakedFunds > 0 && overview.assemblyUnstakedFunds > 0
-                    ? overview.assemblyUnstakedFunds
+                overview?.assemblyStakedFunds > 0 && overview?.assemblyUnstakedFunds > 0
+                    ? overview?.assemblyUnstakedFunds
                     : 0
             const shimmerPartialFunds =
-                overview.shimmerStakedFunds > 0 && overview.shimmerUnstakedFunds > 0 ? overview.shimmerUnstakedFunds : 0
+                overview?.shimmerStakedFunds > 0 && overview?.shimmerUnstakedFunds > 0
+                    ? overview?.shimmerUnstakedFunds
+                    : 0
 
             return Math.max(assemblyPartialFunds, shimmerPartialFunds)
         }


### PR DESCRIPTION
# Description of change

Fix logic to use partiallyUnstakedAmount instead of unstakedAmount

Update colours:

- Red colour indicates that the staking feature is new to the user.
- Yellow indicates there is partially staked funds that need action

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
