### PR TITLE
fix: close popup on settings navigation

### DIFF
--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -12,6 +12,7 @@ import {
 import { selectedAccountId } from 'shared/lib/wallet'
 import { get, readable, writable } from 'svelte/store'
 import { deepLinkRequestActive } from './deepLinking/deepLinking'
+import { closePopup } from './popup'
 import { ProfileType } from './typings/profile'
 
 /**
@@ -312,6 +313,7 @@ export const resetLedgerRoute = (): void => {
 }
 
 export const openSettings = (): void => {
+    closePopup()
     previousDashboardRoute.set(get(dashboardRoute))
     dashboardRoute.set(Tabs.Settings)
     settingsRoute.set(SettingsRoutes.Init)


### PR DESCRIPTION
# Description of change

When using electron menu to navigate to settings it will not close any popups, so this fix manually calls function to close the popups. 

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

Manually on MacOS 12.0

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
