### PR TITLE
Feat: Learn more in airdrop network info

### DIFF
--- a/packages/shared/components/popups/AirdropNetworkInfo.svelte
+++ b/packages/shared/components/popups/AirdropNetworkInfo.svelte
@@ -1,9 +1,35 @@
 <script lang="typescript">
-    import { Illustration, Text } from 'shared/components'
+    import { Illustration, Link, Text } from 'shared/components'
+    import { Electron } from 'shared/lib/electron'
     import { localize } from 'shared/lib/i18n'
-    import type { StakingAirdrop } from 'shared/lib/participation/types'
+    import { showAppNotification } from 'shared/lib/notifications'
+    import { StakingAirdrop } from 'shared/lib/participation/types'
+    import { capitalize } from 'shared/lib/utils'
 
     export let airdrop: StakingAirdrop
+
+    const handleLearnMoreClick = (): void => {
+        const url = getLearnMoreUrl()
+        if (!url) {
+            showAppNotification({
+                type: 'error',
+                message: localize('error.participation.cannotVisitAirdropWebsite', {
+                    values: { airdrop: capitalize(airdrop) },
+                }),
+            })
+        }
+        Electron.openUrl(getLearnMoreUrl())
+    }
+    const getLearnMoreUrl = (): string => {
+        switch (airdrop) {
+            case StakingAirdrop.Assembly:
+                return 'https://assembly.sc'
+            case StakingAirdrop.Shimmer:
+                return 'https://shimmer.network'
+            default:
+                return ''
+        }
+    }
 </script>
 
 <div class="mb-5 text-center">
@@ -13,4 +39,5 @@
 <div class="flex flex-col flex-wrap space-y-3">
     <Text type="p">{localize(`popups.${airdrop}-info.body1`)}</Text>
     <Text type="p">{localize(`popups.${airdrop}-info.body2`)}</Text>
+    <Link onClick={handleLearnMoreClick} classes="text-14">{localize('actions.visitWebsite')}</Link>
 </div>


### PR DESCRIPTION
# Description of change

Adds a link to the assembly & shimmer network info popup.

## Type of change

- New (a change which implements a new feature)

## How the change has been tested

Tested on:

- macOS Monterey 12.1 

<img width="497" alt="Bildschirmfoto 2021-12-20 um 15 39 19" src="https://user-images.githubusercontent.com/17240275/146784943-7a02875e-a453-4c58-826a-25294b0a4844.png">