### PR TITLE
feat: keep track of the last logged in profile

### DIFF
--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -56,7 +56,7 @@
              * from the Svelte store list of profiles, otherwise the
              * actor is not able to be destroyed.
              */
-            await logout()
+            await logout(true)
 
             /**
              * CAUTION: The profile must be removed from the

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -83,7 +83,7 @@ export const login = (): void => {
 
  * Logout from current profile
  */
-export const logout = (): Promise<void> =>
+export const logout = (_clearActiveProfile: boolean = false): Promise<void> =>
     new Promise<void>((resolve) => {
         const _activeProfile = get(activeProfile)
 
@@ -107,7 +107,7 @@ export const logout = (): Promise<void> =>
 
             clearSendParams()
             closePopup(true)
-            clearActiveProfile()
+            if (_clearActiveProfile) clearActiveProfile()
             resetParticipation()
             resetWallet()
             resetRouter()

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -13,7 +13,7 @@ import type { WalletAccount } from './typings/wallet'
 import { getOfficialNetworkConfig } from './network'
 import { NetworkConfig, NetworkType } from './typings/network'
 
-export const activeProfileId = writable<string | null>(null)
+export const activeProfileId = persistent<string | null>('activeProfileId', null)
 
 export const profiles = persistent<Profile[]>('profiles', [])
 

--- a/packages/shared/routes/login/Login.svelte
+++ b/packages/shared/routes/login/Login.svelte
@@ -3,7 +3,8 @@
     import { Transition } from 'shared/components'
     import { SelectProfile, EnterPin } from './views/'
     import { Locale } from 'shared/lib/typings/i18n'
-    import { migrateProfile } from 'shared/lib/profile'
+    import { migrateProfile, activeProfileId } from 'shared/lib/profile'
+    import { get } from 'svelte/store'
 
     export let locale: Locale
 
@@ -16,7 +17,7 @@
 
     const dispatch = createEventDispatcher()
 
-    let state: LoginState = LoginState.Init
+    let state: LoginState = get(activeProfileId) ? LoginState.EnterPin : LoginState.Init
     let stateHistory = []
 
     const _next = (event) => {
@@ -49,6 +50,7 @@
         if (prevState) {
             state = prevState
         } else {
+            state = LoginState.Init
             dispatch('previous')
         }
     }

--- a/packages/shared/routes/login/Login.svelte
+++ b/packages/shared/routes/login/Login.svelte
@@ -21,7 +21,7 @@
     let stateHistory = []
 
     onMount(() => {
-        if (get(profiles).find((p) => p.id === get(activeProfileId))) {
+        if (get(activeProfileId) && get(profiles)?.find((p) => p.id === get(activeProfileId))) {
             _next()
         } else {
             clearActiveProfile()

--- a/packages/shared/routes/login/Login.svelte
+++ b/packages/shared/routes/login/Login.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Transition } from 'shared/components'
-    import { activeProfileId, migrateProfile } from 'shared/lib/profile'
+    import { activeProfileId, clearActiveProfile, migrateProfile, profiles } from 'shared/lib/profile'
     import type { Locale } from 'shared/lib/typings/i18n'
     import { createEventDispatcher, onMount } from 'svelte'
     import { get } from 'svelte/store'
@@ -21,8 +21,10 @@
     let stateHistory = []
 
     onMount(() => {
-        if (get(activeProfileId)) {
+        if (get(profiles).find((p) => p.id === get(activeProfileId))) {
             _next()
+        } else {
+            clearActiveProfile()
         }
     })
 

--- a/packages/shared/routes/login/Login.svelte
+++ b/packages/shared/routes/login/Login.svelte
@@ -1,10 +1,10 @@
 <script lang="typescript">
-    import { createEventDispatcher } from 'svelte'
     import { Transition } from 'shared/components'
-    import { SelectProfile, EnterPin } from './views/'
-    import { Locale } from 'shared/lib/typings/i18n'
-    import { migrateProfile, activeProfileId } from 'shared/lib/profile'
+    import { activeProfileId, migrateProfile } from 'shared/lib/profile'
+    import type { Locale } from 'shared/lib/typings/i18n'
+    import { createEventDispatcher, onMount } from 'svelte'
     import { get } from 'svelte/store'
+    import { EnterPin, SelectProfile } from './views/'
 
     export let locale: Locale
 
@@ -17,12 +17,22 @@
 
     const dispatch = createEventDispatcher()
 
-    let state: LoginState = get(activeProfileId) ? LoginState.EnterPin : LoginState.Init
+    let state: LoginState = LoginState.Init
     let stateHistory = []
 
-    const _next = (event) => {
+    onMount(() => {
+        if (get(activeProfileId)) {
+            _next()
+        }
+    })
+
+    const _next = (
+        event: {
+            detail: any
+        } = { detail: {} }
+    ) => {
         let nextState
-        const params = event.detail || {}
+        const params = event?.detail || {}
         switch (state) {
             case LoginState.Init: {
                 const { shouldAddProfile } = params
@@ -50,7 +60,6 @@
         if (prevState) {
             state = prevState
         } else {
-            state = LoginState.Init
             dispatch('previous')
         }
     }

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -3,7 +3,7 @@
     import { Electron } from 'shared/lib/electron'
     import { ongoingSnapshot, openSnapshotPopup } from 'shared/lib/migration'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { activeProfile } from 'shared/lib/profile'
+    import { activeProfile, activeProfileId } from 'shared/lib/profile'
     import { validatePinFormat } from 'shared/lib/utils'
     import { api, getStoragePath, initialise } from 'shared/lib/wallet'
     import { createEventDispatcher, onDestroy } from 'svelte'
@@ -113,6 +113,7 @@
 
     function handleBackClick() {
         if (!hasReachedMaxAttempts) {
+            activeProfileId.set(null)
             dispatch('previous')
         }
     }

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -3,7 +3,7 @@
     import { Electron } from 'shared/lib/electron'
     import { ongoingSnapshot, openSnapshotPopup } from 'shared/lib/migration'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { activeProfile, activeProfileId } from 'shared/lib/profile'
+    import { activeProfile, clearActiveProfile } from 'shared/lib/profile'
     import { validatePinFormat } from 'shared/lib/utils'
     import { api, getStoragePath, initialise } from 'shared/lib/wallet'
     import { createEventDispatcher, onDestroy } from 'svelte'
@@ -113,7 +113,7 @@
 
     function handleBackClick() {
         if (!hasReachedMaxAttempts) {
-            activeProfileId.set(null)
+            clearActiveProfile()
             dispatch('previous')
         }
     }


### PR DESCRIPTION
# Description of change

Keep track of the last logged-in profile using persistent storage of the active profile id

## Links to any relevant issues

Resolves #1562
Closes https://github.com/iotaledger/firefly/issues/2050

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Update (a change that updates existing functionality)

## How the change has been tested

- Select a profile
- Refresh the application
- Enter pin screen is the first loaded one and the select profile is the first step one
- Click on the previous button
- Refresh the application
- Select profile screen is the first loaded one

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
