### PR TITLE
fix: check for activeProfile object before accessing migratedTransactions prop

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -1726,7 +1726,11 @@ export const processMigratedTransactions = (accountId: string, messages: Message
             if (account) {
                 const _activeProfile = get(activeProfile)
 
-                if (_activeProfile.migratedTransactions && _activeProfile.migratedTransactions.length) {
+                if (
+                    _activeProfile &&
+                    _activeProfile.migratedTransactions &&
+                    _activeProfile.migratedTransactions.length
+                ) {
                     const { funds } = message.payload.data.essence.receipt.data
 
                     const tailTransactionHashes = funds.map((fund) => fund.tailTransactionHash)


### PR DESCRIPTION
# Description of change

If `activeProfile` is null, it leads to a crash because we don't do a null check.

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
