### PR TITLE
Feat: Add tooltip to wallet staking

### DIFF
--- a/packages/shared/components/WalletPill.svelte
+++ b/packages/shared/components/WalletPill.svelte
@@ -1,0 +1,39 @@
+<script lang="typescript">
+    import { Text, Tooltip } from 'shared/components'
+    import { getInitials } from 'shared/lib/helpers'
+    import { localize } from 'shared/lib/i18n'
+
+    export let name: string = ''
+    export let color: string = 'blue'
+    export let size: 's' | 'm' = 'm'
+    export let active: boolean = false
+    export let onClick: () => void = () => {}
+    export let enableTooltip = false
+    export let tooltipPosition: 'top' | 'bottom' | 'left' | 'right' = 'top'
+    export let classes: string = ''
+
+    let showTooltip = false
+    let tooltipAnchor
+
+    const toggleTooltip = (): void => {
+        showTooltip = !showTooltip
+    }
+</script>
+
+<button
+    on:click={onClick}
+    on:mouseenter={toggleTooltip}
+    on:mouseleave={toggleTooltip}
+    bind:this={tooltipAnchor}
+    class="{size === 'm' ? 'w-10 h-10 rounded-xl p-2 text-14' : 'w-8 h-8 rounded-lg p-1 text-12'} leading-100 font-bold text-center
+            {active ? `bg-${color}-500 text-white` : 'bg-gray-200 dark:bg-gray-700 text-gray-500'} 
+            hover:bg-{color}-500 hover:text-white {classes}">{getInitials(name, 2)}
+</button>
+
+{#if enableTooltip && showTooltip}
+    <Tooltip anchor={tooltipAnchor} position={tooltipPosition}>
+        <Text type="p" classes="text-gray-900 bold text-center">
+            {localize('general.stakingName', { values: { name } })}
+        </Text>
+    </Tooltip>
+{/if}

--- a/packages/shared/components/index.js
+++ b/packages/shared/components/index.js
@@ -51,6 +51,7 @@ export { default as ButtonCheckbox } from './ButtonCheckbox.svelte'
 export { default as Animation } from './Animation.svelte'
 export { default as ProgressFlow } from './ProgressFlow.svelte'
 export { default as Video } from './Video.svelte'
+export { default as WalletPill } from './WalletPill.svelte'
 
 export * from './modals'
 // Charts

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1005,7 +1005,8 @@
         "unstaking": "Unstaking",
         "notStaked": "Not staked",
         "stakedFunds": "Staked funds",
-        "unstakedFunds": "Unstaked funds"
+        "unstakedFunds": "Unstaked funds",
+        "stakingName": "Staking: {name}"
     },
     "dates": {
         "today": "Today",

--- a/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
@@ -1,7 +1,6 @@
 <script lang="typescript">
-    import { HR, Link, StakingAirdropIndicator, Text } from 'shared/components'
+    import { HR, Link, StakingAirdropIndicator, Text, WalletPill } from 'shared/components'
     import { Electron } from 'shared/lib/electron'
-    import { getInitials } from 'shared/lib/helpers'
     import { localize } from 'shared/lib/i18n'
     import { showAppNotification } from 'shared/lib/notifications'
     import { formatStakingAirdropReward, isStakingPossible } from 'shared/lib/participation'
@@ -24,7 +23,9 @@
     const isShimmer = (): boolean => airdrop === StakingAirdrop.Shimmer
 
     const parseRemainingTime = (overview: ParticipationOverview): [string, string] => {
-        const formattedValue = getBestTimeDuration(isAssembly() ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime)
+        const formattedValue = getBestTimeDuration(
+            isAssembly() ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
+        )
         const timeAmount = parseFloat(formattedValue).toString()
         const timeUnit = formattedValue.replace(timeAmount.toString(), '')
 
@@ -111,10 +112,8 @@
         <div class="flex flex-col">
             <div class="flex flex-row flex-wrap mb-2">
                 {#each stakedAccountsInCurrentAirdrop as acc}
-                    <div
-                        class="mb-2 mr-2 w-8 h-8 rounded-lg p-1 flex items-center justify-center bg-{acc.color}-500">
-                        <span
-                            class="text-12 leading-100 font-bold text-center text-white">{getInitials(acc.alias, 2)}</span>
+                    <div class="mb-2 mr-2">
+                        <WalletPill active enableTooltip size="s" name={acc.alias} color={acc.color} classes="cursor-default" />
                     </div>
                 {/each}
             </div>

--- a/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountNavigation.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Icon, Text } from 'shared/components'
+    import { Icon, Text, WalletPill } from 'shared/components'
     import { getInitials } from 'shared/lib/helpers'
     import { accountRoute, walletRoute } from 'shared/lib/router'
     import { AccountRoutes, WalletRoutes } from 'shared/lib/typings/routes'
@@ -73,14 +73,13 @@
     </button>
     <Text type="h3" classes="flex-1 text-center mt-1 mx-5">{activeAccount.alias}</Text>
     <div class="flex-1 flex flex-row justify-end overflow-x-auto scroll-tertiary">
-        <div class="flex flex-row pb-1" bind:this={accountElement}>
+        <div class="flex flex-row pb-1 space-x-4" bind:this={accountElement}>
             {#each accounts as acc}
-                <button
-                    on:click={() => handleAccountClick(acc.id)}
-                    class="w-10 h-10 rounded-xl p-2 text-14 leading-100 font-bold text-center
-            {activeAccount.id === acc.id ? `bg-${acc.color}-500 text-white` : 'bg-gray-200 dark:bg-gray-700 text-gray-500'} 
-            hover:bg-{acc.color}-500 hover:text-white">{getInitials(acc.alias, 2)}
-                </button>
+                <WalletPill
+                    active={activeAccount.id === acc.id}
+                    name={acc.alias}
+                    color={acc.color}
+                    onClick={() => handleAccountClick(acc.id)} />
             {/each}
         </div>
     </div>


### PR DESCRIPTION
# Description of change

This PR aims to add a tooltip to the wallet pills that appear on the airdrop project tiles. In order to achieve so I decided creating a new reusable `WalletPill` component

## Links to any relevant issues

N/A

## Type of change

- Update (a change which updates existing functionality)

## How the change has been tested

- Wallet navigation should behave as usual, no changes.
Now when you hover the mini wallet in the staking tiles it should display the full name of the wallet.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
