### PR TITLE
fix: minimum staking reward calculation

### DIFF
--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -109,7 +109,7 @@
     }
 
     let tooltipText
-    $: $participationOverview, (tooltipText = getLocalizedTooltipText())
+    $: $participationOverview, (tooltipText = getLocalizedTooltipText()), console.log($participationOverview)
 
     const getLocalizedTooltipText = (): { title: string; body: string[] } => {
         const { accounts } = get(wallet)
@@ -160,9 +160,12 @@
                 }
             } else if (!isAccountStaked(account?.id) && isStakingPossible($stakingEventState)) {
                 const timeNeededShimmer = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Shimmer)
+                console.log(`shimmer: ${timeNeededShimmer} = ${getBestTimeDuration(timeNeededShimmer)}`)
                 const timeNeededAssembly = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Assembly)
+                console.log(`assembly: ${timeNeededAssembly} = ${getBestTimeDuration(timeNeededAssembly)}`)
                 const remainingTime =
                     airdrop === StakingAirdrop.Assembly ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
+                console.log(`remainingTime: ${remainingTime}`)
                 const _getBody = () => {
                     let body = []
                     if (isBelowMinimumAssemblyRewards) {

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -158,8 +158,8 @@
                     body: _getBody(),
                 }
             } else if (!isAccountStaked(account?.id) && isStakingPossible($stakingEventState)) {
-                const timeNeededShimmer = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Shimmer)
                 const timeNeededAssembly = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Assembly)
+                const timeNeededShimmer = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Shimmer)
                 const remainingTime =
                     airdrop === StakingAirdrop.Assembly ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
                 const _getBody = () => {
@@ -172,7 +172,7 @@
                                     airdropRewardMin: assemblyMinimumRewards,
                                 },
                             })} ${localize('tooltips.stakingMinRewards.bodyWillNotReachMin')}`)
-                        } else {
+                        } else if (timeNeededAssembly > 0) {
                             body.push(`${localize('tooltips.stakingMinRewards.bodyBelowMin', {
                                 values: {
                                     airdrop: capitalize(StakingAirdrop.Assembly),
@@ -191,7 +191,7 @@
                                     airdropRewardMin: shimmerMinimumRewards,
                                 },
                             })} ${localize('tooltips.stakingMinRewards.bodyWillNotReachMin')}`)
-                        } else {
+                        } else if (timeNeededShimmer > 0) {
                             body.push(`${localize('tooltips.stakingMinRewards.bodyBelowMin', {
                                 values: {
                                     airdrop: capitalize(StakingAirdrop.Shimmer),

--- a/packages/shared/components/AccountTile.svelte
+++ b/packages/shared/components/AccountTile.svelte
@@ -109,7 +109,7 @@
     }
 
     let tooltipText
-    $: $participationOverview, (tooltipText = getLocalizedTooltipText()), console.log($participationOverview)
+    $: $participationOverview, (tooltipText = getLocalizedTooltipText())
 
     const getLocalizedTooltipText = (): { title: string; body: string[] } => {
         const { accounts } = get(wallet)
@@ -160,12 +160,9 @@
                 }
             } else if (!isAccountStaked(account?.id) && isStakingPossible($stakingEventState)) {
                 const timeNeededShimmer = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Shimmer)
-                console.log(`shimmer: ${timeNeededShimmer} = ${getBestTimeDuration(timeNeededShimmer)}`)
                 const timeNeededAssembly = <number>getTimeUntilMinimumAirdropReward(account, StakingAirdrop.Assembly)
-                console.log(`assembly: ${timeNeededAssembly} = ${getBestTimeDuration(timeNeededAssembly)}`)
                 const remainingTime =
                     airdrop === StakingAirdrop.Assembly ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
-                console.log(`remainingTime: ${remainingTime}`)
                 const _getBody = () => {
                     let body = []
                     if (isBelowMinimumAssemblyRewards) {

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -323,7 +323,24 @@ const calculateNumMilestonesUntilMinimumReward = (
     rewardsNeeded: number,
     airdrop: StakingAirdrop,
     amountStaked: number
-): number => (rewardsNeeded * 1_000_000) / (amountStaked * getAirdropRewardMultipler(airdrop))
+): number => {
+    console.log(
+        `calculateNumMilestonesUntilMinimumReward() - rewardsNeeded: ${rewardsNeeded}, airdrop: ${airdrop}, amountStaked: ${amountStaked}`
+    )
+    console.log(
+        `calculateNumMilestonesUntilMinimumReward() -getAirdropRewardMultipler(airdrop): ${getAirdropRewardMultipler(
+            airdrop
+        )}`
+    )
+
+    let result = (rewardsNeeded * 1_000_000) / (amountStaked * getAirdropRewardMultipler(airdrop))
+    console.log(
+        `(rewardsNeeded * 1_000_000): ${
+            rewardsNeeded * 1_000_000
+        } / (amountStaked * getAirdropRewardMultipler(airdrop)): ${amountStaked * getAirdropRewardMultipler(airdrop)}`
+    )
+    return isNaN(result) ? 0 : result
+}
 
 const getMinimumRewardsRequired = (rewards: number, airdrop: StakingAirdrop): number => {
     const event = getStakingEventFromAirdrop(airdrop)
@@ -337,11 +354,15 @@ const getMinimumRewardsRequired = (rewards: number, airdrop: StakingAirdrop): nu
 
 const calculateTimeUntilMinimumReward = (rewards: number, airdrop: StakingAirdrop, amountStaked: number): number => {
     const minRewardsRequired = getMinimumRewardsRequired(rewards, airdrop)
-    return (
-        calculateNumMilestonesUntilMinimumReward(minRewardsRequired, airdrop, amountStaked) *
-        SECONDS_PER_MILESTONE *
-        MILLISECONDS_PER_SECOND
+    console.log(`minRewardsRequired: ${minRewardsRequired}`)
+    const numMilestonesUntilMinimumReward = calculateNumMilestonesUntilMinimumReward(
+        minRewardsRequired,
+        airdrop,
+        amountStaked
     )
+
+    console.log(`milestones: ${numMilestonesUntilMinimumReward}`)
+    return numMilestonesUntilMinimumReward * SECONDS_PER_MILESTONE * MILLISECONDS_PER_SECOND
 }
 
 /**
@@ -362,11 +383,15 @@ export const getTimeUntilMinimumAirdropReward = (
     airdrop: StakingAirdrop,
     format: boolean = false
 ): number | string => {
+    console.log(`account: ${account.alias}, airdrop: ${airdrop}, format: ${format}`)
+
     if (!account) return format ? getBestTimeDuration(0) : 0
 
     const rewards = getCurrentRewardsForAirdrop(account, airdrop)
     const amountStaked = account?.rawIotaBalance
     const timeRequired = calculateTimeUntilMinimumReward(rewards, airdrop, amountStaked)
+
+    console.log(`rewards: ${rewards}, amountStaked: ${amountStaked}, timeRequired: ${timeRequired}`)
 
     return format ? getBestTimeDuration(timeRequired) : timeRequired
 }
@@ -468,7 +493,9 @@ export const getCurrentRewardsForAirdrop = (account: WalletAccount, airdrop: Sta
     const overview = get(participationOverview).find((apo) => apo.accountIndex === account?.index)
     if (!overview) return 0
 
-    return airdrop === StakingAirdrop.Assembly ? overview.assemblyRewards : overview.shimmerRewards
+    return airdrop === StakingAirdrop.Assembly
+        ? overview.assemblyRewards + overview.assemblyRewardsBelowMinimum
+        : overview.shimmerRewards + overview.shimmerRewardsBelowMinimum
 }
 
 /**

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -311,12 +311,13 @@ export const isStakingForAssembly = (participations: Participation[]): boolean =
 export const isStakingPossible = (stakingEventState: ParticipationEventState): boolean =>
     stakingEventState === ParticipationEventState.Commencing || stakingEventState === ParticipationEventState.Holding
 
-const getAirdropRewardMultipler = (airdrop: StakingAirdrop): number =>
-    airdrop === StakingAirdrop.Assembly
+const getAirdropRewardMultipler = (airdrop: StakingAirdrop): number => {
+    return airdrop === StakingAirdrop.Assembly
         ? ASSEMBLY_REWARD_MULTIPLIER
         : airdrop === StakingAirdrop.Shimmer
         ? SHIMMER_REWARD_MULTIPLIER
         : 0
+}
 
 const calculateNumMilestonesUntilMinimumReward = (
     rewardsNeeded: number,

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -311,34 +311,19 @@ export const isStakingForAssembly = (participations: Participation[]): boolean =
 export const isStakingPossible = (stakingEventState: ParticipationEventState): boolean =>
     stakingEventState === ParticipationEventState.Commencing || stakingEventState === ParticipationEventState.Holding
 
-const getAirdropRewardMultipler = (airdrop: StakingAirdrop): number => {
-    return airdrop === StakingAirdrop.Assembly
+const getAirdropRewardMultipler = (airdrop: StakingAirdrop): number =>
+    airdrop === StakingAirdrop.Assembly
         ? ASSEMBLY_REWARD_MULTIPLIER
         : airdrop === StakingAirdrop.Shimmer
         ? SHIMMER_REWARD_MULTIPLIER
         : 0
-}
 
 const calculateNumMilestonesUntilMinimumReward = (
     rewardsNeeded: number,
     airdrop: StakingAirdrop,
     amountStaked: number
 ): number => {
-    console.log(
-        `calculateNumMilestonesUntilMinimumReward() - rewardsNeeded: ${rewardsNeeded}, airdrop: ${airdrop}, amountStaked: ${amountStaked}`
-    )
-    console.log(
-        `calculateNumMilestonesUntilMinimumReward() -getAirdropRewardMultipler(airdrop): ${getAirdropRewardMultipler(
-            airdrop
-        )}`
-    )
-
-    let result = (rewardsNeeded * 1_000_000) / (amountStaked * getAirdropRewardMultipler(airdrop))
-    console.log(
-        `(rewardsNeeded * 1_000_000): ${
-            rewardsNeeded * 1_000_000
-        } / (amountStaked * getAirdropRewardMultipler(airdrop)): ${amountStaked * getAirdropRewardMultipler(airdrop)}`
-    )
+    const result = (rewardsNeeded * 1_000_000) / (amountStaked * getAirdropRewardMultipler(airdrop))
     return isNaN(result) ? 0 : result
 }
 
@@ -354,14 +339,12 @@ const getMinimumRewardsRequired = (rewards: number, airdrop: StakingAirdrop): nu
 
 const calculateTimeUntilMinimumReward = (rewards: number, airdrop: StakingAirdrop, amountStaked: number): number => {
     const minRewardsRequired = getMinimumRewardsRequired(rewards, airdrop)
-    console.log(`minRewardsRequired: ${minRewardsRequired}`)
     const numMilestonesUntilMinimumReward = calculateNumMilestonesUntilMinimumReward(
         minRewardsRequired,
         airdrop,
         amountStaked
     )
 
-    console.log(`milestones: ${numMilestonesUntilMinimumReward}`)
     return numMilestonesUntilMinimumReward * SECONDS_PER_MILESTONE * MILLISECONDS_PER_SECOND
 }
 
@@ -383,15 +366,11 @@ export const getTimeUntilMinimumAirdropReward = (
     airdrop: StakingAirdrop,
     format: boolean = false
 ): number | string => {
-    console.log(`account: ${account.alias}, airdrop: ${airdrop}, format: ${format}`)
-
     if (!account) return format ? getBestTimeDuration(0) : 0
 
     const rewards = getCurrentRewardsForAirdrop(account, airdrop)
     const amountStaked = account?.rawIotaBalance
     const timeRequired = calculateTimeUntilMinimumReward(rewards, airdrop, amountStaked)
-
-    console.log(`rewards: ${rewards}, amountStaked: ${amountStaked}, timeRequired: ${timeRequired}`)
 
     return format ? getBestTimeDuration(timeRequired) : timeRequired
 }
@@ -431,6 +410,7 @@ const calculateIotasUntilMinimumReward = (rewards: number, airdrop: StakingAirdr
  * @method getIotasUntilMinimumAirdropReward
  *
  * @param {WalletAccount} account
+ * @param {StakingAirdrop} airdrop
  * @param {boolean} format
  *
  * @returns {number | string}
@@ -484,7 +464,7 @@ export const canAccountReachMinimumAirdrop = (account: WalletAccount, airdrop: S
  *
  * @method getCurrentRewardsForAirdrop
  *
- * @param {AccountParticipationOverview} overview
+ * @param {WalletAccount} account
  * @param {StakingAirdrop} airdrop
  *
  * @returns {number}
@@ -503,7 +483,7 @@ export const getCurrentRewardsForAirdrop = (account: WalletAccount, airdrop: Sta
  *
  * @method getCurrentStakeForAirdrop
  *
- * @param {AccountParticipationOverview} overview
+ * @param {WalletAccount} account
  * @param {StakingAirdrop} airdrop
  *
  * @returns {number}


### PR DESCRIPTION
# Description of change
Fixes the logic for some edge cases around calculating the minimum reward time for either staking airdrops.

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Cases:
- Stake an account with enough for minimum airdrop reward for either or both airdrops
- Stake an account with enough for minimum airdrop reward for either or both airdrops then send some funds (leaving a a non-zero balance)
- Stake an accounts funds on one address, reaching the minimum for either or both airdrops, then unstake / move funds to another address (on same account) and begin staking again 
    - This means that the `rewards` and `rewardsBelowMinimum` fields in the `AccountParticipationOverview` type must __both__ be non-zero

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes