### PR TITLE
fix: merge staking selection logic

### DIFF
--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -83,7 +83,7 @@
             accountToParticipate.set(accountToStake)
             participationAction.set(ParticipationAction.Stake)
 
-            const selections = Object.keys(airdropSelections).filter((as) => airdropSelections[as])
+            const selections = !isPartialStake ? Object.keys(airdropSelections).filter((as) => airdropSelections[as]) : activeAirdrops
             const participations: Participation[] = selections.map(
                 (selection) =>
                     <Participation>{


### PR DESCRIPTION
# Description of change

It was using the auto selected checkbox to decide airdrop selection when merging partially staked funds, this fix changes that to use the active airdrops when the confirmation is for a merge instead of the checkboxes.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)

## How the change has been tested

Manually on MacOS 12.0

- Merge for Assembly, send more funds to account, merge and watch the wallet icons for each event.
- Merge for Shimmer, send more funds to account, merge and watch the wallet icons for each event.
- Merge for Both, send more funds to account, merge and watch the wallet icons for each event


## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
