### PR TITLE
hotfix: best time duration function

### DIFF
--- a/packages/shared/lib/tests/time.test.ts
+++ b/packages/shared/lib/tests/time.test.ts
@@ -34,20 +34,20 @@ describe('File: time.ts', () => {
 
         it('should return best duration for valid values', () => {
             expect(getBestTimeDuration(ONE_DAY_MILLIS * 2)).toEqual('2 days')
-            expect(getBestTimeDuration(ONE_DAY_MILLIS * 1.5)).toEqual('1 day')
+            expect(getBestTimeDuration(ONE_DAY_MILLIS * 1.5)).toEqual('2 days')
             expect(getBestTimeDuration(ONE_DAY_MILLIS)).toEqual('1 day')
 
-            expect(getBestTimeDuration(ONE_HOUR_MILLIS * 25)).toEqual('1 day')
+            expect(getBestTimeDuration(ONE_HOUR_MILLIS * 25)).toEqual('2 days')
             expect(getBestTimeDuration(ONE_HOUR_MILLIS * 24)).toEqual('1 day')
             expect(getBestTimeDuration(ONE_HOUR_MILLIS * 12)).toEqual('12 hours')
             expect(getBestTimeDuration(ONE_HOUR_MILLIS)).toEqual('1 hour')
 
-            expect(getBestTimeDuration(ONE_MINUTE_MILLIS * 61)).toEqual('1 hour')
+            expect(getBestTimeDuration(ONE_MINUTE_MILLIS * 61)).toEqual('2 hours')
             expect(getBestTimeDuration(ONE_MINUTE_MILLIS * 60)).toEqual('1 hour')
             expect(getBestTimeDuration(ONE_MINUTE_MILLIS * 30)).toEqual('30 minutes')
             expect(getBestTimeDuration(ONE_MINUTE_MILLIS)).toEqual('1 minute')
 
-            expect(getBestTimeDuration(MILLISECONDS_PER_SECOND * 61)).toEqual('1 minute')
+            expect(getBestTimeDuration(MILLISECONDS_PER_SECOND * 61)).toEqual('2 minutes')
             expect(getBestTimeDuration(MILLISECONDS_PER_SECOND * 60)).toEqual('1 minute')
             expect(getBestTimeDuration(MILLISECONDS_PER_SECOND * 30)).toEqual('30 seconds')
             expect(getBestTimeDuration(MILLISECONDS_PER_SECOND)).toEqual('1 second')

--- a/packages/shared/lib/time.ts
+++ b/packages/shared/lib/time.ts
@@ -34,16 +34,18 @@ export const getBestTimeDuration = (millis: number, noDurationUnit: Duration = '
     if (Number.isNaN(millis)) return zeroTime
 
     const inDays = millis / (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
-    if (inDays >= 1) return localize('times.day', { values: { time: Math.floor(inDays) } })
+    if (inDays >= 1) return localize('times.day', { values: { time: inDays > 1 ? Math.ceil(inDays) : inDays } })
 
     const inHours = millis / (MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
-    if (inHours >= 1) return localize('times.hour', { values: { time: Math.floor(inHours) } })
+    if (inHours >= 1) return localize('times.hour', { values: { time: inHours > 1 ? Math.ceil(inHours) : inHours } })
 
     const inMinutes = millis / (SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
-    if (inMinutes >= 1) return localize('times.minute', { values: { time: Math.floor(inMinutes) } })
+    if (inMinutes >= 1)
+        return localize('times.minute', { values: { time: inMinutes > 1 ? Math.ceil(inMinutes) : inMinutes } })
 
     const inSeconds = millis / MILLISECONDS_PER_SECOND
-    if (inSeconds >= 1) return localize('times.second', { values: { time: Math.floor(inSeconds) } })
+    if (inSeconds >= 1)
+        return localize('times.second', { values: { time: inSeconds > 1 ? Math.ceil(inSeconds) : inSeconds } })
 
     return zeroTime
 }


### PR DESCRIPTION
# Description of change
- Fixes the logic for `getBestTimeDuration` (`time.ts`) to return the correct number 
- Fixes test in `time.test.ts`

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Cases:
- Try various amounts of time (negative, zero, near-zero, and non-zero)

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes