### PR TITLE
fix: blank theme selection

### DIFF
--- a/packages/shared/lib/appSettings.ts
+++ b/packages/shared/lib/appSettings.ts
@@ -20,7 +20,7 @@ export const appSettings = persistent<AppSettings>('settings', {
  * e.g. queries on MacOS result in up-to-date information whereas Linux-based platforms
  * result in stale information.
  */
-const isSystemInDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
+const SYSTEM_IS_IN_DARKMODE = window.matchMedia('(prefers-color-scheme: dark)').matches
 
 /**
  * Determines if the theme is dark or not based on the current
@@ -31,4 +31,4 @@ const isSystemInDarkMode = window.matchMedia('(prefers-color-scheme: dark)').mat
  * @returns {boolean} True if the app should be in dark mode according to the theme
  */
 export const shouldBeDarkMode = (theme: AppTheme): boolean =>
-    theme === 'system' ? isSystemInDarkMode : theme === 'dark'
+    theme === 'system' ? SYSTEM_IS_IN_DARKMODE : theme === 'dark'

--- a/packages/shared/routes/dashboard/settings/views/General.svelte
+++ b/packages/shared/routes/dashboard/settings/views/General.svelte
@@ -12,12 +12,12 @@
 
     export let locale: Locale
 
-    let notificationsChecked = $appSettings.notifications
+    let notificationsChecked = $appSettings?.notifications
     let hideNetworkStatistics = $activeProfile?.settings.hideNetworkStatistics
 
-    let appTheme: AppTheme = $appSettings.theme || 'light'
+    let appTheme: AppTheme = $appSettings?.theme || $appSettings?.darkMode ? 'dark' : 'light'
     $: $appSettings.theme = appTheme
-    $: $appSettings.darkMode = shouldBeDarkMode($appSettings.theme)
+    $: $appSettings.darkMode = shouldBeDarkMode($appSettings?.theme)
 
     $: $appSettings.notifications = notificationsChecked
     $: updateProfile('settings.hideNetworkStatistics', hideNetworkStatistics)

--- a/packages/shared/routes/dashboard/settings/views/General.svelte
+++ b/packages/shared/routes/dashboard/settings/views/General.svelte
@@ -1,7 +1,8 @@
 <script lang="typescript">
     import { Checkbox, Dropdown, HR, Radio, Text } from 'shared/components'
     import { loggedIn } from 'shared/lib/app'
-    import { appSettings, AppTheme, shouldBeDarkMode } from 'shared/lib/appSettings'
+    import { appSettings, shouldBeDarkMode } from 'shared/lib/appSettings'
+    import { AppTheme } from 'shared/lib/typings/app'
     import { exchangeRates } from 'shared/lib/currency'
     import { locales, setLanguage, _ } from 'shared/lib/i18n'
     import { addProfileCurrencyPriceData } from 'shared/lib/market'
@@ -14,7 +15,7 @@
     let notificationsChecked = $appSettings.notifications
     let hideNetworkStatistics = $activeProfile?.settings.hideNetworkStatistics
 
-    let appTheme: AppTheme = $appSettings.theme
+    let appTheme: AppTheme = $appSettings.theme || 'light'
     $: $appSettings.theme = appTheme
     $: $appSettings.darkMode = shouldBeDarkMode($appSettings.theme)
 


### PR DESCRIPTION
# Description of change
With the recent 1.3.0 update came changes to the `AppSettings` type, namely adding a `theme` field. When updating Firefly from 1.2.0 to 1.3.0, this field is initially `undefined` as there is no default. 

## Links to any relevant issues
None

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- MacOS (10.15.7)

Cases:
- Setting `theme` to `undefined` in the general settings component
- Using `AppSettings` type without the new `theme` field

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes