### PR TITLE
fix(shared): Fix issue changing node URL

### DIFF
--- a/packages/shared/components/popups/AddNode.svelte
+++ b/packages/shared/components/popups/AddNode.svelte
@@ -29,6 +29,7 @@
     const { accounts } = $wallet
 
     let nodeUrl: string = node?.url || ''
+    const oldNodeUrl: string = nodeUrl
     const optNodeAuth: NodeAuth = node?.auth || { username: '', password: '', jwt: '' }
 
     let addressError = ''
@@ -117,6 +118,7 @@
                                 network: getNetworkById(nodeInfo?.nodeinfo.networkId),
                                 isPrimary: node?.isPrimary || false,
                             },
+                            oldNodeUrl,
                         )
                         closePopup()
                     })

--- a/packages/shared/routes/dashboard/settings/views/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/Advanced.svelte
@@ -86,7 +86,7 @@
             props: {
                 nodes: networkConfig.nodes,
                 network: networkConfig.network,
-                onSuccess: (isNetworkSwitch: boolean, node: Node) => {
+                onSuccess: (_isNetworkSwitch: boolean, node: Node, _oldNodeUrl: string) => {
                     if(node.isPrimary) {
                         networkConfig.nodes = networkConfig.nodes.map((n) => ({ ...n, isPrimary: false }))
                     } else if (!networkConfig.nodes.some((n) => n.isPrimary)) {
@@ -116,11 +116,11 @@
                 node,
                 nodes: networkConfig.nodes,
                 network: networkConfig.network,
-                onSuccess: (isNetworkSwitch: boolean, node: Node) => {
-                    const idx = networkConfig.nodes.findIndex((n) => n.url === node.url)
+                onSuccess: (_isNetworkSwitch: boolean, node: Node, oldNodeUrl: string) => {
+                    const idx = networkConfig.nodes.findIndex((n) => n.url === oldNodeUrl)
                     if (idx >= 0) {
                         if(node.isPrimary) {
-                            networkConfig.nodes = networkConfig.nodes.map((n) => ({ ...n, isPrimary: n.url === node.url }))
+                            networkConfig.nodes = networkConfig.nodes.map((n) => ({ ...n, isPrimary: n.url === oldNodeUrl }))
                         } else if (!networkConfig.nodes.some((n) => n.isPrimary)) {
                             node.isPrimary = true
                         }


### PR DESCRIPTION
# Description of change

When editing a node, the new settings are not saved if the URL is changed. This is because we look for which node to update using the new URL, but the state still has the old URL.

## Links to any relevant issues

Fixes #1862 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on macOS (dev)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
