### PR TITLE
fix: ensure syncing message only shows for valid pending transactions

### DIFF
--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -1,5 +1,5 @@
 import { toHexString } from '../utils'
-import { DUST_THRESHOLD, hasPendingTransactions } from '../wallet'
+import { DUST_THRESHOLD, hasValidPendingTransactions } from '../wallet'
 import type { WalletAccount } from '../typings/wallet'
 
 import { getParticipationOverview } from './api'
@@ -98,7 +98,7 @@ export const canParticipate = (eventState: ParticipationEventState): boolean => 
 export const getAccountParticipationAbility = (account: WalletAccount): AccountParticipationAbility => {
     if (account?.rawIotaBalance < DUST_THRESHOLD) {
         return AccountParticipationAbility.HasDustAmount
-    } else if (hasPendingTransactions(account)) {
+    } else if (hasValidPendingTransactions(account)) {
         return AccountParticipationAbility.HasPendingTransaction
     } else if (!canAccountReachMinimumAirdrop(account, StakingAirdrop.Assembly)) {
         return AccountParticipationAbility.WillNotReachMinAirdrop

--- a/packages/shared/lib/typings/address.ts
+++ b/packages/shared/lib/typings/address.ts
@@ -4,7 +4,7 @@ export interface AddressOutput {
     index: number
     isSpent: boolean
     messageId: string
-    transactionId: number[]
+    transactionId: string
 }
 
 export interface Address {

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -2075,10 +2075,11 @@ export const hasValidPendingTransactions = (account: WalletAccount): boolean => 
         if (msg.payload?.type === 'Transaction') {
             return msg.payload?.data?.essence?.data?.inputs
         }
+        return []
     })
     const unspentOutputs = account?.addresses.filter((a) => a.balance > 0).flatMap((a) => Object.values(a.outputs))
 
     return pendingInputs.some((i) =>
-        unspentOutputs.map((o) => o.transactionId).includes(i.data?.metadata?.transactionId)
+        unspentOutputs.some((o) => o.transactionId === i.data?.metadata?.transactionId)
     )
 }

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -8,14 +8,14 @@ import type {
     ReattachmentEventPayload,
     TransactionEventPayload,
     TransferProgressEventPayload,
-    TransferState
+    TransferState,
 } from 'shared/lib/typings/events'
 import type { Payload } from 'shared/lib/typings/message'
 import type {
     AddressInput,
     MigrationBundle,
     MigrationData,
-    SendMigrationBundleResponse
+    SendMigrationBundleResponse,
 } from 'shared/lib/typings/migration'
 import { formatUnitBestMatch } from 'shared/lib/units'
 import { get, writable } from 'svelte/store'
@@ -37,18 +37,20 @@ import {
     ParticipationAction,
     ParticipationEvent,
     ParticipationOverviewResponse,
-    PendingParticipation
+    PendingParticipation,
 } from './participation/types'
 import { openPopup } from './popup'
 import { activeProfile, isLedgerProfile, isStrongholdLocked, updateProfile } from './profile'
 import { walletSetupType } from './router'
 import type {
     Account,
-    Account as BaseAccount, AccountIdentifier, AccountToCreate,
+    Account as BaseAccount,
+    AccountIdentifier,
+    AccountToCreate,
     Balance,
     SignerType,
     SyncAccountOptions,
-    SyncedAccount
+    SyncedAccount,
 } from './typings/account'
 import type { Address } from './typings/address'
 import type { Actor, GetMigrationAddressResponse } from './typings/bridge'
@@ -69,10 +71,8 @@ import type {
     Duration,
     StrongholdStatus,
     WalletAccount,
-    WalletState
+    WalletState,
 } from './typings/wallet'
-
-
 
 const ACCOUNT_COLORS = ['turquoise', 'green', 'orange', 'yellow', 'purple', 'pink']
 
@@ -839,7 +839,8 @@ function displayParticipationNotification(pendingParticipation: PendingParticipa
         showAppNotification({
             type: 'info',
             message: localize(
-                `popups.stakingManager.${pendingParticipation.action === ParticipationAction.Stake ? 'staked' : 'unstaked'
+                `popups.stakingManager.${
+                    pendingParticipation.action === ParticipationAction.Stake ? 'staked' : 'unstaked'
                 }Successfully`,
                 { values: { account: account.alias } }
             ),
@@ -1145,7 +1146,7 @@ export const initialiseListeners = (): void => {
                         })
                     }
                 },
-                onError(response) { },
+                onError(response) {},
             })
 
             // Migration
@@ -2070,12 +2071,14 @@ export const hasPendingTransactions = (account: WalletAccount): boolean => {
 export const hasValidPendingTransactions = (account: WalletAccount): boolean => {
     if (!account) return false
     const pendingMessages = account?.messages.filter((m) => !m.confirmed)
-    const pendingInputs = pendingMessages.flatMap(msg => {
+    const pendingInputs = pendingMessages.flatMap((msg) => {
         if (msg.payload?.type === 'Transaction') {
             return msg.payload?.data?.essence?.data?.inputs
         }
     })
-    const unspentOutputs = account?.addresses.filter((a) => a.balance > 0).flatMap(a => Object.values(a.outputs))
+    const unspentOutputs = account?.addresses.filter((a) => a.balance > 0).flatMap((a) => Object.values(a.outputs))
 
-    return pendingInputs.some(i => unspentOutputs.map(o => o.transactionId).includes(i.data?.metadata?.transactionId))
+    return pendingInputs.some((i) =>
+        unspentOutputs.map((o) => o.transactionId).includes(i.data?.metadata?.transactionId)
+    )
 }

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -2079,7 +2079,5 @@ export const hasValidPendingTransactions = (account: WalletAccount): boolean => 
     })
     const unspentOutputs = account?.addresses.filter((a) => a.balance > 0).flatMap((a) => Object.values(a.outputs))
 
-    return pendingInputs.some((i) =>
-        unspentOutputs.some((o) => o.transactionId === i.data?.metadata?.transactionId)
-    )
+    return pendingInputs.some((i) => unspentOutputs.some((o) => o.transactionId === i.data?.metadata?.transactionId))
 }


### PR DESCRIPTION
# Description of change

Block staking on a wallet only if the pending transactions can actually confirm (by comparing UTXO id in message against the UTXO on the address)

## Type of change

- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)


## How the change has been tested

Tested invalid pending transactions by double spending (to create one that will never confirm).
Tested valid pending transactions with a normal spend.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
