### PR TITLE
fix(shared): Localize "Advanced options" label

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -22,6 +22,7 @@
                 "nonFirst": "For now, let's start with your profile name."
             },
             "addMore": "You can add more profiles later.",
+            "advancedOptions": "Advanced options",
             "developer": {
                 "label": "Developer profile",
                 "info": "Connect to the devnet or a private network"

--- a/packages/shared/routes/setup/Profile.svelte
+++ b/packages/shared/routes/setup/Profile.svelte
@@ -134,7 +134,7 @@
                 disabled={busy}
                 submitHandler={handleContinueClick} />
 
-            <CollapsibleBlock label="Advanced options" showBlock={get(newProfile)?.isDeveloperProfile ?? false}> 
+            <CollapsibleBlock label={locale('views.profile.advancedOptions')} showBlock={get(newProfile)?.isDeveloperProfile ?? false}> 
                 <ButtonCheckbox icon="dev" bind:value={isDeveloperProfile}>
                     <div class="text-left">
                         <Text type="p">{locale('views.profile.developer.label')}</Text>


### PR DESCRIPTION
# Description of change

Localizes the "Advanced options" label so that it can be translated

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on macOS

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code