### PR TITLE
feat: searchable dropdown options

### DIFF
--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -84,6 +84,14 @@
                         e.preventDefault()
                     }
                 }
+            } else if (e.keyCode >= 65 && e.keyCode <= 122) {
+                const children = [...navContainer.children]
+                const itemsValues = items.map(item => item.value.toLowerCase())
+                const idx = itemsValues.findIndex(item => item.startsWith(e.key.toLowerCase()))
+                if (idx >= 0) {
+                    children[idx].focus()
+                    e.preventDefault()
+                }
             }
         }
     }

--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -24,6 +24,7 @@
     let navContainer
     let divContainer
     let focusedItem
+    let search = ''
 
     items = sortItems ? items.sort((a, b) => (a.label > b.label ? 1 : -1)) : items
 
@@ -47,6 +48,7 @@
         } else {
             divContainer.focus()
             focusedItem = undefined
+            search = ''
         }
     }
 
@@ -84,14 +86,17 @@
                         e.preventDefault()
                     }
                 }
-            } else if (e.keyCode >= 65 && e.keyCode <= 122) {
+            } else if ((e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 65 && e.keyCode <= 122)) {
                 const children = [...navContainer.children]
-                const itemsValues = items.map(item => item.value.toLowerCase())
-                const idx = itemsValues.findIndex(item => item.startsWith(e.key.toLowerCase()))
+                const itemsValues = items.map(item => item.label.toLowerCase())
+                search += e.key
+                const idx = itemsValues.findIndex(item => item.includes(search.toLowerCase()))
                 if (idx >= 0) {
                     children[idx].focus()
                     e.preventDefault()
                 }
+            } else if (e.key === 'Backspace') {
+                search = search.slice(0, -1)
             }
         }
     }
@@ -225,7 +230,7 @@
     bg-white dark:bg-gray-800 focus:border-blue-500 {dropdown ? 'border-blue-500' : showBorderWhenClosed ? 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700' : ''}"
         tabindex="0"
         bind:this={divContainer}>
-        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white"><Text type={valueTextType} smaller>{value || placeholder}</Text></div>
+        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white"><Text type={valueTextType} smaller>{search || value || placeholder}</Text></div>
         <Icon
             icon={small ? 'small-chevron-down' : 'chevron-down'}
             width={small ? 16 : 24}

--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -230,7 +230,11 @@
     bg-white dark:bg-gray-800 focus:border-blue-500 {dropdown ? 'border-blue-500' : showBorderWhenClosed ? 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700' : ''}"
         tabindex="0"
         bind:this={divContainer}>
-        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white"><Text type={valueTextType} smaller>{search || value || placeholder}</Text></div>
+        <div class="w-full text-12 leading-140 text-gray-800 dark:text-white">
+            <Text classes="overflow-hidden" type={valueTextType} smaller>
+                {search || value || placeholder}
+            </Text>
+        </div>
         <Icon
             icon={small ? 'small-chevron-down' : 'chevron-down'}
             width={small ? 16 : 24}


### PR DESCRIPTION
# Description of change

Makes the dropdown menu options searchable with key presses

## Links to any relevant issues

Resolves https://github.com/iotaledger/firefly/discussions/1541.
Closes https://github.com/iotaledger/firefly/issues/2051

## Type of change

- New (a change that implements a new feature)

## How the change has been tested

Pressing alphanumeric keys should include the text being typed in dropdown placeholder and apply the `includes` string method which should focus on the option that satisfies the condition, I've tested in settings dropdowns

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
