### PR TITLE
feat: close dropdown on click outside

### DIFF
--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Icon, Text, Error } from 'shared/components'
+    import { clickOutside } from 'shared/lib/actions'
     import { onMount } from 'svelte'
 
     export let value = undefined
@@ -203,7 +204,7 @@
         e.stopPropagation()
         toggleDropDown()
     }}
-    use:handleClickOutside
+    use:clickOutside
     on:clickOutside={handleClickOutside}
     on:keydown={handleKey}
     class:active={dropdown}


### PR DESCRIPTION
# Description of change

Adds dropdown closing when outside clicking, uses a function from actions lib

## Links to any relevant issues

Resolves https://github.com/iotaledger/firefly/discussions/1784
Closes https://github.com/iotaledger/firefly/issues/2042

## Type of change

- New (a change that implements a new feature)

## How the change has been tested

Open any dropdown and click outside, it should close the dropdown

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
