### PR TITLE
enhancement: remove conversion when unit changes on send form

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -99,33 +99,7 @@
         showDropdown = false
     }
 
-    const onUnitClick = (toUnit: AmountUnit) => {
-        updateAmount(unit, toUnit)
-        unit = toUnit
-    }
-
-    const updateAmount = (fromUnit: AmountUnit, toUnit: AmountUnit) => {
-        if (amount.length <= 0 || fromUnit === toUnit) return
-
-        // IOTA -> FIAT
-        if (isFiatCurrency(toUnit)) {
-            let _amount = parseFloat(convertAmountToFiat(amount).slice(2)) ?? 0
-            amount = isNaN(_amount)  ? '0' : _amount.toString()
-        } else {
-            let rawAmount
-
-            // FIAT -> IOTA
-            if (isFiatCurrency(fromUnit)) {
-                rawAmount = convertFromFiat(amount, $currencies[CurrencyTypes.USD], $exchangeRates[currency])
-            }
-            // IOTA -> IOTA
-            else {
-                rawAmount = changeUnits(parseCurrency(amount), fromUnit as Unit, Unit.i)
-            }
-
-            amount = formatUnitPrecision(rawAmount, toUnit as Unit, false)
-        }
-    }
+    const onUnitClick = (toUnit: AmountUnit) => { unit = toUnit }
 
     const focusItem = (itemId) => {
         const elem = document.getElementById(itemId)

--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -21,7 +21,6 @@
 
     export let amount = undefined
     export let unit: AmountUnit = Unit.Mi
-    export let label = undefined
     export let placeholder = undefined
     export let classes = ''
     export let error = ''
@@ -30,8 +29,8 @@
 
     export let onMaxClick = (): void => {}
 
-    const currency: AvailableExchangeRates = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
-    const Units: AmountUnit[] = [currency].concat(Object.values(Unit).filter((u) => u !== 'Pi'))
+    const currency = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD as AmountUnit
+    const units: AmountUnit[] = [currency].concat(Object.values(Unit).filter((u) => u !== 'Pi'))
 
     let showDropdown = false
 
@@ -159,7 +158,7 @@
             } else if (e.key === 'Enter') {
                 if (focusedItem) {
                     const idx = [...navContainer.children].indexOf(focusedItem)
-                    onUnitClick(Units[idx])
+                    onUnitClick(units[idx])
                 }
             }
         }
@@ -235,7 +234,7 @@
             <nav
                 class="absolute w-10 overflow-y-auto pointer-events-none opacity-0 z-10 text-left top-10 right-0 rounded-b-lg bg-white dark:bg-gray-800 border border-solid border-blue-500 {showDropdown ? 'dropdown' : ''}"
                 bind:this={navContainer}>
-                {#each Units as _unit}
+                {#each units as _unit}
                     <button
                         id={_unit}
                         class="text-center w-full py-2 {unit === _unit && 'bg-gray-100 dark:bg-gray-700 dark:bg-opacity-20'}

--- a/packages/shared/lib/tests/network.test.ts
+++ b/packages/shared/lib/tests/network.test.ts
@@ -36,8 +36,12 @@ describe('File: network.ts', () => {
         type: NetworkType.ChrysalisMainnet,
         bech32Hrp: 'iota',
     }
-    const MAINNET_URLS = ['https://chrysalis-nodes.iota.org', 'https://chrysalis-nodes.iota.cafe']
-    const MAINNET_NODES = [0, 1].map((i) => _buildNode(MAINNET_URLS[i], MAINNET))
+    const MAINNET_URLS = [
+        'https://chrysalis-nodes.iota.org',
+        'https://chrysalis-nodes.iota.cafe',
+        'https://mainnet-node.tanglebay.com',
+    ]
+    const MAINNET_NODES = MAINNET_URLS.map((url) => _buildNode(url, MAINNET))
     const MAINNET_CONFIG: NetworkConfig = {
         network: MAINNET,
         nodes: MAINNET_NODES,
@@ -56,7 +60,7 @@ describe('File: network.ts', () => {
         'https://api.lb-0.h.chrysalis-devnet.iota.cafe',
         'https://api.lb-1.h.chrysalis-devnet.iota.cafe',
     ]
-    const DEVNET_NODES = [0, 1].map((i) => _buildNode(DEVNET_URLS[i], DEVNET))
+    const DEVNET_NODES = DEVNET_URLS.map((url) => _buildNode(url, DEVNET))
     const DEVNET_CONFIG: NetworkConfig = {
         network: DEVNET,
         nodes: DEVNET_NODES,
@@ -85,7 +89,11 @@ describe('File: network.ts', () => {
                 includeOfficialNodes: true,
                 localPow: true,
                 node: _buildNode(MAINNET_URLS[0], MAINNET, true, false),
-                nodes: [_buildNode(MAINNET_URLS[0], MAINNET, true, false), _buildNode(MAINNET_URLS[1], MAINNET)],
+                nodes: [
+                    _buildNode(MAINNET_URLS[0], MAINNET, true, false),
+                    _buildNode(MAINNET_URLS[1], MAINNET),
+                    _buildNode(MAINNET_URLS[2], MAINNET),
+                ],
             })
         })
     })
@@ -106,6 +114,7 @@ describe('File: network.ts', () => {
             expect(getOfficialNodes(NetworkType.ChrysalisMainnet)).toEqual([
                 _buildNode(MAINNET_URLS[0], MAINNET),
                 _buildNode(MAINNET_URLS[1], MAINNET),
+                _buildNode(MAINNET_URLS[2], MAINNET),
             ])
             expect(getOfficialNodes(NetworkType.ChrysalisDevnet)).toEqual([
                 _buildNode(DEVNET_URLS[0], DEVNET),

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,9 +1,10 @@
 {
     "extends": "@tsconfig/svelte/tsconfig.json",
     "compilerOptions": {
-        "outDir": "out",
         "baseUrl": "./",
-        "lib": ["DOM", "ESNext"]
+        "importsNotUsedAsValues": "remove",
+        "lib": ["DOM", "ESNext"],
+        "outDir": "out"
     },
     "include": ["./lib"],
     "exclude": ["**/node_modules", "**/tests"]


### PR DESCRIPTION
# Description of change

The input field is changed independent of the IOTA unit field. This creates a bad UX, since users might be unaware that the input has changed, while editing something unrelated to that.

## Links to any relevant issues

Closes https://github.com/iotaledger/firefly/issues/2092

## Type of change

Choose a type of change, and delete any options that are not relevant.

* Fix (a change which fixes an issue)

## How the change has been tested

Manual testing

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
