### PR TITLE
Fix: restore settings icons

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -46,6 +46,8 @@
     <Text type="h2" classes="mb-14">{localize('views.settings.settings')}</Text>
     <div class="flex items-start flex-row space-x-10">
         <SettingsMenu
+            icon="settings"
+            iconColor="bg-blue-500"
             icons={SettingsIcons}
             settings={GeneralSettings}
             activeSettings={$loggedIn ? GeneralSettings : GeneralSettingsNoProfile}
@@ -54,6 +56,8 @@
             onClick={(setting) => onSettingClick(SettingsRoutes.GeneralSettings, setting)}
             {localize} />
         <SettingsMenu
+            icon="security"
+            iconColor="bg-yellow-500"
             icons={SettingsIcons}
             settings={securitySettings}
             activeSettings={$loggedIn ? SecuritySettings : undefined}
@@ -62,6 +66,8 @@
             onClick={(setting) => onSettingClick(SettingsRoutes.Security, setting)}
             {localize} />
         <SettingsMenu
+            icon="tools"
+            iconColor="bg-green-600"
             icons={SettingsIcons}
             settings={advancedSettings}
             activeSettings={$loggedIn ? advancedSettings : AdvancedSettingsNoProfile}
@@ -70,6 +76,8 @@
             onClick={(setting) => onSettingClick(SettingsRoutes.AdvancedSettings, setting)}
             {localize} />
         <SettingsMenu
+            icon="info"
+            iconColor="bg-purple-500"
             icons={SettingsIcons}
             settings={HelpAndInfo}
             activeSettings={HelpAndInfo}

--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -53,8 +53,7 @@
             activeSettings={$loggedIn ? GeneralSettings : GeneralSettingsNoProfile}
             title={localize('views.settings.generalSettings.title')}
             description=""
-            onClick={(setting) => onSettingClick(SettingsRoutes.GeneralSettings, setting)}
-            {localize} />
+            onClick={(setting) => onSettingClick(SettingsRoutes.GeneralSettings, setting)} />
         <SettingsMenu
             icon="security"
             iconColor="bg-yellow-500"
@@ -63,8 +62,7 @@
             activeSettings={$loggedIn ? SecuritySettings : undefined}
             title={localize('views.settings.security.title')}
             description=""
-            onClick={(setting) => onSettingClick(SettingsRoutes.Security, setting)}
-            {localize} />
+            onClick={(setting) => onSettingClick(SettingsRoutes.Security, setting)} />
         <SettingsMenu
             icon="tools"
             iconColor="bg-green-600"
@@ -73,8 +71,7 @@
             activeSettings={$loggedIn ? advancedSettings : AdvancedSettingsNoProfile}
             title={localize('views.settings.advancedSettings.title')}
             description=""
-            onClick={(setting) => onSettingClick(SettingsRoutes.AdvancedSettings, setting)}
-            {localize} />
+            onClick={(setting) => onSettingClick(SettingsRoutes.AdvancedSettings, setting)} />
         <SettingsMenu
             icon="info"
             iconColor="bg-purple-500"
@@ -83,7 +80,6 @@
             activeSettings={HelpAndInfo}
             title={localize('views.settings.helpAndInfo.title')}
             description=""
-            onClick={(setting) => onSettingClick(SettingsRoutes.HelpAndInfo, setting)}
-            {localize} />
+            onClick={(setting) => onSettingClick(SettingsRoutes.HelpAndInfo, setting)} />
     </div>
 </div>


### PR DESCRIPTION
# Description of change

- In PR #2155 the settings icons got removed by mistake. This PR brings them back
- Additionally it removes unnecessary `localize` prop

![image](https://user-images.githubusercontent.com/3624944/151206698-1b3c517c-1467-4b8b-8ec4-cd2cdc9a3287.png)

## Links to any relevant issues

N/A

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
