### PR TITLE
fix: allow delete profile with balance

### DIFF
--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -48,7 +48,7 @@ import {
     storeMnemonic as _storeMnemonic,
     verifyMnemonic as _verifyMnemonic,
     getStrongholdStatus as _getStrongholdStatus,
-    removeStorage as _removeStorage,
+    deleteStorage as _deleteStorage,
     lockStronghold as _lockStronghold,
     changeStrongholdPassword as _changeStrongholdPassword,
     setClientOptions as _setClientOptions,
@@ -243,8 +243,8 @@ export const api = {
     setStoragePassword: function (password: string): (__ids: CommunicationIds) => Promise<string> {
         return (__ids: CommunicationIds) => _setStoragePassword(sendMessage, __ids, password)
     },
-    removeStorage: function (): (__ids: CommunicationIds) => Promise<string> {
-        return (__ids: CommunicationIds) => _removeStorage(sendMessage, __ids)
+    deleteStorage: function (): (__ids: CommunicationIds) => Promise<string> {
+        return (__ids: CommunicationIds) => _deleteStorage(sendMessage, __ids)
     },
     send: function (
         fromAccountId: AccountIdentifier,

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -56,7 +56,7 @@
              * from the Svelte store list of profiles, otherwise the
              * actor is not able to be destroyed.
              */
-            await logout(true)
+            await logout(true, false)
 
             /**
              * CAUTION: The profile must be removed from the

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -6,7 +6,7 @@
     import { activeProfile, isSoftwareProfile, profiles, removeProfile, removeProfileFolder } from 'shared/lib/profile'
     import { setRoute } from 'shared/lib/router'
     import { AppRoute } from 'shared/lib/typings/routes'
-    import { api, asyncDeleteStorage, asyncRemoveWalletAccounts, wallet } from 'shared/lib/wallet'
+    import { api, asyncDeleteStorage, asyncStopBackgroundSync } from 'shared/lib/wallet'
     import { get } from 'svelte/store'
     import type { Locale } from 'shared/lib/typings/i18n'
 
@@ -40,9 +40,9 @@
             if (!_activeProfile) return
 
             /**
-             * CAUTION: The individual accounts must be removed from wallet.rs.
+             * CAUTION: We need to stop the background sync before we delete the profile.
              */
-            await asyncRemoveWalletAccounts(get(get(wallet).accounts).map((a) => a.id))
+            await asyncStopBackgroundSync()
 
             /**
              * CAUTION: The storage for wallet.rs must also be deleted in order

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -6,7 +6,7 @@
     import { activeProfile, isSoftwareProfile, profiles, removeProfile, removeProfileFolder } from 'shared/lib/profile'
     import { setRoute } from 'shared/lib/router'
     import { AppRoute } from 'shared/lib/typings/routes'
-    import { api, asyncRemoveStorage, asyncRemoveWalletAccounts, wallet } from 'shared/lib/wallet'
+    import { api, asyncDeleteStorage, asyncRemoveWalletAccounts, wallet } from 'shared/lib/wallet'
     import { get } from 'svelte/store'
     import type { Locale } from 'shared/lib/typings/i18n'
 
@@ -49,7 +49,7 @@
              * to free the locks on the files within the profile folder (removed
              * later).
              */
-            await asyncRemoveStorage()
+            await asyncDeleteStorage()
 
             /**
              * CAUTION: Logout must occur before the profile is removed

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -83,7 +83,7 @@ export const login = (): void => {
 
  * Logout from current profile
  */
-export const logout = (_clearActiveProfile: boolean = false): Promise<void> =>
+export const logout = (_clearActiveProfile: boolean = false, _lockStronghold: boolean = true): Promise<void> =>
     new Promise<void>((resolve) => {
         const _activeProfile = get(activeProfile)
 
@@ -117,7 +117,9 @@ export const logout = (_clearActiveProfile: boolean = false): Promise<void> =>
             resolve()
         }
 
-        if (get(isSoftwareProfile) && !get(isStrongholdLocked)) {
+        // no need to lock strong hold if we are logging out after deleting a profile
+        // or we are not using a software profile
+        if (_lockStronghold && get(isSoftwareProfile) && !get(isStrongholdLocked)) {
             api.lockStronghold({
                 onSuccess() {
                     _cleanup()

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -1,7 +1,7 @@
 import { persistent } from 'shared/lib/helpers'
 import { ledgerSimulator } from 'shared/lib/ledger'
 import { generateRandomId, migrateObjects } from 'shared/lib/utils'
-import { asyncRemoveStorage, destroyActor, getStoragePath, getWalletStoragePath } from 'shared/lib/wallet'
+import { asyncDeleteStorage, destroyActor, getStoragePath, getWalletStoragePath } from 'shared/lib/wallet'
 import { derived, get, Readable, writable } from 'svelte/store'
 import { Electron } from './electron'
 import type { ValuesOf } from './typings/utils'
@@ -137,7 +137,7 @@ export const disposeNewProfile = async (): Promise<void> => {
     const _newProfile = get(newProfile)
     if (_newProfile) {
         try {
-            await asyncRemoveStorage()
+            await asyncDeleteStorage()
             await removeProfileFolder(_newProfile.name)
         } catch (err) {
             console.error(err)

--- a/packages/shared/lib/shell/walletApi.ts
+++ b/packages/shared/lib/shell/walletApi.ts
@@ -78,7 +78,7 @@ const apiToResponseTypeMap = {
     isLatestAddressUnused: ResponseTypes.IsLatestAddressUnused,
     areLatestAddressesUnused: ResponseTypes.AreAllLatestAddressesUnused,
     setAlias: ResponseTypes.UpdatedAlias,
-    removeStorage: ResponseTypes.DeletedStorage,
+    deleteStorage: ResponseTypes.DeletedStorage,
     lockStronghold: ResponseTypes.LockedStronghold,
     changeStrongholdPassword: ResponseTypes.StrongholdPasswordChanged,
     getLedgerDeviceStatus: ResponseTypes.LedgerStatus,

--- a/packages/shared/lib/typings/wallet.ts
+++ b/packages/shared/lib/typings/wallet.ts
@@ -143,7 +143,7 @@ export function setStoragePassword(bridge: Bridge, __ids: CommunicationIds, pass
     })
 }
 
-export function removeStorage(bridge: Bridge, __ids: CommunicationIds): Promise<string> {
+export function deleteStorage(bridge: Bridge, __ids: CommunicationIds): Promise<string> {
     return bridge({
         actorId: __ids.actorId,
         id: __ids.messageId,

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -277,7 +277,7 @@ interface IWalletApi {
         newPinCode: string,
         callbacks: { onSuccess: (response: Event<void>) => void; onError: (err: ErrorEventPayload) => void }
     )
-    removeStorage(callbacks: { onSuccess: (response: Event<void>) => void; onError: (err: ErrorEventPayload) => void })
+    deleteStorage(callbacks: { onSuccess: (response: Event<void>) => void; onError: (err: ErrorEventPayload) => void })
     setClientOptions(
         clientOptions: ClientOptions,
         callbacks: { onSuccess: (response: Event<void>) => void; onError: (err: ErrorEventPayload) => void }
@@ -446,7 +446,6 @@ export const api: IWalletApi = new Proxy(
             const _handleCallbackError = (err: any) => {
                 const title = `Callback Error ${propKey.toString()}`
 
-                console.error(title, err)
                 void Electron.unhandledException(title, { message: err?.message, stack: err?.stack })
             }
 
@@ -721,9 +720,9 @@ export const asyncRemoveWalletAccount = (accountId: string): Promise<void> =>
 export const asyncRemoveWalletAccounts = (accountIds: string[]): Promise<void[]> =>
     Promise.all(accountIds.map((id) => asyncRemoveWalletAccount(id)))
 
-export const asyncRemoveStorage = (): Promise<void> =>
+export const asyncDeleteStorage = (): Promise<void> =>
     new Promise<void>((resolve, reject) => {
-        api.removeStorage({
+        api.deleteStorage({
             onSuccess() {
                 resolve()
             },

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -821,6 +821,23 @@ export const asyncGetNodeInfo = (accountId: string, url?: string, auth?: NodeAut
     })
 }
 
+export const asyncStopBackgroundSync = (): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+        api.stopBackgroundSync({
+            onSuccess() {
+                isBackgroundSyncing.set(false)
+                resolve()
+            },
+            onError(err) {
+                showAppNotification({
+                    type: 'error',
+                    message: localize('error.global.generic'),
+                })
+                reject()
+            },
+        })
+    })
+
 /**
  * Displays participation (stake/unstake) notification
  *

--- a/packages/shared/routes/dashboard/settings/views/security/DeleteProfile.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/DeleteProfile.svelte
@@ -1,18 +1,9 @@
 <script lang="typescript">
-    import { Button, Text } from 'shared/components'
+    import { Button,Text } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
-    import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
-    import { wallet } from 'shared/lib/wallet'
-    import { get } from 'svelte/store'
 
     function handleDeleteClick() {
-        if (get(get(wallet).balanceOverview).balanceRaw > 0) {
-            return showAppNotification({
-                type: 'error',
-                message: localize('error.profile.delete.nonEmptyAccounts'),
-            })
-        }
         openPopup({ type: 'deleteProfile' })
     }
 </script>


### PR DESCRIPTION
# Description of change

This change allows the user to delete a profile without balance, as it removes the unnecessary calls to delete each account within a profile before deleting the account.

## Links to any relevant issues

Fixes #2035 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Fix (a change which fixes an issue)


## How the change has been tested

Describe the tests that you ran to verify your changes.

Tested thoroughly, unfortunately there is still a bug after deleting which we are waiting for a response from the wallet team on. More info here: https://github.com/iotaledger/firefly/issues/1674

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my latest changes pass CI tests
- [ ] New and existing unit tests pass locally with my changes
