### PR TITLE
fix: setting title consistency

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -287,7 +287,7 @@
         "settings": {
             "settings": "Settings",
             "generalSettings": {
-                "title": "General Settings",
+                "title": "General",
                 "description": "Configure your app's appearance and other general settings"
             },
             "security": {
@@ -295,7 +295,7 @@
                 "description": "Change your password and adjust security-related settings"
             },
             "advancedSettings": {
-                "title": "Advanced Settings",
+                "title": "Advanced",
                 "description": "Tools and manual settings for technical users"
             },
             "helpAndInfo": {


### PR DESCRIPTION
# Description of change
This PR fixes some inconsistency in the title section headers (at least for the English locale).

__Before__
![current](https://user-images.githubusercontent.com/44885822/151449156-c237df43-7813-4761-8858-c4dc079b0b95.png)

__After__
![category](https://user-images.githubusercontent.com/44885822/151449169-93cae8b2-82fa-4415-96b2-01e2d04a7524.png)

__Alternative__
![category-and-settings](https://user-images.githubusercontent.com/44885822/151449182-c75ae836-d70e-40d4-9e6c-9876be17d10a.png)

## Links to any relevant issues
_None_

## Type of change
- Fix (a change which fixes an issue)

## How the change has been tested
Platforms:
- Ubuntu 21.10

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my latest changes pass CI tests
- [x] New and existing unit tests pass locally with my changes
