### PR TITLE
chore(ci): Invalidate CloudFront cache for auto-update files upon release

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -257,3 +257,10 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: eu-central-1
+
+    - name: Invalidate CloudFront cache for auto-update files
+      run: aws cloudfront create-invalidation --distribution-id E32G4HRED4PO65 --paths "/latest*"
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: eu-central-1


### PR DESCRIPTION
## Summary
The autoupdater checks for new updates by looking at the version listed in the `latest.yml`, `latest-mac.yml`, or `latest-linux.yml` files. Since these are served through CloudFront, it can take up to 30 minutes for changes to be reflected to users. This can cause confusion when a new version is announced in Discord, but a new version is not shown in Firefly.

### Changelog

N/A


## Relevant Issues

Closes #2219 

## Type of Change

- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing


## Testing
Tested locally

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code