### PR TITLE
feat: Sentry reporting conditional initialization

### DIFF
--- a/packages/desktop/electron/lib/aboutPreload.js
+++ b/packages/desktop/electron/lib/aboutPreload.js
@@ -6,7 +6,7 @@ const {
 
 const sendCrashReportsArg = '--send-crash-reports=true'
 if (window.process.argv.includes(sendCrashReportsArg)) {
-    require('../../sentry')
+    require('../../sentry')(true)
 }
 
 contextBridge.exposeInMainWorld('about', {

--- a/packages/desktop/electron/lib/errorPreload.js
+++ b/packages/desktop/electron/lib/errorPreload.js
@@ -3,7 +3,7 @@ const { version } = require('../../package.json')
 
 const sendCrashReportsArg = '--send-crash-reports=true'
 if (window.process.argv.includes(sendCrashReportsArg)) {
-    require('../../sentry')
+    require('../../sentry')(true)
 }
 
 contextBridge.exposeInMainWorld('error', {

--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -3,12 +3,10 @@ const { app, dialog, ipcMain, protocol, shell, BrowserWindow, session } = requir
 const path = require('path')
 const os = require('os')
 const fs = require('fs')
-const Sentry = require('@sentry/electron')
 const { execSync } = require('child_process')
 const { machineIdSync } = require('node-machine-id')
 const Keychain = require('./lib/keychain')
 const { initMenu, contextMenu } = require('./lib/menu')
-const { captureException } = require('../sentry')
 
 const canSendCrashReports = () => {
     let sendCrashReports = loadJsonConfig('settings.json')?.sendCrashReports
@@ -22,6 +20,11 @@ const canSendCrashReports = () => {
 
 const CAN_LOAD_SENTRY = app.isPackaged
 const SEND_CRASH_REPORTS = CAN_LOAD_SENTRY && canSendCrashReports()
+
+let captureException = (..._) => {}
+if (SEND_CRASH_REPORTS) {
+    captureException = require('../sentry')(true).captureException
+}
 
 /**
  * Set AppUserModelID for Windows notifications functionality

--- a/packages/desktop/electron/preload.js
+++ b/packages/desktop/electron/preload.js
@@ -1,7 +1,10 @@
 const { ipcRenderer, contextBridge } = require('electron')
-const { captureException } = require('../sentry')
 
 const SEND_CRASH_REPORTS = window.process.argv.includes('--send-crash-reports=true')
+let captureException = (..._) => {}
+if (SEND_CRASH_REPORTS) {
+    captureException = require('../sentry')(true).captureException
+}
 
 // Hook the error handlers as early as possible
 window.addEventListener('error', (event) => {

--- a/packages/desktop/index.js
+++ b/packages/desktop/index.js
@@ -1,6 +1,7 @@
 import { Electron } from 'shared/lib/electron'
 import App from './App.svelte'
-import { captureException } from './sentry'
+
+const captureException = require('./sentry')(false).captureException || function (..._) {}
 
 window.addEventListener('error', (event) => {
     const errorType = 'Render Context (Error)'
@@ -17,7 +18,7 @@ window.addEventListener('error', (event) => {
 window.addEventListener('unhandledrejection', (event) => {
     const errorType = 'Render Context (Unhandled Rejection)'
 
-    captureException(event.reason)
+    captureException(event.reason || event)
     Electron.unhandledException(errorType, event.reason || event)
 
     event.preventDefault()

--- a/packages/desktop/sentry.js
+++ b/packages/desktop/sentry.js
@@ -12,6 +12,7 @@ const environment = SENTRY_ENVIRONMENT || ''
 
 let machineId = ''
 
+/* eslint-disable no-undef */
 if (SENTRY_MAIN_PROCESS || PRELOAD_SCRIPT) {
     const { machineIdSync } = require('node-machine-id')
     try {
@@ -25,7 +26,13 @@ if (SENTRY_MAIN_PROCESS || PRELOAD_SCRIPT) {
     })
 }
 
-Sentry.init({ appName, debug, dsn, environment })
-Sentry.setUser({ id: machineId })
+module.exports = function (initialize) {
+    if (initialize) {
+        Sentry.init({ appName, debug, dsn, environment })
+        Sentry.setUser({ id: machineId })
+    }
 
-export const captureException = Sentry.captureException
+    return {
+        captureException: Sentry.captureException,
+    }
+}


### PR DESCRIPTION
## Summary
Each time the Sentry JS module was being imported, initialization code was being run. By using a functional-style export, we can pass a parameter when importing that specifies whether or not to initialize Sentry.

### Changelog
```
- Add import parameter for Sentry JS module, specifying whether or not to initialize Sentry
```

## Relevant Issues
- #2266 

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Test specific scenarios describe in #1603.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas