### PR TITLE
feat: adapt settings for mobile (UI)

### DIFF
--- a/packages/shared/components/Button.svelte
+++ b/packages/shared/components/Button.svelte
@@ -24,6 +24,7 @@
     export let inlineStyle = ''
     export let showHoverText = undefined
     export let iconOnly = false
+    export let unstyled = false
 
     export let onClick = (): void | string => ''
 
@@ -40,7 +41,7 @@
 </script>
 
 <style type="text/scss">
-    button {
+    button:not(.unstyled) {
         @apply bg-blue-500;
         min-width: 100px;
         span {
@@ -406,6 +407,7 @@
         class:active
         class:with-icon={icon}
         class:darkmode={darkModeEnabled}
+        class:unstyled
         style={inlineStyle}
         {disabled}
         bind:this={buttonElement}>
@@ -418,7 +420,7 @@
     <button
         {type}
         {form}
-        class="cursor-pointer text-center rounded-xl px-3 pt-2.5 pb-3.5 {classes}"
+        class="cursor-pointer {!unstyled && 'text-center rounded-xl px-3 pt-2.5 pb-3.5'} {classes}"
         use:bindEvents={events}
         on:click={onClick}
         class:secondary
@@ -432,6 +434,7 @@
         class:active
         class:darkmode={darkModeEnabled}
         class:showHoverText
+        class:unstyled
         style={inlineStyle}
         {disabled}
         bind:this={buttonElement}>

--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -2,8 +2,14 @@ import { cleanupSignup, login, mobile, strongholdPassword, walletPin } from 'sha
 import { activeProfile, profiles, setProfileType } from 'shared/lib/profile'
 import {
     AccountRoutes,
+    AdvancedSettings,
+    AdvancedSettingsNoProfile,
     AppRoute,
+    GeneralSettings,
+    GeneralSettingsNoProfile,
+    HelpAndInfo,
     LedgerRoutes,
+    SecuritySettings,
     SettingsRoutes,
     SetupType,
     Tabs,
@@ -98,7 +104,14 @@ export const settingsRoute = writable<SettingsRoutes>(SettingsRoutes.Init)
 /**
  * Settings child route
  */
-export const settingsChildRoute = writable<string>(null)
+export const settingsChildRoute = writable<
+    | GeneralSettings
+    | GeneralSettingsNoProfile
+    | SecuritySettings
+    | AdvancedSettings
+    | AdvancedSettingsNoProfile
+    | HelpAndInfo
+>(null)
 
 /**
  * Navigate to initial route
@@ -300,9 +313,9 @@ export const resetRouter = (): void => {
 
     walletRoute.set(WalletRoutes.Init)
     accountRoute.set(AccountRoutes.Init)
-    settingsRoute.set(SettingsRoutes.Init)
     dashboardRoute.set(Tabs.Wallet)
     deepLinkRequestActive.set(false)
+    resetSettingsRoute()
 }
 
 export const resetWalletRoute = (): void => {
@@ -322,4 +335,9 @@ export const openSettings = (): void => {
     previousDashboardRoute.set(get(dashboardRoute))
     dashboardRoute.set(Tabs.Settings)
     settingsRoute.set(SettingsRoutes.Init)
+}
+
+export const resetSettingsRoute = (): void => {
+    settingsRoute.set(SettingsRoutes.Init)
+    settingsChildRoute.set(null)
 }

--- a/packages/shared/routes/dashboard/settings/Settings.svelte
+++ b/packages/shared/routes/dashboard/settings/Settings.svelte
@@ -1,18 +1,46 @@
 <script lang="typescript">
-    import { Icon } from 'shared/components'
+    import { Drawer, Icon, Text } from 'shared/components'
     import { mobile } from 'shared/lib/app'
-    import { isLocaleLoaded } from 'shared/lib/i18n'
+    import { getInitials } from 'shared/lib/helpers'
+    import { isLocaleLoaded, localize } from 'shared/lib/i18n'
+    import { activeProfile } from 'shared/lib/profile'
     import { dashboardRoute, previousDashboardRoute, settingsChildRoute, settingsRoute } from 'shared/lib/router'
-    import { SettingsRoutes } from 'shared/lib/typings/routes'
+    import { SettingsRoutes, Tabs } from 'shared/lib/typings/routes'
     import { onDestroy } from 'svelte'
     import { get } from 'svelte/store'
     import { SettingsHome, SettingsViewer } from './views'
 
     export let handleClose
 
+    const profileColor = 'blue' // TODO: each profile has a different color
+
+    /**
+     * Scroll top each time a route changes
+     * Mobile only
+     */
+    $: $mobile, $dashboardRoute, $settingsChildRoute, scrollTop()
+
+    function handleBackClick() {
+        if ($settingsRoute === SettingsRoutes.Init) {
+            closeSettings()
+        } else {
+            settingsRoute.set(SettingsRoutes.Init)
+            settingsChildRoute.set(null)
+        }
+    }
+
     function closeSettings() {
         dashboardRoute.set(get(previousDashboardRoute))
         previousDashboardRoute.set(undefined)
+    }
+
+    function scrollTop() {
+        if ($mobile && ($dashboardRoute === Tabs.Settings || $settingsChildRoute)) {
+            const scroller = document.getElementById('scroller')
+            if (scroller) {
+                scroller.scrollTop = 0
+            }
+        }
     }
 
     onDestroy(() => {
@@ -25,16 +53,47 @@
     })
 </script>
 
-<div
-    class="relative h-full w-full px-6 pb-10 md:px-16 md:py-12 md:bg-white md:dark:bg-gray-900 flex flex-1 {$settingsRoute !== SettingsRoutes.Init && 'md:pt-20'} ">
-    {#if !$mobile}
+{#if $mobile}
+    <Drawer fromRight dimLength={0} fullScreen classes="flex">
+        <div class="flex w-full h-full relative z-0 pt-20">
+            <div
+                class="fixed top-0 cursor-pointer w-full px-8 py-3 flex items-centers justify-center bg-white dark:bg-gray-800"
+                on:click={handleBackClick}>
+                <Icon icon="arrow-left" classes="absolute left-6 text-gray-500 text-blue-500" />
+                <Text type="h4" classes="text-center">
+                    {localize($settingsRoute === SettingsRoutes.Init ? 'general.yourWallets' : `views.settings.${$settingsChildRoute}.title`)}
+                </Text>
+            </div>
+            <div class="flex-1 overflow-y-auto px-6" id="scroller">
+                {#if $settingsRoute === SettingsRoutes.Init}
+                    <!-- TODO: remove dummy data -->
+                    <div class="flex flex-row items-center space-x-6 mb-7 w-full">
+                        <div
+                            class="w-16 h-16 flex items-center justify-center rounded-full bg-{profileColor}-500 leading-100">
+                            <span
+                                class="text-20 text-center text-white uppercase font-semibold">{getInitials($activeProfile?.name, 1) || 'J'}</span>
+                        </div>
+                        <Text type="h4">{$activeProfile?.name || 'John Doe'}</Text>
+                    </div>
+                {/if}
+                {#if $settingsRoute === SettingsRoutes.Init}
+                    <SettingsHome />
+                {:else}
+                    <SettingsViewer />
+                {/if}
+            </div>
+        </div>
+    </Drawer>
+{:else}
+    <div
+        class="relative h-fulll w-full px-6 pb-10 md:px-16 md:py-12 md:bg-white md:dark:bg-gray-900 flex flex-1 {$settingsRoute !== SettingsRoutes.Init && 'md:pt-20'} ">
         <button on:click={handleClose || closeSettings} class="absolute top-8 right-8">
             <Icon icon="close" classes="text-gray-800 dark:text-white" />
         </button>
-    {/if}
-    {#if $settingsRoute === SettingsRoutes.Init}
-        <SettingsHome />
-    {:else}
-        <SettingsViewer />
-    {/if}
-</div>
+        {#if $settingsRoute === SettingsRoutes.Init}
+            <SettingsHome />
+        {:else}
+            <SettingsViewer />
+        {/if}
+    </div>
+{/if}

--- a/packages/shared/routes/dashboard/settings/Settings.svelte
+++ b/packages/shared/routes/dashboard/settings/Settings.svelte
@@ -86,7 +86,7 @@
     </Drawer>
 {:else}
     <div
-        class="relative h-fulll w-full px-6 pb-10 md:px-16 md:py-12 md:bg-white md:dark:bg-gray-900 flex flex-1 {$settingsRoute !== SettingsRoutes.Init && 'md:pt-20'} ">
+        class="relative h-full w-full px-6 pb-10 md:px-16 md:py-12 md:bg-white md:dark:bg-gray-900 flex flex-1 {$settingsRoute !== SettingsRoutes.Init && 'md:pt-20'} ">
         <button on:click={handleClose || closeSettings} class="absolute top-8 right-8">
             <Icon icon="close" classes="text-gray-800 dark:text-white" />
         </button>

--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -2,12 +2,14 @@
     import { SettingsMenu, Text } from 'shared/components'
     import { loggedIn, mobile } from 'shared/lib/app'
     import { localize } from 'shared/lib/i18n'
+    import { Platform } from 'shared/lib/platform'
     import { isLedgerProfile, isSoftwareProfile } from 'shared/lib/profile'
     import { settingsChildRoute, settingsRoute } from 'shared/lib/router'
     import { SettingsIcons } from 'shared/lib/typings/icons'
     import {
         AdvancedSettings,
         AdvancedSettingsNoProfile,
+        ExternalRoute,
         GeneralSettings,
         GeneralSettingsNoProfile,
         HelpAndInfo,
@@ -37,12 +39,16 @@
             | AdvancedSettingsNoProfile
             | HelpAndInfo
     ) {
-        settingsRoute.set(route)
-        settingsChildRoute.set(childRoute)
+        if (route === SettingsRoutes.HelpAndInfo && $mobile) {
+            Platform.openUrl(ExternalRoute[childRoute])
+        } else {
+            settingsRoute.set(route)
+            settingsChildRoute.set(childRoute)
+        }
     }
 </script>
 
-<div class="h-full w-full flex flex-col">
+<div class="flex flex-col flex-1 md:flex-initial pb-10 md:pb-0 md:h-full md:w-full">
     {#if !$mobile}
         <Text type="h2" classes="mb-14">{localize('views.settings.settings')}</Text>
     {/if}

--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -40,7 +40,20 @@
             | HelpAndInfo
     ) {
         if (route === SettingsRoutes.HelpAndInfo && $mobile) {
-            Platform.openUrl(ExternalRoute[childRoute])
+            switch (childRoute) {
+                case HelpAndInfo.Documentation:
+                    Platform.openUrl(ExternalRoute.Documentation)
+                    break
+                case HelpAndInfo.Discord:
+                    Platform.openUrl(ExternalRoute.Discord)
+                    break
+                case HelpAndInfo.FAQ:
+                    Platform.openUrl(ExternalRoute.FAQ)
+                    break
+                case HelpAndInfo.ReportAnIssue:
+                    Platform.openUrl(ExternalRoute.FAQ)
+                    break
+            }
         } else {
             settingsRoute.set(route)
             settingsChildRoute.set(childRoute)

--- a/packages/shared/routes/dashboard/settings/views/SettingsViewer.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsViewer.svelte
@@ -16,6 +16,7 @@
         SettingsRoutesNoProfile,
     } from 'shared/lib/typings/routes'
     import { onMount } from 'svelte'
+    import { fly } from 'svelte/transition'
     import { Advanced, General, Help, Security } from './'
 
     const routes = Object.values($loggedIn ? SettingsRoutes : SettingsRoutesNoProfile).filter(
@@ -66,16 +67,18 @@
         settingsRoute.set(SettingsRoutes.Init)
     }
     onMount(() => {
-        const child = $settingsChildRoute
-        settingsChildRoute.set(null)
-        if (child) {
-            scrollIntoView(child, { behavior: 'auto' })
+        if (!$mobile) {
+            const child = $settingsChildRoute
+            settingsChildRoute.set(null)
+            if (child) {
+                scrollIntoView(child, { behavior: 'auto' })
+            }
         }
     })
 </script>
 
 {#key $_}
-    <div class="flex flex-1 flex-row items-start">
+    <div class="flex flex-1 flex-row items-start" in:fly={{ duration: $mobile ? 200 : 0, x: 200 }}>
         {#if !$mobile}
             <button data-label="back-button" class="absolute top-8 left-8" on:click={handleBackClick}>
                 <div class="flex items-center space-x-3">

--- a/packages/shared/routes/dashboard/settings/views/advanced/Advanced.svelte
+++ b/packages/shared/routes/dashboard/settings/views/advanced/Advanced.svelte
@@ -1,7 +1,8 @@
 <script lang="typescript">
     import { HR } from 'shared/components'
-    import { loggedIn } from 'shared/lib/app'
+    import { loggedIn, mobile } from 'shared/lib/app'
     import { isLedgerProfile } from 'shared/lib/profile'
+    import { settingsChildRoute } from 'shared/lib/router'
     import { AdvancedSettings } from 'shared/lib/typings/routes'
     import {
         BalanceFinder,
@@ -31,12 +32,12 @@
 
 <div>
     {#each settings as { component, childRoute, requireLogin, requireLedger }, index}
-        {#if (!requireLogin || (requireLogin && $loggedIn)) && (!requireLedger || (requireLedger && $isLedgerProfile))}
+        {#if (!requireLogin || (requireLogin && $loggedIn)) && (!requireLedger || (requireLedger && $isLedgerProfile)) && (!$mobile || ($mobile && $settingsChildRoute === childRoute))}
             <section id={childRoute} class="w-full sm:w-3/4">
                 <svelte:component this={component} id={childRoute} />
             </section>
             {#if index < settings.length - 1}
-                <HR classes="pb-5 mt-5 justify-center" />
+                <HR classes="pb-5 mt-5 justify-center hidden md:block" />
             {/if}
         {/if}
     {/each}

--- a/packages/shared/routes/dashboard/settings/views/advanced/NetworkConfiguration.svelte
+++ b/packages/shared/routes/dashboard/settings/views/advanced/NetworkConfiguration.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
-    import { Button, Checkbox, HR, Radio, Text } from 'shared/components'
+    import { Button, Checkbox, Drawer, HR, Radio, Text } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { localize } from 'shared/lib/i18n'
     import {
         ensureSinglePrimaryNode,
@@ -166,6 +167,9 @@
                 {/if}
                 {#each networkConfig.nodes as node}
                     <div
+                        on:click={() => {
+                            if ($mobile) nodeContextMenu = node
+                        }}
                         class="flex flex-row items-center justify-between py-4 px-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20">
                         <div class="flex flex-row items-center space-x-4 overflow-hidden">
                             <Text
@@ -176,20 +180,32 @@
                                 {node.isPrimary ? localize('views.settings.configureNodeList.primaryNode') : ''}
                             </Text>
                         </div>
-                        <button
-                            on:click={(e) => {
-                                nodeContextMenu = node
-                                contextPosition = { x: e.clientX, y: e.clientY }
-                            }}
-                            class="dark:text-white">...</button>
+                        {#if !$mobile}
+                            <button
+                                on:click={(e) => {
+                                    nodeContextMenu = node
+                                    contextPosition = { x: e.clientX, y: e.clientY }
+                                }}
+                                class="dark:text-white">...</button>
+                        {/if}
                     </div>
                 {/each}
                 {#if nodeContextMenu}
-                    <NodeConfigOptions
-                        bind:nodeContextMenu
-                        bind:networkConfig
-                        {contextPosition}
-                        {ensureOnePrimaryNode} />
+                    {#if $mobile}
+                        <Drawer dimLength={180} on:close={() => (nodeContextMenu = undefined)}>
+                            <NodeConfigOptions
+                                bind:nodeContextMenu
+                                bind:networkConfig
+                                {contextPosition}
+                                {ensureOnePrimaryNode} />
+                        </Drawer>
+                    {:else}
+                        <NodeConfigOptions
+                            bind:nodeContextMenu
+                            bind:networkConfig
+                            {contextPosition}
+                            {ensureOnePrimaryNode} />
+                    {/if}
                 {/if}
             </div>
             <div class="flex flex-row justify-between space-x-3 w-full mt-4">

--- a/packages/shared/routes/dashboard/settings/views/advanced/NodeConfigOptions.svelte
+++ b/packages/shared/routes/dashboard/settings/views/advanced/NodeConfigOptions.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
-    import { HR, Text } from 'shared/components'
+    import { Button, HR, Text } from 'shared/components'
     import { clickOutside } from 'shared/lib/actions'
+    import { mobile } from 'shared/lib/app'
     import { localize } from 'shared/lib/i18n'
     import { getOfficialNodes, updateClientOptions } from 'shared/lib/network'
     import { openPopup } from 'shared/lib/popup'
@@ -79,40 +80,62 @@
 </script>
 
 <div
-    class="fixed flex flex-col border border-solid bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 rounded-lg overflow-hidden"
+    class={$mobile ? 'flex flex-col flex-wrap space-y-4 p-8' : 'fixed flex flex-col border border-solid bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 rounded-lg overflow-hidden'}
     use:clickOutside={{ includeScroll: true }}
-    on:clickOutside={() => (nodeContextMenu = undefined)}
-    style={`left: ${contextPosition.x - 10}px; top: ${contextPosition.y - 10}px`}>
+    on:clickOutside={() => {
+        if (!$mobile) nodeContextMenu = undefined
+    }}
+    style={!$mobile && `left: ${contextPosition.x - 10}px; top: ${contextPosition.y - 10}px`}>
     {#if !nodeContextMenu?.isDisabled}
-        <button
-            on:click={() => handleSetPrimaryNode(nodeContextMenu)}
-            class={'flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20'}>
-            <Text smaller>{localize('views.settings.configureNodeList.setAsPrimary')}</Text>
-        </button>
-        <button
-            on:click={() => {
+        <Button
+            medium
+            unstyled={!$mobile}
+            onClick={() => handleSetPrimaryNode(nodeContextMenu)}
+            classes={!$mobile && 'flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20'}>
+            {#if $mobile}
+                {localize('views.settings.configureNodeList.setAsPrimary')}
+            {:else}
+                <Text smaller>{localize('views.settings.configureNodeList.setAsPrimary')}</Text>
+            {/if}
+        </Button>
+        <Button
+            medium
+            unstyled={!$mobile}
+            onClick={() => {
                 handleViewNodeInfoClick(nodeContextMenu)
                 nodeContextMenu = undefined
             }}
-            class="flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20">
-            <Text smaller>{localize('views.settings.configureNodeList.viewInfo')}</Text>
-        </button>
+            classes={!$mobile && 'flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20'}>
+            {#if $mobile}
+                {localize('views.settings.configureNodeList.viewInfo')}
+            {:else}
+                <Text smaller>{localize('views.settings.configureNodeList.viewInfo')}</Text>
+            {/if}
+        </Button>
     {/if}
     {#if !getOfficialNodes(networkConfig?.network.type)
         .map((n) => n.url)
         .includes(nodeContextMenu?.url)}
-        <button
-            on:click={() => {
+        <Button
+            medium
+            unstyled={!$mobile}
+            onClick={() => {
                 handleEditNodeDetailsClick(nodeContextMenu)
                 nodeContextMenu = undefined
             }}
-            class="flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20">
-            <Text smaller>{localize('views.settings.configureNodeList.editDetails')}</Text>
-        </button>
+            classes={!$mobile && 'flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20'}>
+            {#if $mobile}
+                {localize('views.settings.configureNodeList.editDetails')}
+            {:else}
+                <Text smaller>{localize('views.settings.configureNodeList.editDetails')}</Text>
+            {/if}
+        </Button>
     {/if}
     {#if nodeContextMenu && nodeContextMenu.url !== networkConfig?.nodes?.find((n) => n.isPrimary)?.url}
-        <button
-            on:click={() => {
+        <Button
+            medium
+            unstyled={!$mobile}
+            onClick={() => {
                 nodeContextMenu.isDisabled = !nodeContextMenu.isDisabled
                 networkConfig.nodes = networkConfig.nodes.map((n) => ({
                     ...n,
@@ -120,23 +143,34 @@
                 }))
                 nodeContextMenu = undefined
             }}
-            class="flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20">
-            <Text smaller>
+            classes={!$mobile && 'flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20'}>
+            {#if $mobile}
                 {localize(nodeContextMenu.isDisabled ? 'views.settings.configureNodeList.includeNode' : 'views.settings.configureNodeList.excludeNode')}
-            </Text>
-        </button>
+            {:else}
+                <Text smaller>
+                    {localize(nodeContextMenu.isDisabled ? 'views.settings.configureNodeList.includeNode' : 'views.settings.configureNodeList.excludeNode')}
+                </Text>
+            {/if}
+        </Button>
     {/if}
     {#if !getOfficialNodes(networkConfig?.network?.type)
         .map((n) => n.url)
         .includes(nodeContextMenu?.url)}
         <HR />
-        <button
-            on:click={() => {
+        <Button
+            medium
+            warning
+            unstyled={!$mobile}
+            onClick={() => {
                 handleRemoveNodeClick(nodeContextMenu)
                 nodeContextMenu = undefined
             }}
-            class="flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20">
-            <Text smaller error>{localize('views.settings.configureNodeList.removeNode')}</Text>
-        </button>
+            classes={!$mobile && 'flex p-3 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:bg-opacity-20'}>
+            {#if $mobile}
+                {localize('views.settings.configureNodeList.removeNode')}
+            {:else}
+                <Text smaller>{localize('views.settings.configureNodeList.removeNode')}</Text>
+            {/if}
+        </Button>
     {/if}
 </div>

--- a/packages/shared/routes/dashboard/settings/views/general/Currency.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/Currency.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Dropdown, Text } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { exchangeRates } from 'shared/lib/currency'
     import { localize } from 'shared/lib/i18n'
     import { addProfileCurrencyPriceData } from 'shared/lib/market'
@@ -18,10 +19,35 @@
     }
 </script>
 
-<Text type="h4" classes="mb-3">{localize('views.settings.currency.title')}</Text>
-<Text type="p" secondary classes="mb-5">{localize('views.settings.currency.description')}</Text>
-<Dropdown
-    sortItems={true}
-    onSelect={handleCurrencySelect}
-    value={$activeProfile?.settings.currency}
-    items={currencyList} />
+<style type="text/scss">
+    button {
+        &.active {
+            @apply bg-blue-500;
+            @apply bg-opacity-10;
+            :global(p) {
+                @apply text-blue-500;
+            }
+        }
+    }
+</style>
+
+{#if $mobile}
+    <div class="flex flex-col flex-wrap space-y-2 overflow-y-auto">
+        {#each currencyList as currency}
+            <button
+                class="relative flex items-center p-2 w-full whitespace-nowrap rounded-md"
+                on:click={() => handleCurrencySelect(currency)}
+                class:active={currency?.label === $activeProfile?.settings.currency}>
+                <Text type="p" smaller>{currency?.label}</Text>
+            </button>
+        {/each}
+    </div>
+{:else}
+    <Text type="h4" classes="mb-3">{localize('views.settings.currency.title')}</Text>
+    <Text type="p" secondary classes="mb-5">{localize('views.settings.currency.description')}</Text>
+    <Dropdown
+        sortItems={true}
+        onSelect={handleCurrencySelect}
+        value={$activeProfile?.settings.currency}
+        items={currencyList} />
+{/if}

--- a/packages/shared/routes/dashboard/settings/views/general/General.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/General.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { HR } from 'shared/components'
-    import { loggedIn } from 'shared/lib/app'
+    import { loggedIn, mobile } from 'shared/lib/app'
+    import { settingsChildRoute } from 'shared/lib/router'
     import { GeneralSettings } from 'shared/lib/typings/routes'
     import { Currency, Language, NetworkStatus, Notifications, Theme } from './'
 
@@ -19,12 +20,12 @@
 
 <div>
     {#each settings as { component, childRoute, requireLogin }, index}
-        {#if !requireLogin || (requireLogin && $loggedIn)}
+        {#if (!requireLogin || (requireLogin && $loggedIn)) && (!$mobile || ($mobile && $settingsChildRoute === childRoute))}
             <section id={childRoute} class="w-full sm:w-3/4">
                 <svelte:component this={component} />
             </section>
             {#if index < settings.length - 1}
-                <HR classes="pb-5 mt-5 justify-center" />
+                <HR classes="pb-5 mt-5 justify-center hidden md:block" />
             {/if}
         {/if}
     {/each}

--- a/packages/shared/routes/dashboard/settings/views/general/Language.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/Language.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Dropdown, Text } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { appSettings } from 'shared/lib/appSettings'
     import { locales, localize, setLanguage } from 'shared/lib/i18n'
     import { refreshBalanceOverview, updateAccountsBalanceEquiv } from 'shared/lib/wallet'
@@ -13,5 +14,30 @@
     }
 </script>
 
-<Text type="h4" classes="mb-3">{localize('views.settings.language.title')}</Text>
-<Dropdown sortItems={true} onSelect={handleLanguage} value={locales[$appSettings.language]} items={languageList} />
+<style type="text/scss">
+    button {
+        &.active {
+            @apply bg-blue-500;
+            @apply bg-opacity-10;
+            :global(p) {
+                @apply text-blue-500;
+            }
+        }
+    }
+</style>
+
+{#if $mobile}
+    <div class="flex flex-col flex-wrap space-y-2 overflow-y-auto">
+        {#each languageList as language}
+            <button
+                class="relative flex items-center p-2 w-full whitespace-nowrap rounded-md"
+                on:click={() => handleLanguage(language)}
+                class:active={language?.label === locales[$appSettings.language]}>
+                <Text type="p" smaller>{language?.label}</Text>
+            </button>
+        {/each}
+    </div>
+{:else}
+    <Text type="h4" classes="mb-3">{localize('views.settings.language.title')}</Text>
+    <Dropdown sortItems={true} onSelect={handleLanguage} value={locales[$appSettings.language]} items={languageList} />
+{/if}

--- a/packages/shared/routes/dashboard/settings/views/general/NetworkStatus.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/NetworkStatus.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Checkbox, Text } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { localize } from 'shared/lib/i18n'
     import { activeProfile, updateProfile } from 'shared/lib/profile'
 
@@ -8,6 +9,8 @@
     $: updateProfile('settings.hideNetworkStatistics', hideNetworkStatistics)
 </script>
 
-<Text type="h4" classes="mb-3">{localize('views.settings.networkStatus.title')}</Text>
+{#if !$mobile}
+    <Text type="h4" classes="mb-3">{localize('views.settings.networkStatus.title')}</Text>
+{/if}
 <Text type="p" secondary classes="mb-5">{localize('views.settings.networkStatus.description')}</Text>
 <Checkbox label={localize('actions.hideNetworkStatistics')} bind:checked={hideNetworkStatistics} />

--- a/packages/shared/routes/dashboard/settings/views/general/Notifications.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/Notifications.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Checkbox, Text } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { appSettings } from 'shared/lib/appSettings'
     import { localize } from 'shared/lib/i18n'
 
@@ -8,6 +9,8 @@
     $: $appSettings.notifications = notificationsChecked
 </script>
 
-<Text type="h4" classes="mb-3">{localize('views.settings.notifications.title')}</Text>
+{#if !$mobile}
+    <Text type="h4" classes="mb-3">{localize('views.settings.notifications.title')}</Text>
+{/if}
 <Text type="p" secondary classes="mb-5">{localize('views.settings.notifications.description')}</Text>
 <Checkbox label={localize('actions.enableSystemNotifications')} bind:checked={notificationsChecked} />

--- a/packages/shared/routes/dashboard/settings/views/general/Theme.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/Theme.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
-    import { Radio, Text, TextHint } from 'shared/components'
+    import { ButtonRadio, Radio, Text, TextHint } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { appSettings, shouldBeDarkMode } from 'shared/lib/appSettings'
     import { localize } from 'shared/lib/i18n'
     import type { AppTheme } from 'shared/lib/typings/app'
@@ -10,10 +11,18 @@
     $: $appSettings.darkMode = shouldBeDarkMode($appSettings.theme)
 </script>
 
-<Text type="h4" classes="mb-3">{localize('views.settings.theme.title')}</Text>
-<Radio value={'light'} bind:group={appTheme} label={localize('general.lightTheme')} />
-<Radio value={'dark'} bind:group={appTheme} label={localize('general.darkTheme')} />
-<Radio value={'system'} bind:group={appTheme} label={localize('general.systemTheme')} />
+{#if $mobile}
+    <ButtonRadio icon="theme-light" value={'light'} bind:group={appTheme}>{localize('general.lightTheme')}</ButtonRadio>
+    <ButtonRadio icon="theme-dark" value={'dark'} bind:group={appTheme}>{localize('general.darkTheme')}</ButtonRadio>
+    <ButtonRadio icon="theme-dark" value={'system'} bind:group={appTheme}>
+        {localize('general.systemTheme')}
+    </ButtonRadio>
+{:else}
+    <Text type="h4" classes="mb-3">{localize('views.settings.theme.title')}</Text>
+    <Radio value={'light'} bind:group={appTheme} label={localize('general.lightTheme')} />
+    <Radio value={'dark'} bind:group={appTheme} label={localize('general.darkTheme')} />
+    <Radio value={'system'} bind:group={appTheme} label={localize('general.systemTheme')} />
+{/if}
 {#if appTheme === 'system'}
-    <TextHint classes="mb-5" icon="exclamation" hint={localize('views.settings.theme.advice')}/>
+    <TextHint classes="mb-5" icon="exclamation" hint={localize('views.settings.theme.advice')} />
 {/if}

--- a/packages/shared/routes/dashboard/settings/views/help/Help.svelte
+++ b/packages/shared/routes/dashboard/settings/views/help/Help.svelte
@@ -37,7 +37,7 @@
             <svelte:component this={component} route={childRoute} {url} {actionLocale} />
         </section>
         {#if index < settings.length - 1}
-            <HR classes="pb-5 mt-5 justify-center" />
+            <HR classes="pb-5 mt-5 justify-center hidden md:block" />
         {/if}
     {/each}
 </div>

--- a/packages/shared/routes/dashboard/settings/views/security/AppLock.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/AppLock.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Dropdown, Text } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { localize } from 'shared/lib/i18n'
     import { activeProfile, updateProfile } from 'shared/lib/profile'
 
@@ -25,9 +26,35 @@
     const lockOptions = lockScreenTimeoutOptions()
 </script>
 
-<Text type="h4" classes="mb-3">{localize('views.settings.appLock.title')}</Text>
-<Text type="p" secondary classes="mb-5">{localize('views.settings.appLock.description')}</Text>
-<Dropdown
-    onSelect={updateLockTimeout}
-    value={assignTimeoutOptionLabel($activeProfile?.settings.lockScreenTimeout)}
-    items={lockOptions} />
+<style type="text/scss">
+    button {
+        &.active {
+            @apply bg-blue-500;
+            @apply bg-opacity-10;
+            :global(p) {
+                @apply text-blue-500;
+            }
+        }
+    }
+</style>
+
+{#if $mobile}
+    <Text type="p" secondary classes="mb-5">{localize('views.settings.appLock.description')}</Text>
+    <div class="flex flex-col flex-wrap space-y-2 overflow-y-auto">
+        {#each lockOptions as option}
+            <button
+                class="relative flex items-center p-2 w-full whitespace-nowrap rounded-md"
+                on:click={() => updateLockTimeout(option)}
+                class:active={option?.value === $activeProfile?.settings.lockScreenTimeout}>
+                <Text type="p" smaller>{option?.label}</Text>
+            </button>
+        {/each}
+    </div>
+{:else}
+    <Text type="h4" classes="mb-3">{localize('views.settings.appLock.title')}</Text>
+    <Text type="p" secondary classes="mb-5">{localize('views.settings.appLock.description')}</Text>
+    <Dropdown
+        onSelect={updateLockTimeout}
+        value={assignTimeoutOptionLabel($activeProfile?.settings.lockScreenTimeout)}
+        items={lockOptions} />
+{/if}

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
@@ -104,6 +104,7 @@
     }
 </script>
 
+<!-- TODO: improve UX for mobile, 3 step screen -->
 <form id="form-change-password" on:submit={changePassword}>
     <Text type="h4" classes="mb-3">{localize('views.settings.changePassword.title')}</Text>
     <Text type="p" secondary classes="mb-5">{localize('views.settings.changePassword.description')}</Text>

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
@@ -86,6 +86,7 @@
     }
 </script>
 
+<!-- TODO: improve UX for mobile, 3 step screen -->
 <form on:submit={changePincode} id="pincode-change-form">
     <Text type="h4" classes="mb-3">{localize('views.settings.changePincode.title')}</Text>
     <Text type="p" secondary classes="mb-5">{localize('views.settings.changePincode.description')}</Text>

--- a/packages/shared/routes/dashboard/settings/views/security/Security.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/Security.svelte
@@ -1,7 +1,9 @@
 <script lang="typescript">
     import { HR } from 'shared/components'
+    import { mobile } from 'shared/lib/app'
     import { Platform } from 'shared/lib/platform'
     import { isSoftwareProfile, updateProfile } from 'shared/lib/profile'
+    import { settingsChildRoute } from 'shared/lib/router'
     import { SecuritySettings } from 'shared/lib/typings/routes'
     import { getDefaultStrongholdName } from 'shared/lib/utils'
     import { api } from 'shared/lib/wallet'
@@ -49,12 +51,12 @@
 
 <div>
     {#each settings as { component, childRoute, requireSoftware }, index}
-        {#if !requireSoftware || (requireSoftware && $isSoftwareProfile)}
+        {#if (!requireSoftware || (requireSoftware && $isSoftwareProfile)) && (!$mobile || ($mobile && $settingsChildRoute === childRoute))}
             <section id={childRoute} class="w-full sm:w-3/4">
                 <svelte:component this={component} {...props[childRoute]} />
             </section>
             {#if index < settings.length - 1}
-                <HR classes="pb-5 mt-5 justify-center" />
+                <HR classes="pb-5 mt-5 justify-center hidden md:block" />
             {/if}
         {/if}
     {/each}


### PR DESCRIPTION
## Summary

⚠️  This PR depends on #2251, when merged we should change the base to `feat/kickoff-mobile`

### Changelog
```
Adapt settings UI to mobile
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [x] Android

### Instructions

You can test the changes from `packages/mobile` with the usual requirements for Android or iOS.

Additionally, you can test from `packages/desktop` changing:
- In `packages/desktop/App.svelte` 
```
import { mobile } from 'shared/lib/app'
mobile.set(true)
```
- In `packages/desktop/App.svelte` move the popup component to be placed right before the Toast Container
```
...

{#if settings}
    <Settings locale={$_} handleClose={() => (settings = false)} />
{/if}

{#if $popupState.active}
    <Popup
        type={$popupState.type}
        props={$popupState.props}
        hideClose={$popupState.hideClose}
        fullScreen={$popupState.fullScreen}
        transition={$popupState.transition}
        locale={$_}
    />
{/if}

<ToastContainer />

...
```

- In `packages/shared/lib/router.ts` force to login using the following script: 
```
const profileId = 'XXXXXXXXXXXXXXXXXXXXXXXX';
const profileName = 'XXXXXX'
const profilePin = 'XXXXXX'
setActiveProfile(profileId)
Platform.PincodeManager.verify(profileId, profilePin)
    .then((verified) => {
        if (verified === true) {
            return Electron.getUserDataPath().then((path) => {
                initialise(profileId, getStoragePath(path, profileName))
                api.setStoragePassword(profilePin, {
                    onSuccess() {
                        login()
                        setRoute(AppRoute.Welcome)
                    },
                    onError(err) {
                        console.error(err)
                    },
                })
            })
        }
    })
    .catch((error) => {
        console.error(error)
    })
```

⚠️ Please beware in desktop the scrollbars are not the same as in mobile, in desktop they take space they dont in mobile

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
