### PR TITLE
chore: precommit only checks staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh" # Fixes Yarn and Git Bash for Windows 10
 
-yarn pre-commit
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "eslint-plugin-security": "^1.4.0",
         "eslint-plugin-svelte3": "^3.2.0",
         "husky": "^7.0.0",
+        "lint-staged": "^12.3.3",
         "patch-package": "^6.2.2",
         "prettier": "^2.3.2"
     },
@@ -33,5 +34,9 @@
         "lodash": ">=4.17.21",
         "ansi-regex": "5.0.1",
         "glob-parent": " >=5.1.2"
+    },
+    "lint-staged": {
+        "*.{ts,js,scss,css,svelte}": "eslint --cache --fix",
+        "*.{ts,js,json,scss,css}": "prettier --write"
     }
 }


### PR DESCRIPTION
## Summary

Currently unstaged checks are also checked by the linter. This is quite annoying for developers, since they have to change files that are not yet ready and are also not intended to be committed.

### Changelog
```
- Use lint-staged to only check staged files for linting and formatting
- Use format and linting fixing instead of checking
```

## Relevant Issues

Closes: 
- https://github.com/iotaledger/firefly/issues/2036

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
