### PR TITLE
chore(desktop): Output Webpack chunks to build folder

### DIFF
--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -28,7 +28,7 @@ const output = {
     publicPath: prod ? '../' : '/',
     path: path.join(__dirname, '/public'),
     filename: '[name].js',
-    chunkFilename: '[name].[id].js',
+    chunkFilename: 'build/[name].[id].js',
 }
 
 // / ------------------------ Module rules ------------------------


### PR DESCRIPTION
## Summary
Webpack is currently generating chunks (at the moment named `27.27.js` and `987.987.js`) and outputting them into `desktop/public` when they should be in `desktop/public/build`.

### Changelog
N/A, not user-facing

## Relevant Issues
N/A

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
App loads properly

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting