### PR TITLE
Fix Mobile build: Paired Webpack dependencies with desktop versions

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -20,8 +20,8 @@
         "@capacitor/core": "3.2.0",
         "@capacitor/ios": "3.2.0",
         "mini-css-extract-plugin": "^1.6.0",
-        "webpack": "^5.38.1",
-        "webpack-cli": "^4.7.2",
+        "webpack": "^5.16.0",
+        "webpack-cli": "^4.4.0",
         "webpack-dev-server": "^3.11.2"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary
Without this change, mobile is not able to run the development server since there is a conflict with different Webpack versions.

### Changelog
```
Changed webpack and webpack-cli versions pairing with desktop package.json file.
```

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [x] Linux
	- [x] Windows
- __Mobile__
	- [x] iOS
	- [x] Android

### Instructions
```bash
./packages/mobile $ yarn
./packages/mobile $ yarn dev
```

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
