### PR TITLE
fix: disabled popup if event is ended or inactive

### DIFF
--- a/packages/shared/components/popups/GovernanceCastVote.svelte
+++ b/packages/shared/components/popups/GovernanceCastVote.svelte
@@ -1,17 +1,17 @@
 <script lang="typescript">
-    import { onMount } from 'svelte';
+    import { onMount } from 'svelte'
     import { Button, Icon, Text } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
     import { closePopup } from 'shared/lib/popup'
-    import { isSoftwareProfile } from 'shared/lib/profile';
-    import { selectedAccountId, api } from 'shared/lib/wallet';
-    import { participate, participateWithRemainingFunds, stopParticipating } from 'shared/lib/participation/api';
+    import { isSoftwareProfile } from 'shared/lib/profile'
+    import { selectedAccountId, api } from 'shared/lib/wallet'
+    import { participate, participateWithRemainingFunds, stopParticipating } from 'shared/lib/participation/api'
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
-    import { isParticipationPending } from 'shared/lib/participation/stores';
-    import { ParticipationAction, VotingEventAnswer } from 'shared/lib/participation/types';
-    import { sleep } from 'shared/lib/utils';
-    
+    import { isParticipationPending } from 'shared/lib/participation/stores'
+    import { ParticipationAction, VotingEventAnswer } from 'shared/lib/participation/types'
+    import { sleep } from 'shared/lib/utils'
+
     export let currentVoteValue: string
     export let nextVote: VotingEventAnswer
     export let eventId: string
@@ -20,14 +20,14 @@
         Cast = 'castVotes',
         Merge = 'mergeVotes',
         Stop = 'stopVotes',
-        Change = 'changeVotes'
+        Change = 'changeVotes',
     }
 
     let votingAction = VotingAction.Cast
     let disabled = false
     let successText = localize('popups.votingConfirmation.votesSubmitted')
 
-    $: showAdditionalInfo = (votingAction === VotingAction.Change || votingAction === VotingAction.Stop)
+    $: showAdditionalInfo = votingAction === VotingAction.Change || votingAction === VotingAction.Stop
 
     onMount(() => {
         setVotingAction()
@@ -51,7 +51,7 @@
                 type: 'success',
                 props: {
                     successText,
-                }
+                },
             })
         } catch (err) {
             showAppNotification({
@@ -65,16 +65,24 @@
     const vote = async (): Promise<void> => {
         switch (votingAction) {
             case VotingAction.Cast:
-                await participate($selectedAccountId, [{ eventId, answers: [nextVote?.value] }], ParticipationAction.Vote)
+                await participate(
+                    $selectedAccountId,
+                    [{ eventId, answers: [nextVote?.value] }],
+                    ParticipationAction.Vote
+                )
                 break
             case VotingAction.Merge:
-                await participateWithRemainingFunds($selectedAccountId, [{ eventId, answers: [nextVote?.value] }], ParticipationAction.Vote)
+                await participateWithRemainingFunds(
+                    $selectedAccountId,
+                    [{ eventId, answers: [nextVote?.value] }],
+                    ParticipationAction.Vote
+                )
                 break
             case VotingAction.Change:
                 await changeVote()
                 break
             case VotingAction.Stop:
-                await stopParticipating($selectedAccountId, [ eventId ], ParticipationAction.Unvote)
+                await stopParticipating($selectedAccountId, [eventId], ParticipationAction.Unvote)
                 break
             default:
                 throw new Error('Unimplemented voting action!')
@@ -82,7 +90,7 @@
     }
 
     const changeVote = async (): Promise<void> => {
-        const [ messageId ] = await stopParticipating($selectedAccountId, [ eventId ], ParticipationAction.Unvote)
+        const [messageId] = await stopParticipating($selectedAccountId, [eventId], ParticipationAction.Unvote)
         while (isParticipationPending(messageId)) {
             await sleep(2000)
         }
@@ -90,7 +98,7 @@
     }
 
     const handleStopClick = (): void => {
-        votingAction = VotingAction.Stop;
+        votingAction = VotingAction.Stop
         successText = localize('popups.votingConfirmation.votesStopped')
         handleCastClick()
     }
@@ -128,15 +136,19 @@
     <Text type="p" classes="mb-5">{nextVote?.additionalInfo}</Text>
     {#if showAdditionalInfo}
         <div class="flex items-center mb-6 bg-blue-100 rounded-xl p-3">
-            <Icon icon="info" classes="text-gray-500 font-bold"></Icon>
+            <Icon icon="info" classes="text-gray-500 font-bold" />
             <Text type="p" classes="px-3">{localize('popups.votingConfirmation.additionalInfo')}</Text>
         </div>
     {/if}
     <div class="flex justify-between space-x-2">
         <Button onClick={closePopup} secondary classes="mb-0 w-full block text-15">{localize('actions.cancel')}</Button>
-        <Button onClick={handleCastClick} {disabled} classes="mb-0 w-full block text-15">{localize(`actions.${votingAction}`)}</Button>
+        <Button onClick={handleCastClick} {disabled} classes="mb-0 w-full block text-15">
+            {localize(`actions.${votingAction}`)}
+        </Button>
         {#if votingAction === `${VotingAction.Merge}`}
-            <Button onClick={handleStopClick} {disabled} classes="mb-0 w-full block text-15">{localize(`actions.${VotingAction.Stop}`)}</Button>
+            <Button onClick={handleStopClick} {disabled} classes="mb-0 w-full block text-15">
+                {localize(`actions.${VotingAction.Stop}`)}
+            </Button>
         {/if}
     </div>
 </div>

--- a/packages/shared/components/popups/GovernanceVotingPowerInfo.svelte
+++ b/packages/shared/components/popups/GovernanceVotingPowerInfo.svelte
@@ -6,8 +6,10 @@
 
 <div>
     <Text type="h2" classes="mb-10">{localize('views.governance.votingPower.info.title')}</Text>
-    <div class='w-full h-48 bg-lightblue-100 rounded-2xl mb-8 flex justify-center items-center'>
-        <Text type="h3" classes="text-gray-800" overrideColor>{localize('views.governance.votingPower.info.equality')}</Text>
+    <div class="w-full h-48 bg-lightblue-100 rounded-2xl mb-8 flex justify-center items-center">
+        <Text type="h3" classes="text-gray-800" overrideColor
+            >{localize('views.governance.votingPower.info.equality')}</Text
+        >
     </div>
     <Text type="p" classes="mb-2">{localize('views.governance.votingPower.info.description1')}</Text>
     <Text type="p">{localize('views.governance.votingPower.info.description2')}</Text>

--- a/packages/shared/components/popups/Success.svelte
+++ b/packages/shared/components/popups/Success.svelte
@@ -8,7 +8,12 @@
 
 <div>
     <div class="flex justify-center">
-        <Icon icon="success-check" classes="text-white w-full h-full" boxed boxClasses="bg-green-500 justify-center w-11 h-11"/>
+        <Icon
+            icon="success-check"
+            boxed
+            boxClasses="bg-green-500 justify-center w-11 h-11"
+            classes="text-white w-full h-full"
+        />
     </div>
     <Text type="h2" classes="my-5 text-center">{successText}</Text>
     <Button classes="mb-0 w-full block text-15" onClick={closePopup}>{localize('actions.done')}</Button>

--- a/packages/shared/lib/participation/constants.ts
+++ b/packages/shared/lib/participation/constants.ts
@@ -45,4 +45,4 @@ export const STAKING_AIRDROP_TOKENS: { [key in StakingAirdrop]: string } = {
  */
 export const PARTICIPATION_POLL_DURATION = 10 * MILLISECONDS_PER_SECOND
 
-export const TREASURY_VOTE_EVENT_ID = '01fa9037f57cec5ced5b4b3525cc0e4952bf2f7707822ea9e3dbb637e2229f33'
+export const TREASURY_VOTE_EVENT_ID = 'b0cd7ac16c22c12fecad5a9f5c92fb11c84a07a708dd77581d8eb33675723926'

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -73,17 +73,8 @@ export const resetParticipation = (): void => {
  *
  * @returns {boolean}
  */
-export const canParticipate = (eventState: ParticipationEventState): boolean => {
-    switch (eventState) {
-        case ParticipationEventState.Commencing:
-        case ParticipationEventState.Holding:
-            return true
-        case ParticipationEventState.Upcoming:
-        case ParticipationEventState.Ended:
-        default:
-            return false
-    }
-}
+export const canParticipate = (eventState: ParticipationEventState): boolean =>
+    eventState === ParticipationEventState.Commencing || eventState === ParticipationEventState.Holding
 
 /**
  * Determines whether an account can participate in an event.

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -284,12 +284,6 @@
     }
 </script>
 
-<style type="text/scss">
-    :global(:not(body.platform-win32)) .dashboard-wrapper {
-        margin-top: calc(env(safe-area-inset-top) / 2);
-    }
-</style>
-
 <Idle />
 <div class="dashboard-wrapper flex flex-row w-full h-full">
     <Sidebar {locale} />
@@ -299,3 +293,9 @@
         <DeveloperProfileIndicator {locale} classes="absolute top-0" />
     </div>
 </div>
+
+<style type="text/scss">
+    :global(:not(body.platform-win32)) .dashboard-wrapper {
+        margin-top: calc(env(safe-area-inset-top) / 2);
+    }
+</style>

--- a/packages/shared/routes/dashboard/governance/Governance.svelte
+++ b/packages/shared/routes/dashboard/governance/Governance.svelte
@@ -6,7 +6,7 @@
     import { participationEvents } from 'shared/lib/participation/stores'
     import { wallet } from 'shared/lib/wallet'
     import { selectedAccountId } from 'shared/lib/wallet'
-    import { TREASURY_VOTE_EVENT_ID } from 'shared/lib/participation/constants';
+    import { TREASURY_VOTE_EVENT_ID } from 'shared/lib/participation/constants'
 
     const { accounts } = $wallet
 
@@ -28,7 +28,8 @@
                     <WalletPill
                         account={acc}
                         active={acc.id === $selectedAccountId}
-                        onClick={() => handleAccountClick(acc.id)} />
+                        onClick={() => handleAccountClick(acc.id)}
+                    />
                 {/each}
             </div>
         </div>
@@ -39,9 +40,10 @@
                 <WalletPill
                     account={acc}
                     active={acc.id === $selectedAccountId}
-                    onClick={() => handleAccountClick(acc.id)} />
+                    onClick={() => handleAccountClick(acc.id)}
+                />
             {/each}
         </div>
-        <GovernanceEventDetails {event}/>
+        <GovernanceEventDetails {event} />
     {/if}
 </div>

--- a/packages/shared/routes/dashboard/governance/views/GovernanceEventDetails.svelte
+++ b/packages/shared/routes/dashboard/governance/views/GovernanceEventDetails.svelte
@@ -4,31 +4,34 @@
     import { GovernanceRoutes } from 'shared/lib/typings/routes'
     import { governanceRoute } from 'shared/lib/router'
     import { openPopup } from 'shared/lib/popup'
-    import { participationOverview } from 'shared/lib/participation/stores';
+    import { participationOverview } from 'shared/lib/participation/stores'
     import { ParticipationEvent, ParticipationEventState, VotingEventAnswer } from 'shared/lib/participation/types'
-    
-    export let event: ParticipationEvent;
 
-    let currentVoteValue: string;
+    export let event: ParticipationEvent
+
+    let currentVoteValue: string
     $: {
-        const overview = $participationOverview[0];
-        const participation = overview?.participations.find(
-            (participation) => participation.eventId === event.eventId
-        )
+        const overview = $participationOverview[0]
+        const participation = overview?.participations.find((participation) => participation.eventId === event.eventId)
         currentVoteValue = participation?.answers[0] ?? null
     }
+    $: isEventDisabled =
+        event?.status?.status === ParticipationEventState.Ended ||
+        event?.status?.status === ParticipationEventState.Inactive
 
     const handleBackClick = (): void => governanceRoute.set(GovernanceRoutes.Init)
 
     const handleClick = (nextVote: VotingEventAnswer): void => {
-        openPopup({
-            type: 'governanceCastVote',
-            props: {
-                currentVoteValue,
-                eventId: event?.eventId,
-                nextVote,
-            }
-        })
+        if (!isEventDisabled) {
+            openPopup({
+                type: 'governanceCastVote',
+                props: {
+                    currentVoteValue,
+                    eventId: event?.eventId,
+                    nextVote,
+                },
+            })
+        }
     }
 
     const getAnswerHeader = (answerValue: string): string => {
@@ -54,36 +57,49 @@
 <div
     on:click={handleBackClick}
     class="inline-flex justify-between items-center w-20 p-2 pr-4 bg-white hover:bg-gray-100 border
-    rounded-lg border-solid border-gray-300 cursor-pointer mb-5">
+    rounded-lg border-solid border-gray-300 cursor-pointer mb-5"
+>
     <Icon icon="arrow-left" classes="w-4 h-4 text-gray-500" />
     <Text type="p" smaller overrideColor classes="text-gray-800">{localize('actions.back')}</Text>
 </div>
 
 <div class="w-full h-full grid grid-cols-3 gap-x-4 min-h-0">
     <DashboardPane classes="w-full h-full p-6 col-span-2 flex flex-col">
-        <Text type="p" classes="mr-auto uppercase px-2 py-1 mb-2 text-blue-500 bg-blue-100 rounded-lg" smaller bold overrideColor>{event?.status?.status}</Text>
+        <Text
+            type="p"
+            classes="mr-auto uppercase px-2 py-1 mb-2 text-blue-500 bg-blue-100 rounded-lg"
+            smaller
+            bold
+            overrideColor>{event?.status?.status}</Text
+        >
         <Text type="h2" classes="mb-4">{event?.information?.name}</Text>
         <Text type="p" classes="mb-2">{event?.information?.additionalInfo}</Text>
         <Text type="p" classes="mb-2">{event?.information?.payload?.questions[0]?.text}</Text>
         <Text type="p" classes="mb-6">{event?.information?.payload?.questions[0]?.additionalInfo}</Text>
         {#each event?.information?.payload?.questions[0]?.answers as answer}
             <div
-                on:click={() => handleClick(answer)} 
-                class="py-4 px-6 bg-{isSelected(answer?.value) ? 'blue-100' : 'gray-50'} hover:bg-gray-100 border border-solid border-gray-100 rounded-lg flex justify-between mb-4 cursor-pointer"
+                on:click={() => handleClick(answer)}
+                class="py-4 px-6 bg-{isSelected(answer?.value)
+                    ? 'blue-100'
+                    : 'gray-50'} hover:bg-gray-100 border border-solid border-gray-100 rounded-lg flex justify-between mb-4 cursor-pointer"
             >
                 <div>
                     <div class="flex items-center mb-2">
                         {#if isSelected(answer?.value)}
-                            <Icon width=16 height=16 icon="checkbox-round" classes="text-blue-500 mr-2"></Icon>
+                            <Icon width="16" height="16" icon="checkbox-round" classes="text-blue-500 mr-2" />
                         {/if}
-                        <Text type="p" classes="uppercase text-blue-500" overrideColor smaller bold>{getAnswerHeader(answer?.value)}</Text>
+                        <Text type="p" classes="uppercase text-blue-500" overrideColor smaller bold>
+                            {getAnswerHeader(answer?.value)}
+                        </Text>
                     </div>
                     <Text type="h3" classes="mb-2">{answer?.text}</Text>
                     <Text type="p">{answer?.additionalInfo}</Text>
                 </div>
-                <div class="my-auto">
-                    <Icon icon="chevron-right" />
-                </div>
+                {#if !isEventDisabled}
+                    <div class="my-auto">
+                        <Icon icon="chevron-right" />
+                    </div>
+                {/if}
             </div>
         {/each}
     </DashboardPane>
@@ -92,7 +108,9 @@
             <Text type="p" smaller>My voting power</Text>
             <Text type="h1" classes="inline-flex items-end">4528 <Text type="h4" classes="ml-1 mb-1">votes</Text></Text>
             <Text type="p" smaller>My max voting power</Text>
-            <Text type="h1" classes="inline-flex items-end">195609600 <Text type="h4" classes="ml-1 mb-1">votes</Text></Text>
+            <Text type="h1" classes="inline-flex items-end">
+                195609600 <Text type="h4" classes="ml-1 mb-1">votes</Text>
+            </Text>
         </div>
         <Icon icon="info" classes="ml-auto mt-0" />
     </DashboardPane>

--- a/packages/shared/routes/dashboard/governance/views/GovernanceEvents.svelte
+++ b/packages/shared/routes/dashboard/governance/views/GovernanceEvents.svelte
@@ -10,10 +10,22 @@
     const handleButtonClick = () => governanceRoute.set(GovernanceRoutes.EventDetails)
 </script>
 
-<div class="w-full h-full bg-lightblue-200 rounded-2xl"></div>
-<Text type="p" classes="bg-white text-14 px-4 py-2 rounded-2xl text-blue-500 uppercase w-fit -mt-4 mb-6" overrideColor bold smaller>
+<div class="w-full h-full bg-lightblue-200 rounded-2xl" />
+<Text
+    type="p"
+    classes="bg-white text-14 px-4 py-2 rounded-2xl text-blue-500 uppercase w-fit -mt-4 mb-6"
+    overrideColor
+    bold
+    smaller
+>
     {localize(`views.governance.events.status.${event?.status?.status}`)}
 </Text>
 <Text type="h2" classes="text-gray-800 mb-4" overrideColor>{event?.information?.name}</Text>
-<Text type="p" classes="text-gray-700 mb-6 mx-16 text-14 text-center" overrideColor>{event?.information?.additionalInfo} </Text>
-<Button classes="w-1/4" onClick={handleButtonClick} disabled={!event}><Text type="h5" overrideColor classes="text-white">{localize('views.governance.events.button')}</Text></Button>
+<Text type="p" classes="text-gray-700 mb-6 mx-16 text-14 text-center" overrideColor>
+    {event?.information?.additionalInfo}
+</Text>
+<Button classes="w-1/4" onClick={handleButtonClick} disabled={!event}>
+    <Text type="h5" overrideColor classes="text-white">
+        {localize('views.governance.events.button')}
+    </Text>
+</Button>

--- a/packages/shared/routes/dashboard/governance/views/GovernanceInfo.svelte
+++ b/packages/shared/routes/dashboard/governance/views/GovernanceInfo.svelte
@@ -4,13 +4,18 @@
     import { localize } from 'shared/lib/i18n'
 </script>
 
-<div class='h-full flex flex-col justify-between'>
+<div class="h-full flex flex-col justify-between">
     <div>
         <Text type="h3" classes="mr-5 text-gray-800 mb-5" overrideColor>{localize('views.governance.info.title')}</Text>
-        <Text type="p" classes="mr-5 text-gray-700 mb-5 font-normal text-14" overrideColor>{localize('views.governance.info.description')}</Text>
+        <Text type="p" classes="mr-5 text-gray-700 mb-5 font-normal text-14" overrideColor>
+            {localize('views.governance.info.description')}
+        </Text>
     </div>
-    <Link classes="mr-5 text-13 text-gray-800 border border-solid border-gray-300 rounded-xl py-4 pl-6 flex justify-between hover:bg-blue-100"
-    onClick={() => Electron.openUrl('https://iotatreasury.org/how-voting-works.html')}>
-    {localize('views.governance.info.link')} <Icon icon="chevron-right" classes="flex-shrink-0 mx-4 text-gray-700 dark:text-white" />
+    <Link
+        classes="mr-5 text-13 text-gray-800 border border-solid border-gray-300 rounded-xl py-4 pl-6 flex justify-between hover:bg-blue-100"
+        onClick={() => Electron.openUrl('https://iotatreasury.org/how-voting-works.html')}
+    >
+        {localize('views.governance.info.link')}
+        <Icon icon="chevron-right" classes="flex-shrink-0 mx-4 text-gray-700 dark:text-white" />
     </Link>
 </div>

--- a/packages/shared/routes/dashboard/governance/views/GovernanceVotingPower.svelte
+++ b/packages/shared/routes/dashboard/governance/views/GovernanceVotingPower.svelte
@@ -6,8 +6,10 @@
     export let votingPower = 4528125
 </script>
 
-<div class='flex items-center mb-5 cursor-pointer' on:click={() => openPopup({ type: 'governanceVotingPowerInfo' })}>
-    <Text type="p" classes="mr-2 text-gray-700" overrideColor smaller>{localize('views.governance.votingPower.title')}</Text>
+<div class="flex items-center mb-5 cursor-pointer" on:click={() => openPopup({ type: 'governanceVotingPowerInfo' })}>
+    <Text type="p" classes="mr-2 text-gray-700" overrideColor smaller>
+        {localize('views.governance.votingPower.title')}
+    </Text>
     <Icon icon="info-filled" classes="flex-shrink-0 text-gray-500 dark:text-white w-3 h-3" />
 </div>
 <Text type="h1" classes="text-gray-800 inline-flex" overrideColor>{votingPower}</Text>


### PR DESCRIPTION
## Summary

Blocked event disabling if event is inactive/ended. UI finalization has to be done in another PR.

### Changelog

```
chevron and popup disabled if event has ended/is inactive.
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/2348

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
