### PR TITLE
chore: Use Node.js 14 on CI and update readme

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Set up Python 2.x
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.lint.yml
+++ b/.github/workflows/ci.lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install Dependencies
         run: yarn --ignore-scripts

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install Dependencies
         run: yarn --ignore-scripts

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -6,7 +6,7 @@ This is the directory for the desktop application of Firefly - IOTA's new offici
 
 The following __must__ be installed on all platforms:
 
-- [Node.js](https://nodejs.org/en/) 12+ (NOTE: There may be issues with Node.js 15 on Windows)
+- [Node.js](https://nodejs.org/en/) 14+ (NOTE: There may be issues with Node.js 15 on Windows)
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [Rust](https://www.rust-lang.org/tools/install)
 


### PR DESCRIPTION
## Summary
#2381 added `@capacitor/docgen` as a dependency, but it fails to install unless Node.js 14 or later is installed

### Changelog
N/A

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing


## Testing
N/A

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation