### PR TITLE
feat: add account reactivity to voting detail view

### DIFF
--- a/packages/shared/components/popups/GovernanceCastVote.svelte
+++ b/packages/shared/components/popups/GovernanceCastVote.svelte
@@ -4,7 +4,7 @@
     import { localize } from 'shared/lib/i18n'
     import { closePopup } from 'shared/lib/popup'
     import { isSoftwareProfile } from 'shared/lib/profile'
-    import { selectedAccountId, api } from 'shared/lib/wallet'
+    import { selectedAccount, api } from 'shared/lib/wallet'
     import { participate, participateWithRemainingFunds, stopParticipating } from 'shared/lib/participation/api'
     import { showAppNotification } from 'shared/lib/notifications'
     import { openPopup } from 'shared/lib/popup'
@@ -66,14 +66,14 @@
         switch (votingAction) {
             case VotingAction.Cast:
                 await participate(
-                    $selectedAccountId,
+                    $selectedAccount?.id,
                     [{ eventId, answers: [nextVote?.value] }],
                     ParticipationAction.Vote
                 )
                 break
             case VotingAction.Merge:
                 await participateWithRemainingFunds(
-                    $selectedAccountId,
+                    $selectedAccount?.id,
                     [{ eventId, answers: [nextVote?.value] }],
                     ParticipationAction.Vote
                 )
@@ -82,7 +82,7 @@
                 await changeVote()
                 break
             case VotingAction.Stop:
-                await stopParticipating($selectedAccountId, [eventId], ParticipationAction.Unvote)
+                await stopParticipating($selectedAccount?.id, [eventId], ParticipationAction.Unvote)
                 break
             default:
                 throw new Error('Unimplemented voting action!')
@@ -90,11 +90,11 @@
     }
 
     const changeVote = async (): Promise<void> => {
-        const [messageId] = await stopParticipating($selectedAccountId, [eventId], ParticipationAction.Unvote)
+        const [messageId] = await stopParticipating($selectedAccount?.id, [eventId], ParticipationAction.Unvote)
         while (isParticipationPending(messageId)) {
             await sleep(2000)
         }
-        await participate($selectedAccountId, [{ eventId, answers: [nextVote?.value] }], ParticipationAction.Vote)
+        await participate($selectedAccount?.id, [{ eventId, answers: [nextVote?.value] }], ParticipationAction.Vote)
     }
 
     const handleStopClick = (): void => {

--- a/packages/shared/routes/dashboard/governance/Governance.svelte
+++ b/packages/shared/routes/dashboard/governance/Governance.svelte
@@ -5,15 +5,13 @@
     import { governanceRoute } from 'shared/lib/router'
     import { participationEvents } from 'shared/lib/participation/stores'
     import { wallet } from 'shared/lib/wallet'
-    import { selectedAccountId } from 'shared/lib/wallet'
+    import { selectedAccount, setSelectedAccount } from 'shared/lib/wallet'
     import { TREASURY_VOTE_EVENT_ID } from 'shared/lib/participation/constants'
 
     const { accounts } = $wallet
 
-    selectedAccountId.set($accounts[0]?.id)
-
     function handleAccountClick(accountId: string): void {
-        selectedAccountId.set(accountId)
+        setSelectedAccount(accountId)
     }
 
     $: event = $participationEvents.find((p) => p.eventId === TREASURY_VOTE_EVENT_ID)
@@ -27,7 +25,7 @@
                 {#each $accounts as acc}
                     <WalletPill
                         account={acc}
-                        active={acc.id === $selectedAccountId}
+                        active={acc.id === $selectedAccount?.id}
                         onClick={() => handleAccountClick(acc.id)}
                     />
                 {/each}
@@ -39,7 +37,7 @@
             {#each $accounts as acc}
                 <WalletPill
                     account={acc}
-                    active={acc.id === $selectedAccountId}
+                    active={acc.id === $selectedAccount?.id}
                     onClick={() => handleAccountClick(acc.id)}
                 />
             {/each}


### PR DESCRIPTION
## Summary

This PR aims to fix the branch feat/voting after `feat/single-wallet` got merged.
Additionally, I used the time to add reactivity to the event detail page 

### Changelog
```
fix: replace selectedAccountId with selectedAccount
feat: add account reactivity to event details view
```

## Relevant Issues
Closes #2347

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

Vote and switch accounts to see the reactivity working.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
