### PR TITLE
fix: ledger regenerate address

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -125,13 +125,14 @@ export const resetWallet = (): void => {
     walletSetupType.set(null)
 }
 
-// used to make selectedAccount reactive to changes in the wallet
-const _selectedAccountId = writable<AccountIdentifier | null>(null)
+// Created to help selectedAccount reactivity.
+// Use it to detected switches on selectedAccount
+export const selectedAccountId = writable<AccountIdentifier | null>(null)
 
-export const selectedAccount = derived([_selectedAccountId, get(wallet).accounts], ([$_selectedAccountId, $accounts]) =>
-    $accounts.find((acc) => acc.id === $_selectedAccountId)
+export const selectedAccount = derived([selectedAccountId, get(wallet).accounts], ([$selectedAccountId, $accounts]) =>
+    $accounts.find((acc) => acc.id === $selectedAccountId)
 )
-export const setSelectedAccount = (id: AccountIdentifier): void => _selectedAccountId.set(id)
+export const setSelectedAccount = (id: AccountIdentifier): void => selectedAccountId.set(id)
 export const getAccountById = (id: AccountIdentifier): WalletAccount | null => {
     const accounts = get(wallet)?.accounts
     return get(accounts)?.find((account) => account.id === id) || null

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -40,6 +40,7 @@
         processMigratedTransactions,
         removeEventListeners,
         selectedAccount,
+        selectedAccountId,
         setSelectedAccount,
         transferState,
         updateBalanceOverview,
@@ -112,12 +113,8 @@
     let isGeneratingAddress = false
 
     // If account changes force regeneration of Ledger receive address
-    $: {
-        // TODO: fix this, selectedAccount changes triggers too many times
-        selectedAccount?.id
-        if ($isLedgerProfile) {
-            hasGeneratedALedgerReceiveAddress.set(false)
-        }
+    $: if ($selectedAccountId && $isLedgerProfile) {
+        hasGeneratedALedgerReceiveAddress.set(false)
     }
 
     $: if ($accountsLoaded) {


### PR DESCRIPTION
## Summary

This PR aims to fix [this line](https://github.com/iotaledger/firefly/blob/a3710d45da798548e368e3b769eda4c31a8109f1/packages/shared/routes/dashboard/wallet/Wallet.svelte#L148) which was broken in `feat/single-account`, it was being called on every `selectedAccount` change, instead of the selected index. 

### Changelog
```
fix: ledger regenerate address
feat: expose selectedAccountId globally
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
