### PR TITLE
feat: reset governance upon logout

### DIFF
--- a/packages/shared/lib/router.ts
+++ b/packages/shared/lib/router.ts
@@ -1,3 +1,4 @@
+import { get, readable, writable } from 'svelte/store'
 import { cleanupSignup, login, mobile, strongholdPassword, walletPin } from 'shared/lib/app'
 import { activeProfile, profiles, setProfileType } from 'shared/lib/profile'
 import {
@@ -9,7 +10,6 @@ import {
     SetupType,
     Tabs,
 } from 'shared/lib/typings/routes'
-import { get, readable, writable } from 'svelte/store'
 import { deepLinkRequestActive } from './deepLinking/deepLinking'
 import { closePopup } from './popup'
 import { ProfileType } from './typings/profile'
@@ -293,22 +293,22 @@ export const routerPrevious = (): void => {
 
 export const resetRouter = (): void => {
     history.set([])
-    const hasCompletedSetup: boolean = get(profiles).length > 0
+    const hasCompletedSetup = get(profiles).length > 0
     if (hasCompletedSetup) {
         setRoute(AppRoute.Login)
     } else {
         setRoute(AppRoute.Welcome)
     }
 
-    accountRoute.set(AccountRoutes.Init)
+    resetWalletRoute()
     settingsRoute.set(SettingsRoutes.Init)
-    dashboardRoute.set(Tabs.Wallet)
+    governanceRoute.set(GovernanceRoutes.Init)
     deepLinkRequestActive.set(false)
 }
 
 export const resetWalletRoute = (): void => {
-    dashboardRoute.set(Tabs.Wallet)
     accountRoute.set(AccountRoutes.Init)
+    dashboardRoute.set(Tabs.Wallet)
 }
 
 export const resetLedgerRoute = (): void => {


### PR DESCRIPTION
## Summary

The governance router is reset upon logout

### Changelog

```
fix: governance router resets upon logout()
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/2406

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

Go to governance dashboard and view proposal. Log out and log in. If you go to the governance dashboard, you should see the dashboard and not the proposal.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
