### PR TITLE
fix: capacitor binding yarn issue affecting Windows 

### DIFF
--- a/packages/backend/bindings/capacitor/package.json
+++ b/packages/backend/bindings/capacitor/package.json
@@ -17,11 +17,13 @@
     "verify:ios": "cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin && cd ..",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
-    "build": "npm run clean && tsc && rollup -c rollup.config.js",
+    "build": "node ./scripts/build.js",
+    "build:clean" : "rimraf ./dist",
+    "build:bundle": "tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "preinstall": "npm run clean && npm run build"
+    "preinstall": "npm run build"
   },
   "private": true,
   "repository": {

--- a/packages/backend/bindings/capacitor/scripts/build.js
+++ b/packages/backend/bindings/capacitor/scripts/build.js
@@ -1,0 +1,7 @@
+const { resolve } = require('path');
+const { spawnSync } = require('child_process')
+
+spawnSync(process.platform === 'win32' ? 'yarn.cmd' : 'yarn', ['build:clean', 'build:bundle'], {
+    stdio: "inherit",
+    cwd: resolve(__dirname, '../'),
+})


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
An [issue with Yarn](https://github.com/yarnpkg/yarn/issues/4564) is causing yarn workspaces to fail on Windows when there is a script that utilizes a dependency before the yarn workspace is instantiated. The capacitor bindings workspace needs a preinstall script that uses `rimraf` to support its functionality, which is causing Windows to fail.

This PR adds a node script to the capacitor workspace that is instead called in the preinstall script.
### Changelog
```
- Added script to packages/backend/bindings/capacitor/scripts that calls correct dependency path
- Changed package.json scripts to use this new script
```

## Relevant Issues
Closes #2450

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [x] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.
- @amadeu2 Please confirm that mobile functionality remains intact after these changes and that yarn doesn't fail on a Linux OS.
- @maxwellmattryan Please confirm that yarn doesn't fail on Windows with this change.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting
