### PR TITLE
fix: lib module path aliases

### DIFF
--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -6,8 +6,8 @@
         "isolatedModules": false,
         "lib": ["DOM", "ESNext"],
         "paths": {
-            "@common": ["../shared/lib/common/*"],
-            "@core": ["../shared/lib/core/*"]
+            "@common/*": ["../shared/lib/common/*"],
+            "@core/*": ["../shared/lib/core/*"]
         }
     },
     "include": ["./lib/**/*.ts", "../shared/lib/**/*.ts"]


### PR DESCRIPTION
## Summary
There was no wildcard symbol in the TS config paths for desktop, causing a failure in building Svelte components where used.

### Changelog
```
- Add wildcard pattern to desktop TS config file
```

## Relevant Issues
_None_

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Used the fix in a refactoring task with `@common/*`.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation