### PR TITLE
Fix Mobile Plugin Capacitor Bindings iOS build production

### DIFF
--- a/packages/backend/bindings/capacitor/FireflyActorSystemCapacitorBindings.podspec
+++ b/packages/backend/bindings/capacitor/FireflyActorSystemCapacitorBindings.podspec
@@ -11,10 +11,14 @@
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
     #s.vendored_libraries = ['ios/Plugin/Libraries/libwallet.a']
-    s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lc++' }
+    s.pod_target_xcconfig = { 
+      'OTHER_LDFLAGS' => '-lc++',
+      'ENABLE_BITCODE' => '$(ENABLE_BITCODE_$(CONFIGURATION))',
+      'ENABLE_BITCODE_Release' => 'NO', 
+      'ENABLE_BITCODE_Debug' => 'YES'
+    }
     s.weak_frameworks = 'IOTAWalletInternal'
     s.platform = :ios, "12.0"
     s.xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/ios/Plugin/Libraries' }
     s.preserve_paths = ['ios/Plugin/Libraries/module.modulemap']
-    s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
   end

--- a/packages/backend/bindings/capacitor/FireflyActorSystemCapacitorBindings.podspec
+++ b/packages/backend/bindings/capacitor/FireflyActorSystemCapacitorBindings.podspec
@@ -6,7 +6,7 @@
     s.license = { :type => 'MIT' }
     s.homepage = 'https://github.com/iotaledger/firefly'
     s.author = 'IOTA Stiftung'
-    s.source = { :git => 'https://github.com/iotaledger/firefly', :tag => s.version.to_s }
+    s.source = { :git => 'https://github.com/iotaledger/firefly.git', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'

--- a/packages/backend/bindings/capacitor/FireflyActorSystemCapacitorBindings.podspec
+++ b/packages/backend/bindings/capacitor/FireflyActorSystemCapacitorBindings.podspec
@@ -16,4 +16,5 @@
     s.platform = :ios, "12.0"
     s.xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/ios/Plugin/Libraries' }
     s.preserve_paths = ['ios/Plugin/Libraries/module.modulemap']
+    s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
   end

--- a/packages/mobile/ios/App/App/Info.plist
+++ b/packages/mobile/ios/App/App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-        <string>firefly-mobile</string>
+	<string>Firefly</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Summary
To build for production and get *.ipa files we needed to disable bitcode for the bindings plugin, it's related to cargo-lipo.

### Changelog
We do this adding a flag on Pod file.
Also fixed git url.

## Relevant Issues
Closes https://github.com/iotaledger/firefly/issues/2494

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [ ] Android

### Instructions
Open Xcode, and open the Product menu and choose Archive.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
