### PR TITLE
chore: Update `node-abi` to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "resolutions": {
         "lodash": ">=4.17.21",
         "ansi-regex": "5.0.1",
-        "glob-parent": " >=5.1.2"
+        "glob-parent": " >=5.1.2",
+        "node-abi": "^3.8.0"
     },
     "lint-staged": {
         "*.{ts,js,scss,css,svelte}": "eslint --cache --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,12 +7640,12 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@^2.7.0:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
-  integrity sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
+node-abi@^2.7.0, node-abi@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.8.0.tgz#679957dc8e7aa47b0a02589dbfde4f77b29ccb32"
+  integrity sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==
   dependencies:
-    semver "^5.4.1"
+    semver "^7.3.5"
 
 node-addon-api@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## Summary
[`node-abi`](https://github.com/electron/node-abi) is used to map Electron versions to their respective Node.js ABI version. When Electron was updated to 12.2.3, the corresponding ABI version could not be found in the version of `node-abi` we currently use. As a result, native dependencies such as `keytar` would not build properly, causing Webpack to fail to bundle the code and `electron-builder` to show warnings.

When running `yarn build`:
```
Module not found: Error: Can't resolve '../build/Release/keytar.node' in 'firefly/node_modules/keytar/lib'
```

When running `yarn compile:<os>`:
```
Error: Could not detect abi for version 12.2.3 and runtime electron.  Updating "node-abi" might help solve this issue if it is a new release of electron
```

**Note: you may need to remove the root `node_modules` folder and re-run `yarn` so that `keytar` and other dependencies are built properly**

### Changelog
```
- chore: Update node-abi to 3.8.0
```

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Remove `node_modules` folder, reinstall dependencies, and run `yarn build` and `yarn compile:<os>`

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code