### PR TITLE
feat: add global back button

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -78,9 +78,6 @@
     <Route route={AppRoute.CrashReporting}>
         <CrashReporting locale={$_} />
     </Route>
-    <Route route={AppRoute.Settings}>
-        <Settings locale={$_} />
-    </Route>
     <Route route={AppRoute.Appearance}>
         <Appearance locale={$_} />
     </Route>

--- a/packages/shared/lib/core/router/enums/routes.ts
+++ b/packages/shared/lib/core/router/enums/routes.ts
@@ -5,7 +5,6 @@ export enum AppRoute {
     Appearance = 'appearance',
     Profile = 'profile',
     Setup = 'setup',
-    Settings = 'settings',
     // TODO: ledger replace create
     Create = 'create',
     Secure = 'secure',

--- a/packages/shared/routes/dashboard/TopNavigation.svelte
+++ b/packages/shared/routes/dashboard/TopNavigation.svelte
@@ -4,22 +4,21 @@
     import { localize } from '@core/i18n'
     import { AccountSwitcher, Icon, Text } from 'shared/components'
     import { WalletAccount } from 'shared/lib/typings/wallet'
-    import { appRoute, AppRoute, SettingsRoute, settingsRoute, settingsRouter } from '@core/router'
+    import { DashboardRoute, dashboardRoute, SettingsRoute, settingsRoute, settingsRouter } from '@core/router'
 
     export let onCreateAccount = (..._: any[]): void => {}
 
     const viewableAccounts = getContext<Readable<WalletAccount[]>>('viewableAccounts')
 
-    $: showBackButton = isCorrectRoute($appRoute)
+    $: showBackButton = isCorrectRoute($settingsRoute)
 
-    function isCorrectRoute(route: AppRoute): boolean {
-        const showInSettings = $settingsRoute !== SettingsRoute.Init
-        return showInSettings
+    function isCorrectRoute(_: SettingsRoute): boolean {
+        return $settingsRoute !== SettingsRoute.Init
     }
 
-    function handleBackClick() {
-        switch ($appRoute) {
-            case AppRoute.Settings:
+    function handleBackClick(): void {
+        switch ($dashboardRoute) {
+            case DashboardRoute.Settings:
                 $settingsRouter.previous()
                 break
             default:

--- a/packages/shared/routes/dashboard/TopNavigation.svelte
+++ b/packages/shared/routes/dashboard/TopNavigation.svelte
@@ -4,7 +4,7 @@
     import { localize } from '@core/i18n'
     import { AccountSwitcher, Icon, Text } from 'shared/components'
     import { WalletAccount } from 'shared/lib/typings/wallet'
-    import { appRoute, AppRoute, SettingsRoute, settingsRoute } from '@core/router'
+    import { appRoute, AppRoute, SettingsRoute, settingsRoute, settingsRouter } from '@core/router'
 
     export let onCreateAccount = (..._: any[]): void => {}
 
@@ -18,8 +18,12 @@
     }
 
     function handleBackClick() {
-        if ($appRoute === AppRoute.Settings) {
-            settingsRoute.set(SettingsRoute.Init)
+        switch ($appRoute) {
+            case AppRoute.Settings:
+                $settingsRouter.previous()
+                break
+            default:
+                break
         }
     }
 </script>

--- a/packages/shared/routes/dashboard/TopNavigation.svelte
+++ b/packages/shared/routes/dashboard/TopNavigation.svelte
@@ -1,23 +1,39 @@
 <script lang="typescript">
     import { getContext } from 'svelte'
-    import { localize } from 'shared/lib/i18n';
+    import { Readable } from 'svelte/store'
+    import { localize } from '@core/i18n'
     import { AccountSwitcher, Icon, Text } from 'shared/components'
-    import type { Readable } from 'svelte/store'
-    import type { WalletAccount } from 'shared/lib/typings/wallet'
+    import { WalletAccount } from 'shared/lib/typings/wallet'
+    import { appRoute, AppRoute, SettingsRoute, settingsRoute } from '@core/router'
 
     export let onCreateAccount = (..._: any[]): void => {}
 
     const viewableAccounts = getContext<Readable<WalletAccount[]>>('viewableAccounts')
+
+    $: showBackButton = isCorrectRoute($appRoute)
+
+    function isCorrectRoute(route: AppRoute): boolean {
+        const showInSettings = $settingsRoute !== SettingsRoute.Init
+        return showInSettings
+    }
+
+    function handleBackClick() {
+        if ($appRoute === AppRoute.Settings) {
+            settingsRoute.set(SettingsRoute.Init)
+        }
+    }
 </script>
 
 <div
     class="bg-gray-200 dark:bg-gray-800 border-solid border-b border-gray-300 dark:border-gray-700 flex flex-row justify-center py-2 w-full"
 >
-    <button on:click={() => console.log('back')} class="absolute left-6">
-        <div class="flex items-center space-x-3">
-            <Icon icon="arrow-left" classes="text-gray-500" />
-            <Text bigger overrideColor classes="text-gray-500">{localize('actions.back')}</Text>
-        </div>
-    </button>
+    {#if showBackButton}
+        <button on:click={handleBackClick} class="absolute left-6">
+            <div class="flex items-center space-x-3">
+                <Icon icon="arrow-left" classes="text-gray-500" />
+                <Text bigger overrideColor classes="text-gray-500">{localize('actions.back')}</Text>
+            </div>
+        </button>
+    {/if}
     <AccountSwitcher {onCreateAccount} accounts={$viewableAccounts} />
 </div>

--- a/packages/shared/routes/dashboard/TopNavigation.svelte
+++ b/packages/shared/routes/dashboard/TopNavigation.svelte
@@ -1,8 +1,9 @@
 <script lang="typescript">
-    import { AccountSwitcher } from 'shared/components'
-    import type { WalletAccount } from 'shared/lib/typings/wallet'
     import { getContext } from 'svelte'
+    import { localize } from 'shared/lib/i18n';
+    import { AccountSwitcher, Icon, Text } from 'shared/components'
     import type { Readable } from 'svelte/store'
+    import type { WalletAccount } from 'shared/lib/typings/wallet'
 
     export let onCreateAccount = (..._: any[]): void => {}
 
@@ -12,5 +13,11 @@
 <div
     class="bg-gray-200 dark:bg-gray-800 border-solid border-b border-gray-300 dark:border-gray-700 flex flex-row justify-center py-2 w-full"
 >
+    <button on:click={() => console.log('back')} class="absolute left-6">
+        <div class="flex items-center space-x-3">
+            <Icon icon="arrow-left" classes="text-gray-500" />
+            <Text bigger overrideColor classes="text-gray-500">{localize('actions.back')}</Text>
+        </div>
+    </button>
     <AccountSwitcher {onCreateAccount} accounts={$viewableAccounts} />
 </div>

--- a/packages/shared/routes/dashboard/settings/views/SettingsViewer.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsViewer.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Icon, Scroller, SettingsNavigator, Text } from 'shared/components'
+    import { Scroller, SettingsNavigator, Text } from 'shared/components'
     import { loggedIn, mobile } from 'shared/lib/app'
     import { localize, _ } from '@core/i18n'
     import { isLedgerProfile, isSoftwareProfile } from 'shared/lib/profile'
@@ -63,10 +63,6 @@
         }
     }
 
-    function handleBackClick() {
-        $settingsRouter.previous()
-    }
-
     onMount(() => {
         const child = $settingsRouter.getChildRouteAndReset()
         if (child) {
@@ -78,12 +74,6 @@
 {#key $_}
     <div class="flex flex-1 flex-row items-start">
         {#if !$mobile}
-            <button data-label="back-button" class="absolute top-8 left-8" on:click={handleBackClick}>
-                <div class="flex items-center space-x-3">
-                    <Icon icon="arrow-left" classes="text-blue-500" />
-                    <Text type="h5">{localize('actions.back')}</Text>
-                </div>
-            </button>
             <SettingsNavigator
                 {routes}
                 onSettingClick={(id) => scrollIntoView(id)}


### PR DESCRIPTION
## Summary

Add a global back button to the single account view

To create a full global back button, we would need a global route history. This should be easily achieved by implementing a GlobalRoutes store with a history.

### Changelog
```
Used the new routers to create a back button on settings
Removed back button from settings view
Removed unused route
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/2428

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
