### PR TITLE
feat: move stronghold status and action to profile modal

### DIFF
--- a/packages/shared/components/modals/ProfileActions.svelte
+++ b/packages/shared/components/modals/ProfileActions.svelte
@@ -49,7 +49,7 @@
     }
 </script>
 
-<Modal bind:isActive position={{ bottom: '16px', left: '80px' }}>
+<Modal bind:isActive position={{ bottom: '16px', left: '80px' }} classes="w-64">
     <profile-modal-content class="flex flex-col" in:fade={{ duration: 100 }}>
         <div class="flex flex-row flex-nowrap items-center space-x-3 p-3">
             <div class="w-8 h-8 flex items-center justify-center flex-shrink-0 rounded-full bg-{profileColor}-500">
@@ -58,12 +58,13 @@
             <Text>{profileName}</Text>
         </div>
         <HR />
-        <div class="flex justify-between items-center p-2">
+        <div class="flex justify-between items-center p-3">
             <div class="flex items-center">
                 <Icon
                     icon={$isStrongholdLocked ? 'lock' : 'unlock'}
                     boxed
-                    classes="text-blue-500 bg-blue-100 mr-2 rounded"
+                    classes="text-blue-500"
+                    boxClasses="bg-blue-100 mr-3"
                 />
                 <div>
                     <Text type="p">{locale('views.dashboard.profileModal.stronghold.title')}</Text>

--- a/packages/shared/components/modals/ProfileActions.svelte
+++ b/packages/shared/components/modals/ProfileActions.svelte
@@ -1,11 +1,14 @@
 <script lang="typescript">
     import { fade } from 'svelte/transition'
-    import { Icon, Modal, Text, HR } from 'shared/components'
+    import { Icon, Modal, Text, HR, Toggle } from 'shared/components'
     import { logout } from 'shared/lib/app'
     import { getInitials } from 'shared/lib/helpers'
-    import { activeProfile } from 'shared/lib/profile'
+    import { activeProfile, isStrongholdLocked } from 'shared/lib/profile'
     import { openSettings } from 'shared/lib/router'
     import type { Locale } from 'shared/lib/typings/i18n'
+    import { showAppNotification } from 'shared/lib/notifications'
+    import { api } from 'shared/lib/wallet'
+    import { openPopup } from 'shared/lib/popup'
 
     export let locale: Locale
     export let isActive: boolean
@@ -23,6 +26,27 @@
     const handleLogoutClick = async (): Promise<void> => {
         await logout()
     }
+
+    function handleStrongholdToggleClick() {
+        if ($isStrongholdLocked) {
+            openPopup({
+                type: 'password',
+                props: {
+                    isStrongholdLocked: $isStrongholdLocked,
+                },
+            })
+        } else {
+            api.lockStronghold({
+                onSuccess() {},
+                onError(err) {
+                    showAppNotification({
+                        type: 'error',
+                        message: locale(err.error),
+                    })
+                },
+            })
+        }
+    }
 </script>
 
 <Modal bind:isActive position={{ bottom: '16px', left: '80px' }}>
@@ -32,6 +56,25 @@
                 <span class="text-12 leading-100 text-center text-white uppercase">{profileInitial}</span>
             </div>
             <Text>{profileName}</Text>
+        </div>
+        <HR />
+        <div class="flex justify-between items-center p-2">
+            <div class="flex items-center">
+                <Icon
+                    icon={$isStrongholdLocked ? 'lock' : 'unlock'}
+                    boxed
+                    classes="text-blue-500 bg-blue-100 mr-2 rounded"
+                />
+                <div>
+                    <Text type="p">{locale('views.dashboard.profileModal.stronghold.title')}</Text>
+                    <Text type="p" overrideColor classes="text-gray-500 -mt-1"
+                        >{locale(
+                            `views.dashboard.profileModal.stronghold.${$isStrongholdLocked ? 'locked' : 'unlocked'}`
+                        )}</Text
+                    >
+                </div>
+            </div>
+            <Toggle active={!$isStrongholdLocked} onClick={handleStrongholdToggleClick} classes="cursor-pointer" />
         </div>
         <HR />
         <button

--- a/packages/shared/components/modals/ProfileActions.svelte
+++ b/packages/shared/components/modals/ProfileActions.svelte
@@ -3,7 +3,7 @@
     import { Icon, Modal, Text, HR, Toggle } from 'shared/components'
     import { logout } from 'shared/lib/app'
     import { getInitials } from 'shared/lib/helpers'
-    import { activeProfile, isStrongholdLocked } from 'shared/lib/profile'
+    import { activeProfile, isStrongholdLocked, isSoftwareProfile } from 'shared/lib/profile'
     import { openSettings } from 'shared/lib/router'
     import type { Locale } from 'shared/lib/typings/i18n'
     import { showAppNotification } from 'shared/lib/notifications'
@@ -58,25 +58,27 @@
             <Text>{profileName}</Text>
         </div>
         <HR />
-        <div class="flex justify-between items-center p-3">
-            <div class="flex items-center">
-                <Icon
-                    icon={$isStrongholdLocked ? 'lock' : 'unlock'}
-                    boxed
-                    classes="text-blue-500"
-                    boxClasses="bg-blue-100 mr-3"
-                />
-                <div>
-                    <Text type="p">{locale('views.dashboard.profileModal.stronghold.title')}</Text>
-                    <Text type="p" overrideColor classes="text-gray-500 -mt-1"
-                        >{locale(
-                            `views.dashboard.profileModal.stronghold.${$isStrongholdLocked ? 'locked' : 'unlocked'}`
-                        )}</Text
-                    >
+        {#if $isSoftwareProfile}
+            <div class="flex justify-between items-center p-3">
+                <div class="flex items-center">
+                    <Icon
+                        icon={$isStrongholdLocked ? 'lock' : 'unlock'}
+                        boxed
+                        classes="text-blue-500"
+                        boxClasses="bg-blue-100 mr-3"
+                    />
+                    <div>
+                        <Text type="p">{locale('views.dashboard.profileModal.stronghold.title')}</Text>
+                        <Text type="p" overrideColor classes="text-gray-500 -mt-1"
+                            >{locale(
+                                `views.dashboard.profileModal.stronghold.${$isStrongholdLocked ? 'locked' : 'unlocked'}`
+                            )}</Text
+                        >
+                    </div>
                 </div>
+                <Toggle active={!$isStrongholdLocked} onClick={handleStrongholdToggleClick} classes="cursor-pointer" />
             </div>
-            <Toggle active={!$isStrongholdLocked} onClick={handleStrongholdToggleClick} classes="cursor-pointer" />
-        </div>
+        {/if}
         <HR />
         <button
             on:click={() => handleSettingsClick()}

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -499,7 +499,12 @@
             },
             "profileModal": {
                 "allSettings": "All settings",
-                "logout": "Log out"
+                "logout": "Log out",
+                "stronghold": {
+                    "title": "Profile lock",
+                    "locked": "Stronghold locked",
+                    "unlocked": "Stronghold unlocked"
+                }
             }
         },
         "staking": {


### PR DESCRIPTION
## Summary
moves stronghold status and action to profile modal for the single account view

## Relevant Issues
closes #2152 

## Type of Change
Please select any type below that applies to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
