### PR TITLE
chore: Add export compliance info to Info.plist

### DIFF
--- a/packages/mobile/ios/App/App/Info.plist
+++ b/packages/mobile/ios/App/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
## Summary
Adds information related to our use of encryption for US export compliance so that we don't need to provide it to Apple every time we upload a build

### Changelog
```
- Set ITSAppUsesNonExemptEncryption to false for iOS export compliance in Info.plist
```

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
N/A

### Instructions
N/A

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code