### PR TITLE
fix: Prevent barcode scanner from turning on at launch

### DIFF
--- a/packages/mobile/capacitor/lib/barcodeManager.ts
+++ b/packages/mobile/capacitor/lib/barcodeManager.ts
@@ -5,8 +5,6 @@ import { IBarcodeManager } from 'shared/lib/typings/barcodeManager'
 
 const openQRBodyClass: string = 'qr-scanner'
 
-void BarcodeScanner.startScan({ targetedFormats: [SupportedFormat.QR_CODE] }) // this will now only target QR-codes
-
 const _stopScanner = async (): Promise<void> => {
     try {
         document.body.classList.remove(openQRBodyClass)
@@ -99,7 +97,9 @@ export const BarcodeManager: IBarcodeManager = {
             if (permissionGranted) {
                 await BarcodeScanner.hideBackground()
                 document.body.classList.add(openQRBodyClass)
-                const result: ScanResult = await BarcodeScanner.startScan()
+                const result: ScanResult = await BarcodeScanner.startScan({
+                    targetedFormats: [SupportedFormat.QR_CODE],
+                })
                 if (result?.hasContent && result?.content) {
                     document.body.classList.remove(openQRBodyClass)
                     onSuccess(result.content)


### PR DESCRIPTION
## Summary
`BarcodeScanner.startScan` is being called when `barcodeManager` is imported, so it is essentially being called at launch and always running.

### Changelog
```
- Avoid calling `BarcodeScanner.startScan` outside of a function
```

## Relevant Issues
N/A

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [ ] Android

### Instructions
Tested on iOS simulator, verified that `startScan` wasn't being called by watching logs from Capacitor

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting