### PR TITLE
fix: delayed asset warning tooltip

### DIFF
--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -52,7 +52,7 @@
     $: $participationOverview, (tooltipText = getLocalizedTooltipText())
     $: remainingTime = asset?.name === Token.Assembly ? $assemblyStakingRemainingTime : $shimmerStakingRemainingTime
     $: {
-        if (hasAccountReachedMinimumAirdrop($selectedAccount) && !isStakingPossible($stakingEventState)) {
+        if (hasAccountReachedMinimumAirdrop() && !isStakingPossible($stakingEventState)) {
             isBelowMinimumRewards = false
         } else {
             isBelowMinimumRewards = $selectedAccountParticipationOverview?.[`${airdrop}RewardsBelowMinimum`] > 0
@@ -79,7 +79,7 @@
         if (isPartiallyStakedAndCanStake) {
             return {
                 title: localize('tooltips.partiallyStakedFunds.title', {
-                    values: { amount: formatUnitBestMatch(getUnstakedFunds($selectedAccount)) },
+                    values: { amount: formatUnitBestMatch(getUnstakedFunds()) },
                 }),
                 body: [localize('tooltips.partiallyStakedFunds.body')],
             }

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -155,7 +155,7 @@
                 <Text secondary smaller>{`≈ ${asset?.fiatBalance}`}</Text>
             {/if}
         </div>
-        {#if showWarningState}
+        {#if showWarningState && tooltipText?.body}
             <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
                 <Icon
                     icon="exclamation"


### PR DESCRIPTION
## Summary

This PR aims to display the warning icon on the asset tile only when the tooltip information is ready

### Changelog
```
fix: delayed asset warning tooltip
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
