### PR TITLE
feat: increase popup zindex

### DIFF
--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -181,7 +181,7 @@
     <popup
         in:fade={{ duration: transition ? 100 : 0 }}
         class={`flex items-center justify-center fixed top-0 left-0 w-screen p-6
-                h-full overflow-hidden z-10 ${fullScreen ? 'bg-white dark:bg-gray-900' : 'bg-gray-800 bg-opacity-40'} ${
+                h-full overflow-hidden z-20 ${fullScreen ? 'bg-white dark:bg-gray-900' : 'bg-gray-800 bg-opacity-40'} ${
             $mobile && 'z-40'
         }`}
     >


### PR DESCRIPTION
## Summary
 
The developer profile banner was displaying above the loader popup because of a CSS zindez issue. Increasing the popup zindex should fix the issue

### Changelog
```
feat: increase popup zindex to z-20
```

## Relevant Issues
Closes #2677

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
