### PR TITLE
fix: minimum rewards popup warning

### DIFF
--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -50,7 +50,8 @@
         const account = _getAccount(get(accounts))
         const accountOverview = $participationOverview.find((apo) => apo.accountIndex === account?.index)
         mustAcknowledgeBelowMinRewardParticipationWarning =
-            accountOverview?.assemblyRewardsBelowMinimum > 0 || accountOverview?.shimmerRewardsBelowMinimum > 0
+            (accountOverview?.assemblyRewardsBelowMinimum > 0 || accountOverview?.shimmerRewardsBelowMinimum > 0) &&
+            isStakingPossible($stakingEventState)
     }
 
     function handleNextClick() {


### PR DESCRIPTION
## Summary
Currently, despite the staking events having ended, users are still shown a warning if they haven't reached minimum rewards.

### Changelog
```
- Changes conditional to ensure that min rewards warning only shows if staking is possible
```

## Relevant Issues
#2679

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Tested trying to send mainnet transaction without account that had below min rewards.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation