### PR TITLE
fix: cancel any requests to select a Bluetooth device

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.1
-ignore: {}
+version: v1.22.2
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-ELECTRON-2431353:
+    - '*':
+        reason: Mitigation applied in PR 2693
+        expires: 2022-04-30T04:10:45.599Z
+        created: 2022-03-31T04:10:45.605Z
 patch: {}

--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -307,6 +307,17 @@ function createWindow() {
     })
 
     /**
+     * CVE-2022-21718 mitigation
+     * Remove when updating to Electron 13.6.6 or later
+     * https://github.com/advisories/GHSA-3p22-ghq8-v749
+     */
+    windows.main.webContents.on('select-bluetooth-device', (event, _devices, cb) => {
+        event.preventDefault()
+        // Cancel the request
+        cb('')
+    })
+
+    /**
      * Handle permissions requests
      */
     session.defaultSession.setPermissionRequestHandler((_webContents, permission, cb, details) => {


### PR DESCRIPTION
## Summary
Mitigates [CVE-2022-21718](https://nvd.nist.gov/vuln/detail/CVE-2022-21718), which allows a compromised renderer to access a Bluetooth device without permission. This uses the workaround from [GHSA-3p22-ghq8-v749](https://github.com/advisories/GHSA-3p22-ghq8-v749) and can be removed after updating to Electron 13.6.6 or later.

### Changelog
```
- Cancel any requests to select a Bluetooth device
- Ignore this alert in Snyk
```

## Relevant Issues
- [GHSA-3p22-ghq8-v749](https://github.com/advisories/GHSA-3p22-ghq8-v749)
- [SNYK-JS-ELECTRON-2431353](https://security.snyk.io/vuln/SNYK-JS-ELECTRON-2431353)

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS

### Instructions
Add the following code to a function that responds to a user gesture (e.g. a button click) to simulate a compromised renderer requesting access to a Bluetooth device:

```js
navigator.bluetooth.requestDevice({ acceptAllDevices: true }).then((device) => {
            console.log(device)
})
```

The following error should appear:
```
DOMException: User cancelled the requestDevice() chooser.
```

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting