### PR TITLE
chore: update selfsigned to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "lodash": ">=4.17.21",
         "ansi-regex": "5.0.1",
         "glob-parent": " >=5.1.2",
-        "node-abi": "^3.8.0"
+        "node-abi": "^3.8.0",
+        "selfsigned": "^2.0.1"
     },
     "lint-staged": {
         "*.{ts,js,scss,css,svelte}": "eslint --cache --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7669,10 +7669,10 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-hid@2.1.1:
   version "2.1.1"
@@ -9197,12 +9197,12 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
-  integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
+selfsigned@^1.10.8, selfsigned@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.1.tgz#8b2df7fa56bf014d19b6007655fff209c0ef0a56"
+  integrity sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==
   dependencies:
-    node-forge "^0.10.0"
+    node-forge "^1"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
Updates `selfsigned` to 2.0.1 and `node-forge` to 1.3.1, fixing multiple vulnerability alerts about `node-forge`. This comes from a `devDependency` (`webpack-dev-server`), so Firefly is not vulnerable in production. 

### Changelog
```
- Updated selfsigned to 2.0.1
- Updated node-forge to 1.3.1
```

## Relevant Issues
- Dependabot alerts related to `node-forge`
- Snyk alerts related to `node-forge`

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
### Platforms
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
N/A

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code