### PR TITLE
fix: place receive at the top instead of middle

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
@@ -4,7 +4,7 @@
     import { localize } from '@core/i18n'
 </script>
 
-<div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 p-6">
+<div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 p-8">
     <Text classes="text-left" type="h5">{localize('general.myAssets')}</Text>
     <div class="flex flex-auto flex-col overflow-y-auto h-1 -mr-2 pr-2 scroll-secondary scrollable-y">
         {#each $assets as asset}

--- a/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
@@ -33,7 +33,7 @@
 
 <div
     style="--account-color: {color};"
-    class="relative account-color p-6 {$mobile ? 'pb-0 bg-transparent' : 'pb-12'} {classes}"
+    class="relative account-color p-8 {$mobile ? 'pb-0 bg-transparent' : 'pb-12'} {classes}"
 >
     <!-- Balance -->
     <div data-label="total-balance" class="flex flex-col flex-wrap space-y-1.5">
@@ -72,7 +72,7 @@
     {/if}
     <button
         on:click={() => onMenuClick()}
-        class="px-2 py-3 flex flex-row space-x-1 bg-opacity-10 bg-black rounded-lg text-{textColor} absolute top-4 right-4"
+        class="px-2 py-3 m-4 flex flex-row space-x-1 bg-opacity-10 bg-black rounded-lg text-{textColor} absolute top-4 right-4"
     >
         {#each Array(3) as _}
             <svg width="4" height="4" viewBox="0 0 4 4">

--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -35,7 +35,7 @@
         </button>
     </div>
     {#if $isLedgerProfile && !$hasGeneratedALedgerReceiveAddress}
-        <div class="flex w-full h-full justify-center items-end pb-2">
+        <div class="flex w-full h-full justify-center items-end">
             <Button disabled={isGeneratingAddress || $isSyncing} classes="w-full" onClick={() => generateNewAddress()}>
                 {#if isGeneratingAddress}
                     <Spinner

--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -19,9 +19,9 @@
     }
 </script>
 
-<div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 p-6">
+<div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 p-8">
     <div class="w-full flex flex-row justify-between items-center">
-        <div class="w-full flex flex-row space-x-4 items-center justify-center">
+        <div class="w-full flex flex-row space-x-4 items-center">
             <Text classes="text-left" type="h5">{localize('general.receiveFunds')}</Text>
             <button on:click={generateNewAddress} class:pointer-events-none={isGeneratingAddress}>
                 <Icon

--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -13,6 +13,7 @@
     const generateNewAddress = (): void => {
         onGenerateAddress($selectedAccount.id)
     }
+
     const handleCloseClick = (): void => {
         $accountRouter.previous()
     }
@@ -20,7 +21,7 @@
 
 <div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 p-6">
     <div class="w-full flex flex-row justify-between items-center">
-        <div class="w-full flex flex-row space-x-4 items-center">
+        <div class="w-full flex flex-row space-x-4 items-center justify-center">
             <Text classes="text-left" type="h5">{localize('general.receiveFunds')}</Text>
             <button on:click={generateNewAddress} class:pointer-events-none={isGeneratingAddress}>
                 <Icon
@@ -34,7 +35,7 @@
         </button>
     </div>
     {#if $isLedgerProfile && !$hasGeneratedALedgerReceiveAddress}
-        <div class="flex w-full justify-center items-center">
+        <div class="flex w-full h-full justify-center items-end pb-2">
             <Button disabled={isGeneratingAddress || $isSyncing} classes="w-full" onClick={() => generateNewAddress()}>
                 {#if isGeneratingAddress}
                     <Spinner

--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -34,7 +34,7 @@
         </button>
     </div>
     {#if $isLedgerProfile && !$hasGeneratedALedgerReceiveAddress}
-        <div class="flex w-full h-full items-center justify-center">
+        <div class="flex w-full justify-center items-center">
             <Button disabled={isGeneratingAddress || $isSyncing} classes="w-full" onClick={() => generateNewAddress()}>
                 {#if isGeneratingAddress}
                     <Spinner


### PR DESCRIPTION
## Summary

Upon receiving the generate address button is centered in the middle of the screen. This is moved to the top

### Changelog
```
move generate address to the top
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/2690

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
