### PR TITLE
fix: disallow account switching

### DIFF
--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -2,7 +2,7 @@
     import { localize } from '@core/i18n'
     import { showAppNotification } from '@lib/notifications'
     import { participationAction } from '@lib/participation/stores'
-    import { WalletAccount } from 'lib/typings/wallet'
+    import { WalletAccount } from 'shared/lib/typings/wallet'
     import { AccountSwitcherModal, Icon, Text } from 'shared/components'
     import { activeProfile, getColor } from 'shared/lib/profile'
     import { isSyncing, isTransferring, selectedAccount } from 'shared/lib/wallet'
@@ -15,11 +15,11 @@
     function onClick(): void {
         let message: string
         if ($isSyncing) {
-            message = localize('popups.notification.syncing')
+            message = localize('notifications.syncing')
         } else if ($isTransferring) {
-            message = localize('popups.notification.transferring')
+            message = localize('notifications.transferring')
         } else if ($participationAction) {
-            message = localize('popups.notification.participating')
+            message = localize('notifications.participating')
         } else {
             toggleModal()
             return

--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -1,20 +1,42 @@
 <script lang="typescript">
-    import type { WalletAccount } from 'lib/typings/wallet'
+    import { localize } from '@core/i18n'
+    import { showAppNotification } from '@lib/notifications'
+    import { participationAction } from '@lib/participation/stores'
+    import { WalletAccount } from 'lib/typings/wallet'
     import { AccountSwitcherModal, Icon, Text } from 'shared/components'
     import { activeProfile, getColor } from 'shared/lib/profile'
-    import { selectedAccount } from 'shared/lib/wallet'
+    import { isSyncing, isTransferring, selectedAccount } from 'shared/lib/wallet'
 
     export let accounts: WalletAccount[] = []
     export let onCreateAccount = (..._: any[]): void => {}
 
     let showModal = false
 
+    function onClick(): void {
+        let message: string
+        if ($isSyncing) {
+            message = localize('popups.notification.syncing')
+        } else if ($isTransferring) {
+            message = localize('popups.notification.transferring')
+        } else if ($participationAction) {
+            message = localize('popups.notification.participating')
+        } else {
+            toggleModal()
+            return
+        }
+        showAppNotification({
+            type: 'warning',
+            message,
+        })
+        showModal = false
+    }
+
     function toggleModal(): void {
         showModal = !showModal
     }
 </script>
 
-<button on:click={toggleModal} class="flex flex-row justify-center items-center space-x-2">
+<button on:click={onClick} class="flex flex-row justify-center items-center space-x-2">
     <div class="circle" style="--account-color: {getColor($activeProfile, $selectedAccount?.id)};" />
     <Text type="h4">{$selectedAccount?.alias}</Text>
     <div class="transform transition-all {showModal ? 'rotate-180' : 'rotate-0'}">

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1100,7 +1100,10 @@
                     "success": "Payment details added from IOTA link"
                 }
             }
-        }
+        },
+        "syncing": "Wait until synchronization is finished to change account!",
+        "transferring": "Wait until all transactions are completed to change account!",
+        "participating": "Wait until all staking/voting transactions are completed to change account!"
     },
     "error": {
         "profile": {

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1101,9 +1101,9 @@
                 }
             }
         },
-        "syncing": "Wait until synchronization is finished to change account!",
-        "transferring": "Wait until all transactions are completed to change account!",
-        "participating": "Wait until all staking/voting transactions are completed to change account!"
+        "syncing": "Please wait until synchronization is finished to change accounts.",
+        "transferring": "Please wait until all transactions are completed to change accounts.",
+        "participating": "Please wait until all staking/voting transactions are completed to change accounts."
     },
     "error": {
         "profile": {


### PR DESCRIPTION
## Summary

Switching account while voting/staking/transferring/syncing leads to UI inconsistencies.
This is tackled in this PR. The account switcher modal doesn't open and a popup tells 
the user that they need to wait until the corresponding action is finished.

### Changelog
```
Account Switching modal only when no UI inconsistencies could be present
If modal doesn't open, notifications are shown
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/2688

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
