### PR TITLE
fix: reactivity issue when cancelling particpation

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -19,8 +19,7 @@
     let subHeader: string
 
     $: $participationOverview, $stakingEventState, setHeaders()
-    $: $stakingEventState, $selectedAccountParticipationOverview, $selectedAccountId, updateAnimation()
-    $: localePath = `views.staking.info.${$stakingEventState}`
+    $: $stakingEventState, $selectedAccountParticipationOverview, $selectedAccountId, setAnimation()
 
     enum FileNumber {
         NoStaking = 0,
@@ -29,7 +28,7 @@
         AssemblyAndShimmer = 3,
     }
 
-    function updateAnimation(): void {
+    function setAnimation(): void {
         const prefix = 'staking-info'
         if (!$stakingEventState || !$selectedAccountParticipationOverview) {
             animation = `${prefix}-upcoming`
@@ -63,23 +62,24 @@
     }
 
     function setHeaders(): void {
+        const localePath = `views.staking.info.${$stakingEventState}`
         if ($stakingEventState === ParticipationEventState.Holding) {
             const isStaking = $stakedAccounts.length > 0
-            const localiseHoldingHeader = $stakedAccounts.length > 0 ? 'Holding' : 'NotHolding'
-            const localiseHoldingSubHeader = $stakedAccounts.length > 0 ? 'Holding' : 'NotHolding'
+            const localiseHoldingHeader = isStaking ? 'Holding' : 'NotHolding'
+            const localiseHoldingSubHeader = isStaking ? 'Holding' : 'NotHolding'
+            const timeDuration = isStaking
+                ? { values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) } }
+                : {}
 
-            header = localize(
-                `${localePath}Header${localiseHoldingHeader}`,
-                isStaking ? { values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) } } : {}
-            )
+            header = localize(`${localePath}Header${localiseHoldingHeader}`, timeDuration)
             subHeader = localize(`${localePath}Subheader${localiseHoldingSubHeader}`)
         } else {
             header = localize(`${localePath}Header`)
-            subHeader = localize(`views.staking.info.${$stakingEventState}Subheader`)
+            subHeader = localize(`${localePath}Subheader`)
         }
     }
 
-    function handleLearnMoreClick(): void {
+    function onClickLearnMore(): void {
         Platform.openUrl('https://blog.iota.org/iota-staking-start/')
     }
 </script>
@@ -96,7 +96,7 @@
     <div class="w-full mt-4 flex flex-col items-center text-center">
         <Text type="p" bigger classes="mb-1">{subHeader}</Text>
         <Text type="h2" classes="mb-2">{header}</Text>
-        <Link onClick={handleLearnMoreClick} classes="text-14">{localize('actions.learnAboutStaking')}</Link>
+        <Link onClick={onClickLearnMore} classes="text-14">{localize('actions.learnAboutStaking')}</Link>
     </div>
 </div>
 

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -21,7 +21,7 @@
     $: $selectedAccountParticipationOverview, $stakingEventState, setHeaders()
     $: isAssemblyStaked, isShimmerStaked, $stakingEventState, $selectedAccountId, setAnimation()
 
-    enum FileNumber {
+    enum AnimationFileNumber {
         NoStaking = 0,
         Assembly = 1,
         Shimmer = 2,
@@ -37,13 +37,13 @@
         if ($stakingEventState === ParticipationEventState.Inactive) {
             animation = null
         } else if ($stakingEventState === ParticipationEventState.Holding) {
-            let fileNumber = FileNumber.NoStaking
+            let fileNumber = AnimationFileNumber.NoStaking
             if (isAssemblyStaked && isShimmerStaked) {
-                fileNumber = FileNumber.AssemblyAndShimmer
+                fileNumber = AnimationFileNumber.AssemblyAndShimmer
             } else if (isAssemblyStaked) {
-                fileNumber = FileNumber.Assembly
+                fileNumber = AnimationFileNumber.Assembly
             } else if (isShimmerStaked) {
-                fileNumber = FileNumber.Shimmer
+                fileNumber = AnimationFileNumber.Shimmer
             }
 
             animation = `${prefix}-${$stakingEventState}-${fileNumber}`

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -22,6 +22,13 @@
     $: $stakingEventState, $selectedAccountParticipationOverview, $selectedAccountId, updateAnimation()
     $: localePath = `views.staking.info.${$stakingEventState}`
 
+    enum FileNumber {
+        NoStaking = 0,
+        Assembly = 1,
+        Shimmer = 2,
+        AssemblyAndShimmer = 3,
+    }
+
     function updateAnimation(): void {
         const prefix = 'staking-info'
         if (!$stakingEventState || !$selectedAccountParticipationOverview) {
@@ -38,14 +45,14 @@
                 }
             })
 
-            let fileNumber = 0
+            let fileNumber = FileNumber.NoStaking
             if (stakingParticipationIds.length >= 2) {
-                fileNumber = 3
+                fileNumber = FileNumber.AssemblyAndShimmer
             } else if (stakingParticipationIds.length === 1) {
                 if (stakingParticipationIds[0] === ASSEMBLY_EVENT_ID) {
-                    fileNumber = 1
+                    fileNumber = FileNumber.Assembly
                 } else {
-                    fileNumber = 2
+                    fileNumber = FileNumber.Shimmer
                 }
             }
 

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -7,7 +7,6 @@
         assemblyStakingRemainingTime,
         participationOverview,
         selectedAccountParticipationOverview,
-        shimmerStakingRemainingTime,
         stakedAccounts,
         stakingEventState,
     } from 'shared/lib/participation/stores'
@@ -16,8 +15,14 @@
     import { selectedAccountId } from '@lib/wallet'
 
     let animation: string
+    let header: string
+    let subHeader: string
 
-    const updateAnimation = (): void => {
+    $: $participationOverview, $stakingEventState, setHeaders()
+    $: $stakingEventState, $selectedAccountParticipationOverview, $selectedAccountId, updateAnimation()
+    $: localePath = `views.staking.info.${$stakingEventState}`
+
+    function updateAnimation(): void {
         const prefix = 'staking-info'
         if (!$stakingEventState || !$selectedAccountParticipationOverview) {
             animation = `${prefix}-upcoming`
@@ -50,35 +55,24 @@
         }
     }
 
-    $: $stakingEventState, $selectedAccountParticipationOverview, $selectedAccountId, updateAnimation()
-
-    $: localePath = `views.staking.info.${$stakingEventState}`
-    $: $assemblyStakingRemainingTime, $shimmerStakingRemainingTime
-
-    const getHeaders = (): [string, string] => {
+    function setHeaders(): void {
         if ($stakingEventState === ParticipationEventState.Holding) {
             const isStaking = $stakedAccounts.length > 0
             const localiseHoldingHeader = $stakedAccounts.length > 0 ? 'Holding' : 'NotHolding'
             const localiseHoldingSubHeader = $stakedAccounts.length > 0 ? 'Holding' : 'NotHolding'
 
-            return [
-                localize(
-                    `${localePath}Header${localiseHoldingHeader}`,
-                    isStaking ? { values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) } } : {}
-                ),
-                localize(`${localePath}Subheader${localiseHoldingSubHeader}`),
-            ]
+            header = localize(
+                `${localePath}Header${localiseHoldingHeader}`,
+                isStaking ? { values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) } } : {}
+            )
+            subHeader = localize(`${localePath}Subheader${localiseHoldingSubHeader}`)
         } else {
-            return [localize(`${localePath}Header`), localize(`views.staking.info.${$stakingEventState}Subheader`)]
+            header = localize(`${localePath}Header`)
+            subHeader = localize(`views.staking.info.${$stakingEventState}Subheader`)
         }
     }
 
-    let header, subHeader
-    $: $participationOverview, ([header, subHeader] = getHeaders())
-
-    stakingEventState.subscribe(() => ([header, subHeader] = getHeaders()))
-
-    const handleLearnMoreClick = (): void => {
+    function handleLearnMoreClick(): void {
         Platform.openUrl('https://blog.iota.org/iota-staking-start/')
     }
 </script>


### PR DESCRIPTION
## Summary

Cancelling a participation transaction in ledger created a UI error on the staking animation. This reveals the underlying problem that `participations` are updated as soon as the staking manager is opened after a transaction is sent to the ledger for signing. The current fix is to rely on the staked funds and not on participations (which is not guaranteed to be correct in case of ledger). The proper fix is that `participations` are only handled after the transaction is signed and broadcasted. This requires an event to be emitted from ledger upon sending the transaction or a change in wallet.rs.

### Changelog
```
- animation is based upon stakedFunds instead of participations
- refactored StakingInfo.svelte
```

## Relevant Issues
closes: https://github.com/iotaledger/firefly/issues/2689

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
