### PR TITLE
chore: use alpha in development

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,7 +12,7 @@
         "start:dev": "cross-env NODE_ENV=development PLATFORM=desktop webpack serve --content-base public",
         "start:electron": "cross-env NODE_ENV=development PLATFORM=desktop electron public/build/main.js",
         "start:electron-prod": "cross-env NODE_ENV=production PLATFORM=desktop electron public/build/main.js",
-        "build": "yarn build:prod",
+        "build": "yarn build:alpha",
         "build:dev": "cross-env NODE_ENV=development PLATFORM=desktop webpack",
         "build:alpha": "cross-env NODE_ENV=production PLATFORM=desktop STAGE=alpha webpack",
         "build:beta": "cross-env NODE_ENV=production PLATFORM=desktop STAGE=beta webpack",


### PR DESCRIPTION
## Summary

Currently when running `yarn build` it defaults to the production instance, but as the alpha build is the closest to development we should ideally use that environment, i.e. `build:alpha`.

### Changelog
```
- Change general build script (in desktop) to use alpha environment instead of production
```

## Relevant Issues
None

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Ran `yarn build && yarn start` in desktop directory, resulting in an alpha developer instance.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation