### PR TITLE
fix: rename account issues for 1.4.0

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { Popup, Route, TitleBar, ToastContainer } from 'shared/components'
-    import { stage, loggedIn, hasRenamedProfileFoldersToId } from 'shared/lib/app'
-    import { appSettings, initAppSettings } from 'shared/lib/appSettings'
+    import { stage, loggedIn } from 'shared/lib/app'
+    import { appSettings, hasRenamedProfileFoldersToId, initAppSettings } from 'shared/lib/appSettings'
     import { getVersionDetails, pollVersion, versionDetails } from 'shared/lib/appUpdater'
     import { addError } from 'shared/lib/errors'
     import { goto } from 'shared/lib/helpers'

--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Popup, Route, TitleBar, ToastContainer } from 'shared/components'
-    import { stage, loggedIn } from 'shared/lib/app'
+    import { stage, loggedIn, hasRenamedProfileFoldersToId } from 'shared/lib/app'
     import { appSettings, initAppSettings } from 'shared/lib/appSettings'
     import { getVersionDetails, pollVersion, versionDetails } from 'shared/lib/appUpdater'
     import { addError } from 'shared/lib/errors'
@@ -10,7 +10,7 @@
     import { showAppNotification } from 'shared/lib/notifications'
     import { Electron } from 'shared/lib/electron'
     import { openPopup, popupState } from 'shared/lib/popup'
-    import { cleanupEmptyProfiles, cleanupInProgressProfiles } from 'shared/lib/profile'
+    import { cleanupEmptyProfiles, cleanupInProgressProfiles, renameAllProfileFoldersToId } from 'shared/lib/profile'
     import {
         dashboardRoute,
         initRouter,
@@ -80,6 +80,12 @@
             splash = false
             initRouter()
         }, 3000)
+
+        // This is added to migrate all profile folder names from using the profile name to the id
+        if (get(hasRenamedProfileFoldersToId)) {
+            await renameAllProfileFoldersToId()
+            hasRenamedProfileFoldersToId.set(true)
+        }
 
         initAppSettings.set($appSettings)
 

--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -82,7 +82,7 @@
         }, 3000)
 
         // This is added to migrate all profile folder names from using the profile name to the id
-        if (get(hasRenamedProfileFoldersToId)) {
+        if (!get(hasRenamedProfileFoldersToId)) {
             await renameAllProfileFoldersToId()
             hasRenamedProfileFoldersToId.set(true)
         }

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -76,7 +76,7 @@
              * CAUTION: This removes the actual directory for the profile,
              * so it should occur last.
              */
-            await removeProfileFolder(_activeProfile.name)
+            await removeProfileFolder(_activeProfile.id)
         } catch (err) {
             if (err && err?.type && err?.type == 'AccountNotEmpty') {
                 showAppNotification({

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -44,6 +44,11 @@ export const mnemonic = writable<string[]>(null)
 export const lastActiveAt = writable<Date>(new Date())
 
 /**
+ * Has the profile folders been renamed from using profile name to the profile id?
+ */
+export const hasRenamedProfileFoldersToId = writable<boolean>(false)
+
+/**
  * Input parameters for sending transactions
  */
 export const sendParams = writable<SendParams>({

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -44,11 +44,6 @@ export const mnemonic = writable<string[]>(null)
 export const lastActiveAt = writable<Date>(new Date())
 
 /**
- * Have the profile folders been renamed from using profile names to the profile ids?
- */
-export const hasRenamedProfileFoldersToId = writable<boolean>(false)
-
-/**
  * Input parameters for sending transactions
  */
 export const sendParams = writable<SendParams>({

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -44,7 +44,7 @@ export const mnemonic = writable<string[]>(null)
 export const lastActiveAt = writable<Date>(new Date())
 
 /**
- * Has the profile folders been renamed from using profile name to the profile id?
+ * Have the profile folders been renamed from using profile names to the profile ids?
  */
 export const hasRenamedProfileFoldersToId = writable<boolean>(false)
 

--- a/packages/shared/lib/appSettings.ts
+++ b/packages/shared/lib/appSettings.ts
@@ -70,3 +70,8 @@ export const lastAcceptedPrivacyPolicy = persistent<number>('lastAcceptedPrivacy
  * Note: The initial value must be set to 1 to support existing users and alert them
  */
 export const lastAcceptedTos = persistent<number>('lastAcceptedTos', 1)
+
+/**
+ * Have the profile folders been renamed from using profile names to the profile ids?
+ */
+export const hasRenamedProfileFoldersToId = persistent<boolean>('hasRenamedProfileFoldersToId', false)

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -146,7 +146,7 @@ export const disposeNewProfile = async (): Promise<void> => {
     if (profile) {
         try {
             await asyncDeleteStorage()
-            await removeProfileFolder(profile.name)
+            await removeProfileFolder(profile.id)
         } catch (err) {
             console.error(err)
         }
@@ -266,9 +266,9 @@ export const cleanupInProgressProfiles = (): void => {
  *
  * @returns {void}
  */
-export const removeProfileFolder = async (profileName: string): Promise<void> => {
+export const removeProfileFolder = async (id: string): Promise<void> => {
     try {
-        const profileDataPath = await getProfileDataPath(profileName)
+        const profileDataPath = await getProfileDataPath(id)
         await Platform.removeProfileFolder(profileDataPath)
     } catch (err) {
         console.error(err)
@@ -287,9 +287,9 @@ export const cleanupEmptyProfiles = async (): Promise<void> => {
         const profileDataPath = await getWalletDataPath()
         const storedProfiles = await Platform.listProfileFolders(profileDataPath)
 
-        profiles.update((_profiles) => _profiles.filter((p) => storedProfiles.includes(p.name)))
+        profiles.update((_profiles) => _profiles.filter((p) => storedProfiles.includes(p.id)))
 
-        const appProfiles = get(profiles).map((p) => p.name)
+        const appProfiles = get(profiles).map((p) => p.id)
         for (const storedProfile of storedProfiles) {
             if (!appProfiles.includes(storedProfile)) {
                 await removeProfileFolder(storedProfile)
@@ -449,4 +449,19 @@ export const validateProfileName = (trimmedName: string): void => {
     if (get(profiles).some((p) => p.name === trimmedName)) {
         throw new Error(locale('error.profile.duplicate'))
     }
+}
+
+async function renameProfileFolder(oldName: string, newName: string): Promise<void> {
+    const oldPath = await getProfileDataPath(oldName)
+    const newPath = await getProfileDataPath(newName)
+    await Platform.renameProfileFolder(oldPath, newPath)
+}
+
+export async function renameAllProfileFoldersToId(): Promise<void> {
+    const _profiles = get(profiles)
+    await Promise.all(
+        _profiles.map(async (profile) => {
+            await renameProfileFolder(profile.name, profile.id)
+        })
+    )
 }

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -188,9 +188,9 @@ export const getWalletDataPath = async (): Promise<string> => {
     return `${appPath}/${WALLET_STORAGE_DIRECTORY}/`
 }
 
-export const getProfileDataPath = async (profileName: string): Promise<string> => {
+export const getProfileDataPath = async (id: string): Promise<string> => {
     const walletPath = await getWalletDataPath()
-    return `${walletPath}${profileName}`
+    return `${walletPath}${id}`
 }
 
 /**

--- a/packages/shared/routes/dashboard/settings/views/general/ChangeProfileName.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/ChangeProfileName.svelte
@@ -2,8 +2,6 @@
     import { Button, Input, Text } from 'shared/components'
     import { localize } from 'shared/lib/i18n'
     import { activeProfile, updateProfile, validateProfileName } from 'shared/lib/profile'
-    import { getProfileDataPath } from 'shared/lib/wallet'
-    import { Platform } from 'shared/lib/platform'
     import { showAppNotification } from 'shared/lib/notifications'
 
     let newName = $activeProfile.name
@@ -13,10 +11,9 @@
     $: newName, (error = '')
     $: disabled = invalidName(trimmedProfileName)
 
-    async function onSubmitClick(): Promise<void> {
+    function onSubmitClick(): Promise<void> {
         try {
             validateProfileName(trimmedProfileName)
-            await renameProfileFolder(trimmedProfileName)
             updateProfile('name', trimmedProfileName)
             showAppNotification({
                 type: 'info',
@@ -25,12 +22,6 @@
         } catch (err) {
             return (error = err.message)
         }
-    }
-
-    async function renameProfileFolder(newName: string): Promise<void> {
-        const oldPath = await getProfileDataPath($activeProfile.name)
-        const newPath = await getProfileDataPath(newName)
-        await Platform.renameProfileFolder(oldPath, newPath)
     }
 
     function invalidName(name: string): boolean {

--- a/packages/shared/routes/dashboard/settings/views/general/ChangeProfileName.svelte
+++ b/packages/shared/routes/dashboard/settings/views/general/ChangeProfileName.svelte
@@ -11,7 +11,7 @@
     $: newName, (error = '')
     $: disabled = invalidName(trimmedProfileName)
 
-    function onSubmitClick(): Promise<void> {
+    function onSubmitClick(): void {
         try {
             validateProfileName(trimmedProfileName)
             updateProfile('name', trimmedProfileName)

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -81,7 +81,7 @@
                 .then((verified) => {
                     if (verified === true) {
                         return Platform.getMachineId().then((machineId) =>
-                            getProfileDataPath(profile.name).then((path) => {
+                            getProfileDataPath(profile.id).then((path) => {
                                 initialise(profile.id, path, sendCrashReports, machineId)
                                 api.setStoragePassword(pinCode, {
                                     onSuccess() {

--- a/packages/shared/routes/setup/Congratulations.svelte
+++ b/packages/shared/routes/setup/Congratulations.svelte
@@ -89,16 +89,13 @@
                 }
             }
             const _exportMigrationLog = () => {
-                getProfileDataPath($activeProfile.name)
+                getProfileDataPath($activeProfile.id)
                     .then((source) =>
                         $walletSetupType === SetupType.TrinityLedger
-                            ? Platform.exportLedgerMigrationLog(
-                                  $migrationLog,
-                                  `${$activeProfile.name}-${LOG_FILE_NAME}`
-                              )
+                            ? Platform.exportLedgerMigrationLog($migrationLog, `${$activeProfile.id}-${LOG_FILE_NAME}`)
                             : Platform.exportMigrationLog(
                                   `${source}/${LOG_FILE_NAME}`,
-                                  `${$activeProfile.name}-${LOG_FILE_NAME}`
+                                  `${$activeProfile.id}-${LOG_FILE_NAME}`
                               )
                     )
                     .then((result) => {

--- a/packages/shared/routes/setup/Profile.svelte
+++ b/packages/shared/routes/setup/Profile.svelte
@@ -67,7 +67,7 @@
             if (nameChanged || hasDeveloperProfileChanged) {
                 storeProfile(name, isDeveloperProfile)
 
-                const path = await getProfileDataPath($newProfile.name)
+                const path = await getProfileDataPath($newProfile.id)
                 const machineId = await Platform.getMachineId()
                 const { sendCrashReports } = $initAppSettings ?? { sendCrashReports: false }
                 initialise($newProfile.id, path, sendCrashReports, machineId)


### PR DESCRIPTION
## Summary
To fix a number of issues with renaming account (namely on windows the folder could not be renamed because of a lock, and on both platforms we could not lock stronghold if the folder had moved), we have decided to change the folder names to the profile id, rather than the profile name.

### Changelog
```
- Added functions to rename all profile folder names from profile name to profile id
- Conditionally call this on app load if it has not been called before
- Change logic everywhere that finds profile folder based on name to now use id
- Remove the rename folder function from the ChangeProfileName component
```
## Relevant Issues
- Fixes #2643
- Fixes #2644
- Fixes #2645

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

- I tested this by running a new version on top of an old one where I had many profiles, I could then see in the profile folder all the profiles where know hashes instead of names.
- I then tested creating an account, renaming while stronghold was unlocked and not, and logging out and back in. 
- I also tested deleting an account.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
