### PR TITLE
chore: upload PDB files when building Windows

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,6 +112,21 @@ jobs:
       env:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN_PROD_BACKEND }}
         SENTRY_ENVIRONMENT: ${{ env.STAGE }}
+    
+    - name: Install Sentry CLI
+      # Yarn has issues putting binaries in the PATH on Windows
+      run: npm i -g @sentry/cli
+      if: ${{ startsWith(github.ref, 'refs/tags/desktop') }}
+
+    - name: Upload backend PDB (Windows)
+      run: |
+        sentry-cli difutil check node_neon.pdb
+        sentry-cli upload-dif -o "iota-foundation-h4" -p "firefly-backend" --include-sources node_neon.pdb 
+        sentry-cli upload-dif -o "iota-foundation-h4" -p "firefly-desktop" --include-sources node_neon.pdb
+      working-directory: packages/backend/bindings/node/native/target/x86_64-pc-windows-msvc/release
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      if: ${{ startsWith(github.ref, 'refs/tags/desktop') }}
 
     - name: Set productName
       run: node scripts/fix-productName.js


### PR DESCRIPTION
## Summary
Upload debug files for backend bindings on Windows when building a release on CI

### Changelog
```
Upload debug files for backend bindings on Windows when building a release
```

## Relevant Issues
Closes #2650 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [x] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Tested on CI

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas