### PR TITLE
fix: retain original error structure when sending error to Sentry

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -85,15 +85,12 @@ const handleError = (errorType, error, isRenderProcessError) => {
          * the main process.
          */
         if (SEND_CRASH_REPORTS) {
-            captureException(
-                new Error(
-                    JSON.stringify({
-                        type: errorType,
-                        message: error.message || error.reason || error,
-                        stack: error.stack || undefined,
-                    })
-                )
-            )
+            const errorMessage = error.message || error.reason || error
+            const sentryError = new Error(`${errorType} - ${errorMessage}`)
+            if (error.stack) {
+                sentryError.stack = error.stack
+            }
+            captureException(sentryError)
         }
 
         openErrorWindow()


### PR DESCRIPTION
## Summary
When JS errors are caught and handled by the `handleError` function, we create a new `Error` with a message containing the original error information (including the stacktrace) as JSON. As a result, the real stacktrace is truncated by Sentry because an error message is usually shorter:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/19519564/161458770-3889d6bb-c325-40bb-bf37-4a82f2c454c9.png">
(2nd and 3rd lines are the real stacktrace, while the rest of the lines are the stacktrace seen by Sentry)

Since Sentry doesn't treat it like a real stacktrace, it won't be unminified, which makes it much easier to determine the location of the error in our codebase. It also uses `handleError` as the function causing the error, causing Sentry to group all errors passed to `handleError` together since the stacktrace has precedence in error grouping.

### Changelog
```
- Retain original error structure and stacktrace when sending error to Sentry
```

## Relevant Issues
N/A

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows

### Instructions
Tested by creating an error and viewing it in Sentry

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code