### PR TITLE
enhancement: make staking confirmation dynamic to number of airdrops

### DIFF
--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -162,11 +162,15 @@
     <div class="flex flex-row mt-6 space-x-2 flex-1">
         {#each Object.values(activeAirdrops) as airdrop}
             <div
-                on:click={!canReachAirdropMinimum(airdrop) ? () => {} : () => toggleAirdropSelection(airdrop)}
+                on:click={!canReachAirdropMinimum(airdrop) || activeAirdrops.length <= 1
+                    ? () => {}
+                    : () => toggleAirdropSelection(airdrop)}
                 class="airdrop-container p-4 w-1/2 flex flex-1 flex-col items-center text-center border border-solid rounded-2xl {!canReachAirdropMinimum(
                     airdrop
                 )
                     ? 'cursor-default'
+                    : activeAirdrops.length <= 1
+                    ? 'cursor-default border-blue-500'
                     : 'cursor-pointer hover:bg-blue-50 hover:border-blue-500 focus:border-blue-500 focus:bg-blue-50 dark:hover:bg-gray-800'} {!airdropSelections[
                     airdrop
                 ] || !canReachAirdropMinimum(airdrop)

--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -10,12 +10,7 @@
         getStakingEventFromAirdrop,
         getUnstakedFunds,
     } from 'shared/lib/participation'
-    import {
-        ASSEMBLY_EVENT_ID,
-        SHIMMER_EVENT_ID,
-        STAKING_AIRDROP_TOKENS,
-        STAKING_EVENT_IDS,
-    } from 'shared/lib/participation/constants'
+    import { STAKING_AIRDROP_TOKENS, STAKING_EVENT_IDS } from 'shared/lib/participation/constants'
     import {
         participationAction,
         isPartiallyStaked,
@@ -44,13 +39,9 @@
 
     const airdropSelections: { [key in StakingAirdrop]: boolean } = {
         [StakingAirdrop.Assembly]:
-            activeAirdrops.includes(StakingAirdrop.Assembly) && canReachAirdropMinimum(StakingAirdrop.Assembly)
-                ? true
-                : false,
+            activeAirdrops.includes(StakingAirdrop.Assembly) && canReachAirdropMinimum(StakingAirdrop.Assembly),
         [StakingAirdrop.Shimmer]:
-            activeAirdrops.includes(StakingAirdrop.Shimmer) && canReachAirdropMinimum(StakingAirdrop.Shimmer)
-                ? true
-                : false,
+            activeAirdrops.includes(StakingAirdrop.Shimmer) && canReachAirdropMinimum(StakingAirdrop.Shimmer),
     }
 
     const tooltipAnchors: { [airdrop: string]: unknown } = {}

--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -187,7 +187,7 @@
                     >
                         <Icon icon="exclamation" width="26" height="26" classes="text-orange-500" />
                     </div>
-                {:else}
+                {:else if activeAirdrops.length > 1}
                     <Checkbox
                         round
                         bind:checked={airdropSelections[airdrop]}

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -749,7 +749,7 @@
             "singleAccountHint": "Looking for your wallets? Firefly has changed. Toggle between your wallets in the top menu bar."
         },
         "stakingConfirmation": {
-            "title": "Staking Confirmation",
+            "title": "Confirm Participation",
             "subtitleStake": "You are about to stake",
             "subtitleMerge": "You are about to merge",
             "multiAirdropWarning": "If you do not want to participate in both airdrops, you can opt-out below. You can unstake and restake to opt back in at any time.",

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -748,11 +748,11 @@
             "unstakedSuccessfully": "Your funds have been unstaked for {account}."
         },
         "stakingConfirmation": {
-            "title": "Airdrop Participation",
+            "title": "Staking Confirmation",
             "subtitleStake": "You are about to stake",
             "subtitleMerge": "You are about to merge",
-            "bodyStake": "If you do not want to participate in both airdrops, you can opt-out below. You can unstake and restake to opt back in at any time.",
-            "bodyMerge": "Your funds will be staked for {airdrop}. To change which airdrops you want to participate in, unstake this wallet and stake it again.",
+            "multiAirdropWarning": "If you do not want to participate in both airdrops, you can opt-out below. You can unstake and restake to opt back in at any time.",
+            "mergeStakeWarning": "Your funds will be staked for {airdrop}. To change which airdrops you want to participate in, unstake this wallet and stake it again.",
             "estimatedAirdrop": "Estimated rewards"
         },
         "newStakingPeriodNotification": {


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
This is to make the staking confirmation popup dynamic to the number of airdrops.


### Changelog
```
This will only show body text if there is more than one airdrop active or if the user is merging funds.
This also only shows the airdrop checkbox if that airdrop exists.
And it only auto selects the airdrop if it exists and the user will reach minimum rewards.
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

1. Tested by changing each one of the airdrop event id constants to the empty string.
2. Tested with both airdrops having a valid event id.
3. Tested merging for 1 airdrop.
4. Tested merging for 2 airdrops.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
