### PR TITLE
feat: adjust staking manager UI for single account

### DIFF
--- a/packages/shared/components/TextHint.svelte
+++ b/packages/shared/components/TextHint.svelte
@@ -3,14 +3,16 @@
 
     export let classes: string = ''
     export let icon: 'info' | 'exclamation' | 'none' = 'none'
+    export let iconClasses: string = ''
     export let hint: string = ''
+    export let hintClasses: string = ''
 </script>
 
 {#if hint}
     <div class="flex flex-row items-center {classes}">
         {#if icon !== 'none'}
-            <Icon {icon} classes="mr-3 fill-current text-black dark:text-white" />
+            <Icon {icon} classes="mr-3 fill-current {iconClasses ? iconClasses : 'text-black dark:text-white'}" />
         {/if}
-        <Text type="p" classes="text-black dark:text-white">{hint}</Text>
+        <Text type="p" overrideColor classes={hintClasses ? hintClasses : 'text-black dark:text-white'}>{hint}</Text>
     </div>
 {/if}

--- a/packages/shared/components/popups/NewStakingPeriodNotification.svelte
+++ b/packages/shared/components/popups/NewStakingPeriodNotification.svelte
@@ -5,7 +5,7 @@
     import { AccountParticipationAbility, ParticipationEventState } from '@lib/participation/types'
     import { closePopup, openPopup } from '@lib/popup'
     import { selectedAccount } from '@lib/wallet'
-    import { Button, Icon, Illustration, Text } from 'shared/components'
+    import { Button, Icon, Illustration, Text, TextHint } from 'shared/components'
 
     function handleOk(): void {
         const canStake =
@@ -24,15 +24,16 @@
     }
 </script>
 
-<Illustration illustration="staking-notification" classes="mb-6 mt-3" />
+<Illustration illustration="staking-notification" classes="mb-6 mt-9" />
 <Text type="h3" classes="mb-4">{localize('popups.newStakingPeriodNotification.title')}</Text>
 <Text type="p" secondary classes="mb-6">{localize('popups.newStakingPeriodNotification.body')}</Text>
-<div class="flex items-center justify-between bg-blue-50 dark:bg-gray-800 p-3 rounded-2xl mb-6">
-    <div class="flex flex-row items-center space-x-3">
-        <Icon icon="info" boxed classes="text-blue-500" />
-        <Text type="p" secondary>{localize('popups.newStakingPeriodNotification.info')}</Text>
-    </div>
-</div>
+<TextHint
+    classes="p-4 mb-6 rounded-2xl bg-blue-50 dark:bg-gray-800"
+    icon="info"
+    iconClasses="fill-current text-blue-500"
+    hint={localize('popups.newStakingPeriodNotification.info')}
+    hintClasses="text-gray-500 dark:text-gray-500"
+/>
 <div class="flex flex-row space-x-2">
     <Button classes="w-full" onClick={handleOk}>
         {localize('actions.okIUnderstand')}

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { onMount } from 'svelte'
-    import { Button, Icon, Link, Spinner, Text, TextHint, Tooltip } from 'shared/components'
+    import { Button, Icon, Spinner, Text, TextHint, Tooltip } from 'shared/components'
     import { convertToFiat, currencies, exchangeRates, formatCurrency } from 'shared/lib/currency'
     import { promptUserToConnectLedger } from 'shared/lib/ledger'
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { onMount } from 'svelte'
-    import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
+    import { Button, Icon, Link, Spinner, Text, TextHint, Tooltip } from 'shared/components'
     import { convertToFiat, currencies, exchangeRates, formatCurrency } from 'shared/lib/currency'
     import { promptUserToConnectLedger } from 'shared/lib/ledger'
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'
@@ -246,7 +246,7 @@
 
 <Text type="h5">{localize('popups.stakingManager.title')}</Text>
 <Text type="p" secondary classes="mt-6 mb-4">{localize('popups.stakingManager.description')}</Text>
-<div class="staking flex flex-col scrollable-y">
+<div class="staking flex flex-col scrollable-y mb-4">
     {#if participationAbility !== AccountParticipationAbility.HasDustAmount}
         <div
             class={`w-full mt-4 flex flex-col rounded-xl border-2 border-solid
@@ -371,13 +371,13 @@
     {/if}
 </div>
 
-<div class="mt-2 text-center">
-    <Text type="p" secondary classes="inline">
-        {localize('popups.stakingManager.totalFundsStaked')}:
-
-        <Text type="p" secondary bold classes="inline">{formatUnitBestMatch($stakedAmount)}</Text>
-    </Text>
-</div>
+<TextHint
+    classes="p-4 rounded-2xl bg-blue-50 dark:bg-gray-800"
+    icon="info"
+    iconClasses="fill-current text-blue-500 dark:text-blue-500"
+    hint={localize('popups.stakingManager.singleAccountHint')}
+    hintClasses="text-gray-500 dark:text-gray-500"
+/>
 
 {#if showTooltip}
     <Tooltip anchor={tooltipAnchor} position="right">

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -745,7 +745,8 @@
             "description": "When you stake a wallet, you send a transaction to yourself marking those funds as \"staked\". You can transfer the tokens at any time, but you won’t continue receiving staking rewards.",
             "totalFundsStaked": "Total funds staked",
             "stakedSuccessfully": "Your funds have been staked for {account}.",
-            "unstakedSuccessfully": "Your funds have been unstaked for {account}."
+            "unstakedSuccessfully": "Your funds have been unstaked for {account}.",
+            "singleAccountHint": "Looking for your wallets? Firefly has changed. Toggle between your wallets in the top menu bar."
         },
         "stakingConfirmation": {
             "title": "Airdrop Participation",


### PR DESCRIPTION
## Summary
Have to change staking manager UI per new designs.

### Changelog
```
- Add extra CSS to TextHint component
- Used TextHint in StakingManager and NewStakingPeriodNotification popups
- Added hint locale for English
```

## Relevant Issues
- Closes #2757 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [x] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Manually opened both `StakingManager` and `NewStakingPeriodNotification` popups from the staking dashboard.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation