### PR TITLE
fix: select unhidden account when hiding one

### DIFF
--- a/packages/shared/components/modals/AccountActions.svelte
+++ b/packages/shared/components/modals/AccountActions.svelte
@@ -51,6 +51,9 @@
                         updateProfile('hiddenAccounts', hiddenAccounts)
                     }
                     resetWalletRoute()
+                    const nextSelectedAccount =
+                        $viewableAccounts[$selectedAccount?.index] ?? $viewableAccounts[$viewableAccounts.length - 1]
+                    setSelectedAccount(nextSelectedAccount?.id)
                 },
             },
         })


### PR DESCRIPTION
## Summary
When hiding an account, we should navigate to one of the non-hidden accounts

## Relevant Issues
closes #2744 

## Type of Change
Please select any type below that applies to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
