### PR TITLE
feat: prevent profile modal from closing while unlocking stronghold

### DIFF
--- a/packages/shared/components/modals/Modal.svelte
+++ b/packages/shared/components/modals/Modal.svelte
@@ -12,6 +12,8 @@
     export let position: { top?: string; right?: string; bottom?: string; left?: string } = {}
     export let size: Size = Size.Medium
     export let classes: string = ''
+    export let disableOnClickOutside = false
+
     export function close(): void {
         setShow(false)
     }
@@ -37,6 +39,11 @@
         }
     }
 
+    function handleOnClickOutside(): void {
+        if (disableOnClickOutside) return
+        close()
+    }
+
     let isBlockedByTimeout = false
     let show = false
 </script>
@@ -45,7 +52,7 @@
     <modal-content
         in:fade={{ duration: 100 }}
         use:clickOutside
-        on:clickOutside={close}
+        on:clickOutside={handleOnClickOutside}
         class="{size} bg-white dark:bg-gray-900 border border-solid border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden z-10 {classes}"
         style="--modal-position-top: {top}; --modal-position-right: {right}; --modal-position-bottom: {bottom}; --modal-position-left: {left};"
     >

--- a/packages/shared/components/modals/ProfileActions.svelte
+++ b/packages/shared/components/modals/ProfileActions.svelte
@@ -3,6 +3,7 @@
     import { Chip, Icon, Modal, Text, HR, Toggle, Button } from 'shared/components'
     import { logout } from 'shared/lib/app'
     import { localize } from '@core/i18n'
+    import { LocaleArguments } from '@core/i18n/types'
     import { getLedgerDeviceStatus, getLedgerOpenedApp, ledgerDeviceState } from 'shared/lib/ledger'
     import { showAppNotification } from 'shared/lib/notifications'
     import { popupState, openPopup } from 'shared/lib/popup'
@@ -81,7 +82,7 @@
     }
 
     const updateLedgerConnectionText = (): void => {
-        const values: LocaleArgs =
+        const values: LocaleArguments =
             $ledgerDeviceState === LedgerDeviceState.LegacyConnected ? { legacy: LedgerAppName.IOTALegacy } : {}
         const text = localize(`views.dashboard.profileModal.hardware.statuses.${$ledgerDeviceState}`, { values })
 

--- a/packages/shared/components/modals/ProfileActions.svelte
+++ b/packages/shared/components/modals/ProfileActions.svelte
@@ -5,7 +5,7 @@
     import { localize } from '@core/i18n'
     import { getLedgerDeviceStatus, getLedgerOpenedApp, ledgerDeviceState } from 'shared/lib/ledger'
     import { showAppNotification } from 'shared/lib/notifications'
-    import { openPopup } from 'shared/lib/popup'
+    import { popupState, openPopup } from 'shared/lib/popup'
     import {
         activeProfile,
         hasEverOpenedProfileModal,
@@ -35,6 +35,9 @@
     $: lastBackupDateFormatted = diffDates(lastBackupDate, new Date())
     $: isBackupSafe = lastBackupDate && isRecentDate(lastBackupDate)?.lessThanAMonth
     $: backupWarningColor = getBackupWarningColor(lastBackupDate)
+    // used to prevent the modal from closing when interacting with the password popup
+    // to be able to see the stronghold toggle change
+    $: isPasswordPopupOpen = $popupState?.active && $popupState?.type === 'password'
 
     $: if ($isLedgerProfile && $ledgerDeviceState) {
         updateLedgerConnectionText()
@@ -120,6 +123,7 @@
     position={{ bottom: '16px', left: '80px' }}
     classes="w-80"
     on:open={() => hasEverOpenedProfileModal.set(true)}
+    disableOnClickOutside={isPasswordPopupOpen}
 >
     <profile-modal-content class="flex flex-col" in:fade={{ duration: 100 }}>
         <div class="flex flex-row flex-nowrap items-center space-x-3 p-3">


### PR DESCRIPTION
## Summary
- add `disableOnClickOutside` prop to `Modal.svelte`
- disable click outside on profile modal while unlocking stronghold
- fix `i18n` type import

### Changelog
```
feat: prevent profile modal from closing while unlocking stronghold
```

## Relevant Issues
Closes #2781

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
