### PR TITLE
enhancement: re cache all staking rewards on balance finder

### DIFF
--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -6,6 +6,8 @@
     import { showAppNotification } from 'shared/lib/notifications'
     import { displayNotificationForLedgerProfile, isLedgerConnected } from 'shared/lib/ledger'
     import { Locale } from '@core/i18n'
+    import { cacheAllStakingPeriods, StakingAirdrop } from '@lib/participation'
+    import { onDestroy } from 'svelte'
 
     export let locale: Locale
 
@@ -18,6 +20,7 @@
     let password = ''
     let error = ''
     let isBusy = false
+    let hasUsedBalanceFinder = false
 
     async function handleFindBalances() {
         try {
@@ -38,6 +41,7 @@
 
             currentGapLimit += gapLimitIncrement
             accountDiscoveryThreshold++
+            hasUsedBalanceFinder = true
         } catch (err) {
             error = locale(err.error)
 
@@ -57,6 +61,13 @@
     function handleCancelClick() {
         closePopup()
     }
+
+    onDestroy(() => {
+        if (hasUsedBalanceFinder) {
+            cacheAllStakingPeriods(StakingAirdrop.Assembly)
+            cacheAllStakingPeriods(StakingAirdrop.Shimmer)
+        }
+    })
 </script>
 
 <Text type="h4" classes="mb-6">{locale('popups.balanceFinder.title')}</Text>


### PR DESCRIPTION
## Summary
This change simply makes a call to cache all the previous staking rewards if the balance finder has been run at least once.
This is so we can check if additional addresses or accounts found have staking rewards. And also a fail safe incase the original caching didn't work.

### Changelog
```
- Add call to cacheallrewards for shimmer and assembly when the balance finder popup is destroyed (only if the finder has been run)
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
