### PR TITLE
fix: pass a no-op onClick handler to Profile from EnterPin

### DIFF
--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -146,7 +146,7 @@
     </button>
     <div class="pt-40 pb-16 flex w-full h-full flex-col items-center justify-between">
         <div class="w-96 flex flex-col flex-wrap items-center mb-20">
-            <Profile name={$activeProfile?.name} bgColor="blue" />
+            <Profile name={$activeProfile?.name} bgColor="blue" onClick={() => {}} />
             <Pin
                 bind:this={pinRef}
                 bind:value={pinCode}


### PR DESCRIPTION
## Summary
If a user clicks on the `Profile` component on the `EnterPin` screen, the app will report an error. In dev, this is reported as a warning when it renders:

![image](https://user-images.githubusercontent.com/19519564/162338325-f024cc6a-ae34-48fd-9abb-b8dd36154e72.png)

### Changelog
```
- Pass a no-op onClick handler to Profile from EnterPin
```

## Relevant Issues
Fixes #2788 

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
- __Desktop__
	- [x] MacOS

### Instructions
Click on the profile icon on the `EnterPin` screen

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code