### PR TITLE
fix: check if an onClick handler is defined before calling it

### DIFF
--- a/packages/shared/components/Profile.svelte
+++ b/packages/shared/components/Profile.svelte
@@ -13,7 +13,11 @@
     export let isLedgerProfile = false
     export let bgColor: string
 
-    export let onClick: (id: string) => void | string
+    export let onClick: undefined | ((id: string) => void) = undefined
+
+    function handleOnClick() {
+        onClick && onClick(id)
+    }
 
     const slots = $$props.$$slots
 
@@ -31,7 +35,7 @@
 <div class="flex items-center justify-center w-24">
     <div class="flex flex-col justify-between items-center">
         <div
-            on:click={() => onClick(id)}
+            on:click={() => handleOnClick()}
             class="h-20 w-20 {bgColor
                 ? `bg-${bgColor}-500`
                 : ''} rounded-full font-bold text-center flex items-center justify-center {classes}"


### PR DESCRIPTION
## Summary
If a user clicks on the `Profile` component on the `EnterPin` screen, the app will report an error. In dev, this is reported as a warning when it renders:

![image](https://user-images.githubusercontent.com/19519564/162338325-f024cc6a-ae34-48fd-9abb-b8dd36154e72.png)

### Changelog
```
- Check if an onClick handler is defined before calling it
```

## Relevant Issues
Fixes #2788 

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
   - [x] Desktop
	- [x] MacOS


### Instructions
Click on the profile icon on the `EnterPin` screen

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code