### PR TITLE
fix: single account guide popup display reactivity

### DIFF
--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -400,8 +400,8 @@
         setSelectedAccount($activeProfile.lastUsedAccountId ?? $viewableAccounts?.[0]?.id ?? null)
     }
 
-    $: !$activeProfile.hasFinishedSingleAccountGuide &&
-        openPopup({ type: 'singleAccountGuide', hideClose: true, overflow: true })
+    $: showSingleAccountguide = !$activeProfile?.hasFinishedSingleAccountGuide
+    $: showSingleAccountguide && openPopup({ type: 'singleAccountGuide', hideClose: true, overflow: true })
 </script>
 
 <Idle />


### PR DESCRIPTION
## Summary

This single account guide popup was showing each time the profile changed if the user did not explicitly clicked on the button to acknowledge the changes. This PR aims to fix the reactivity around this problem

### Changelog
```
fix: single account guide display reactivity
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

- Login to your profile and do not accept the single account guide popup, just close it but clicking anywhere
- do anything that would update the profile: create/add account, modify something in the settings...
- the popup should not be shown again until the next time you login 
- if you accept the guide, the popup should not be displayed at all, never again

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
