### PR TITLE
feat: reset account router on account switch

### DIFF
--- a/packages/shared/components/modals/AccountSwitcher.svelte
+++ b/packages/shared/components/modals/AccountSwitcher.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { HR, Icon, Modal, Text } from 'shared/components'
     import { localize } from '@core/i18n'
+    import { resetAccountRouter } from '@core/router'
     import { openPopup } from 'shared/lib/popup'
     import { activeProfile, getColor } from 'shared/lib/profile'
     import type { WalletAccount } from 'shared/lib/typings/wallet'
@@ -12,7 +13,7 @@
 
     const handleAccountClick = (accountId: string): void => {
         setSelectedAccount(accountId)
-        selectedMessage.set(null)
+        resetAccountRouter()
         modal?.close()
     }
 

--- a/packages/shared/lib/core/router/helper.ts
+++ b/packages/shared/lib/core/router/helper.ts
@@ -27,11 +27,14 @@ export const resetRouters = (): void => {
     isDeepLinkRequestActive.set(false)
 }
 
-export const resetWalletRoute = (): void => {
-    get(dashboardRouter).reset()
+export const resetAccountRouter = (): void => {
     get(accountRouter).reset()
-
     selectedMessage.set(null)
+}
+
+export const resetWalletRoute = (): void => {
+    resetAccountRouter()
+    get(dashboardRouter).reset()
 }
 
 export const openSettings = (): void => {


### PR DESCRIPTION
## Summary
This PR aims to fix the following feedback provided after testing 1.5.0 alpha

> Popup elements from Wallet tab (send,receive, customise) stay opened when switching between wallets while Tx history resets its tab. Not sure if intended 


### Changelog
```
feat: reset account router on account switch
```

## Relevant Issues

Closes #2797

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
