### PR TITLE
fix: wrong locale in zen guy tile when `stakingEventState` is `undefined`

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -31,7 +31,7 @@
         $selectedAccountId,
         setAnimation()
 
-    let stakingEventState
+    let stakingEventState: ParticipationEventState
     $: stakingEventState = $assemblyStakingEventState
 
     enum AnimationFileNumber {
@@ -66,7 +66,7 @@
     }
 
     function setHeaders(): void {
-        const localePath = `views.staking.info.${stakingEventState}`
+        const localePath = `views.staking.info.${stakingEventState ?? ParticipationEventState.Inactive}`
         if (stakingEventState === ParticipationEventState.Holding) {
             const isStaking = $stakedAccounts.length > 0
             const localiseHoldingHeader = isStaking ? 'Holding' : 'NotHolding'


### PR DESCRIPTION
## Summary
This PR aims to prevent this:
![image](https://user-images.githubusercontent.com/3624944/162474821-3fa8e939-c3a6-408a-8793-757432c23725.png)


### Changelog
```
fix: wrong locale in zen guy tile when `stakingEventState` is `undefined`
```

## Relevant Issues

Close #2800

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
