### PR TITLE
feat: polish airdrop tile rewards alignment when ASMB staking is possible

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingAirdrop.svelte
@@ -116,75 +116,103 @@
     >
         <source src="assets/videos/airdrop-{airdrop}.mp4" type="video/mp4" />
     </video>
-    <div class="w-full h-full px-8 pb-10 flex flex-col justify-end space-y-5 z-0">
-        <div class="flex flex-col">
-            <div class="flex flex-row items-center mb-3">
-                <Text type="h3" classes="mr-4 text-white text-xl">
-                    {localize(`views.staking.airdrops.${airdrop}.name`)}
-                </Text>
-                <StakingAirdropIndicator {airdrop} />
-            </div>
-            <Text
-                type="p"
-                overrideColor
-                overrideLeading
-                smaller
-                classes="font-normal text-gray-300 dark:text-gray-300 mb-3"
-            >
-                {localize(`views.staking.airdrops.${airdrop}.description`)}
-            </Text>
-            <Link onClick={handleLearnMoreClick} classes="text-14">{localize('actions.visitWebsite')}</Link>
-        </div>
-        {#if isStakingPossible(stakingEventState)}
-            <div class="flex flex-row justify-between space-x-4">
-                <div class="flex flex-col">
-                    <div>
-                        <Text type="p" classes="font-bold text-lg inline text-white dark:text-gray-400 break-all">
-                            {currentStakingRewards.split(' ')[0]}
-                        </Text>
-                        <Text type="p" secondary classes="text-sm inline">
-                            {currentStakingRewards.split(' ')[1]}
-                        </Text>
-                    </div>
-                    <Text type="p" smaller overrideColor classes="font-normal mt-0.5 text-gray-400 dark:text-gray-400">
-                        {localize('views.staking.airdrops.currentStakingPeriod')}
+    <div class="w-full h-full px-8 pb-10 flex flex-col justify-end z-0">
+        <!-- We check if assembly staking is possible to have both airdrops aligned -->
+        <div
+            class="{isStakingPossible($assemblyStakingEventState)
+                ? 'apply-min-height'
+                : ''} flex flex-col flex-wrap justify-between space-y-5"
+        >
+            <div class="flex flex-col">
+                <div class="flex flex-row items-center mb-3">
+                    <Text type="h3" classes="mr-4 text-white text-xl">
+                        {localize(`views.staking.airdrops.${airdrop}.name`)}
                     </Text>
+                    <StakingAirdropIndicator {airdrop} />
                 </div>
+                <Text
+                    type="p"
+                    overrideColor
+                    overrideLeading
+                    smaller
+                    classes="font-normal text-gray-300 dark:text-gray-300 mb-3"
+                >
+                    {localize(`views.staking.airdrops.${airdrop}.description`)}
+                </Text>
+                <Link onClick={handleLearnMoreClick} classes="text-14">{localize('actions.visitWebsite')}</Link>
+            </div>
+            <div class="flex flex-col flex-wrap space-y-5">
                 {#if isStakingPossible(stakingEventState)}
-                    <div class="flex flex-col text-right">
-                        <div>
-                            <Text type="p" classes="font-bold text-lg inline text-white dark:text-white">
-                                {remainingTimeAmount}
+                    <div class="flex flex-row justify-between space-x-4">
+                        <div class="flex flex-col">
+                            <div>
+                                <Text
+                                    type="p"
+                                    classes="font-bold text-lg inline text-white dark:text-gray-400 break-all"
+                                >
+                                    {currentStakingRewards.split(' ')[0]}
+                                </Text>
+                                <Text type="p" secondary classes="text-sm inline">
+                                    {currentStakingRewards.split(' ')[1]}
+                                </Text>
+                            </div>
+                            <Text
+                                type="p"
+                                smaller
+                                overrideColor
+                                classes="font-normal mt-0.5 text-gray-400 dark:text-gray-400"
+                            >
+                                {localize('views.staking.airdrops.currentStakingPeriod')}
                             </Text>
-                            <Text type="p" secondary classes="text-sm inline">{remainingTimeUnit}</Text>
+                        </div>
+                        {#if isStakingPossible(stakingEventState)}
+                            <div class="flex flex-col text-right">
+                                <div>
+                                    <Text type="p" classes="font-bold text-lg inline text-white dark:text-white">
+                                        {remainingTimeAmount}
+                                    </Text>
+                                    <Text type="p" secondary classes="text-sm inline">{remainingTimeUnit}</Text>
+                                </div>
+                                <Text
+                                    type="p"
+                                    smaller
+                                    overrideColor
+                                    classes="font-normal text-sm mt-0.5 text-gray-400 dark:text-gray-400"
+                                >
+                                    {getLocalizedDurationText(stakingEventState)}
+                                </Text>
+                            </div>
+                        {/if}
+                    </div>
+                {/if}
+                <HR />
+                <div class="flex flex-row justify-between space-x-4">
+                    <div class="flex flex-col">
+                        <div>
+                            <Text type="p" classes="font-bold text-lg inline text-white dark:text-gray-400 break-all">
+                                {totalStakingRewards.split(' ')[0]}
+                            </Text>
+                            <Text type="p" secondary classes="text-sm inline">
+                                {totalStakingRewards.split(' ')[1]}
+                            </Text>
                         </div>
                         <Text
                             type="p"
                             smaller
                             overrideColor
-                            classes="font-normal text-sm mt-0.5 text-gray-400 dark:text-gray-400"
+                            classes="font-normal mt-0.5 text-gray-400 dark:text-gray-400"
                         >
-                            {getLocalizedDurationText(stakingEventState)}
+                            {localize('views.staking.airdrops.totalWalletRewards')}
                         </Text>
                     </div>
-                {/if}
-            </div>
-        {/if}
-        <HR />
-        <div class="flex flex-row justify-between space-x-4">
-            <div class="flex flex-col">
-                <div>
-                    <Text type="p" classes="font-bold text-lg inline text-white dark:text-gray-400 break-all">
-                        {totalStakingRewards.split(' ')[0]}
-                    </Text>
-                    <Text type="p" secondary classes="text-sm inline">
-                        {totalStakingRewards.split(' ')[1]}
-                    </Text>
                 </div>
-                <Text type="p" smaller overrideColor classes="font-normal mt-0.5 text-gray-400 dark:text-gray-400">
-                    {localize('views.staking.airdrops.totalWalletRewards')}
-                </Text>
             </div>
         </div>
     </div>
 </div>
+
+<style type="text/scss">
+    .apply-min-height {
+        min-height: 310px;
+    }
+</style>


### PR DESCRIPTION
## Summary

This PR applies a min-height to the staking airdrop tile when assembly staking is possible to align both tiles

### Changelog
```
feat: polish airdrop tile rewards alignment when ASMB staking is possible
```

## Relevant Issues
Closes #2804

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
