### PR TITLE
fix: missing duration arguments during staking

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -10,7 +10,6 @@
         currentShimmerStakingRewards,
         currentShimmerStakingRewardsBelowMinimum,
         selectedAccountParticipationOverview,
-        shimmerStakingEventState,
         stakedAccounts,
     } from 'shared/lib/participation/stores'
     import { ParticipationEventState } from 'shared/lib/participation/types'
@@ -75,7 +74,7 @@
             header = localize(`${baseLocalePath}.headers.${stakingEventState}`)
             body = localize(`${baseLocalePath}.bodies.${stakingEventState}`, { values: { token: Token.IOTA } })
         } else if (stakingEventState === ParticipationEventState.Holding) {
-            const isStaking = $stakedAccounts.length > 0
+            const isStaking = isAssemblyStaked || isShimmerStaked
             const durationArguments: LocaleArguments = isStaking
                 ? { values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) } }
                 : {}


### PR DESCRIPTION
## Summary
There is a bug displaying `{duration}` in the rendered locale because of a bad conditional check.

### Changelog
```
- Improve conditional checking whether user is currently staking or not
```

## Relevant Issues
Fixes #2815 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions


## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation