### PR TITLE
fix: moves prevent account switch logic to account buttons

### DIFF
--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -1,41 +1,18 @@
 <script lang="typescript">
-    import { localize } from '@core/i18n'
-    import { showAppNotification } from '@lib/notifications'
-    import { participationAction } from '@lib/participation/stores'
     import { WalletAccount } from '@lib/typings/wallet'
     import { AccountSwitcherModal, Icon, Text, Modal } from 'shared/components'
-    import { activeProfile, getColor, updateProfile } from '@lib/profile'
-    import { isSyncing, isTransferring, selectedAccount } from '@lib/wallet'
+    import { activeProfile, getColor } from '@lib/profile'
+    import { selectedAccount } from '@lib/wallet'
 
     export let accounts: WalletAccount[] = []
     export let onCreateAccount = (..._: any[]): void => {}
 
     let modal: Modal
     let isModalOpened: boolean
-
-    function onClick(): void {
-        let message: string
-        if ($isSyncing) {
-            message = localize('notifications.syncing')
-        } else if ($isTransferring) {
-            message = localize('notifications.transferring')
-        } else if ($participationAction) {
-            message = localize('notifications.participating')
-        } else {
-            modal?.toggle()
-            return
-        }
-        showAppNotification({
-            type: 'warning',
-            message,
-        })
-        modal?.close()
-        updateProfile('hasFinishedSingleAccountGuide', true)
-    }
 </script>
 
 <svelte:window on:click={() => (isModalOpened = modal?.isOpened())} />
-<button on:click={onClick} class="flex flex-row justify-center items-center space-x-2">
+<button on:click={modal?.toggle} class="flex flex-row justify-center items-center space-x-2">
     <div class="circle" style="--account-color: {getColor($activeProfile, $selectedAccount?.id)};" />
     <Text type="h5">{$selectedAccount?.alias}</Text>
     <div class="transform transition-all {isModalOpened ? 'rotate-180' : 'rotate-0'}">

--- a/packages/shared/components/modals/AccountSwitcher.svelte
+++ b/packages/shared/components/modals/AccountSwitcher.svelte
@@ -2,22 +2,39 @@
     import { HR, Icon, Modal, Text } from 'shared/components'
     import { localize } from '@core/i18n'
     import { resetAccountRouter } from '@core/router'
-    import { openPopup } from 'shared/lib/popup'
-    import { activeProfile, getColor } from 'shared/lib/profile'
-    import type { WalletAccount } from 'shared/lib/typings/wallet'
-    import { selectedAccount, selectedMessage, setSelectedAccount } from 'shared/lib/wallet'
+    import { openPopup } from '@lib/popup'
+    import { activeProfile, getColor } from '@lib/profile'
+    import { WalletAccount } from '@lib/typings/wallet'
+    import { showAppNotification } from '@lib/notifications'
+    import { selectedAccount, setSelectedAccount, isSyncing, isTransferring } from '@lib/wallet'
+    import { participationAction } from '@lib/participation/stores'
 
     export let accounts: WalletAccount[] = []
     export let onCreateAccount = (..._: any[]): void => {}
     export let modal: Modal
 
-    const handleAccountClick = (accountId: string): void => {
-        setSelectedAccount(accountId)
-        resetAccountRouter()
-        modal?.close()
+    function handleAccountClick(accountId: string): void {
+        if ($isSyncing) {
+            showWarning(localize('notifications.syncing'))
+        } else if ($isTransferring) {
+            showWarning(localize('notifications.transferring'))
+        } else if ($participationAction) {
+            showWarning(localize('notifications.participating'))
+        } else {
+            setSelectedAccount(accountId)
+            resetAccountRouter()
+            modal?.close()
+        }
     }
 
-    const handleCreateAccountClick = (): void => {
+    function showWarning(message: string) {
+        showAppNotification({
+            type: 'warning',
+            message,
+        })
+    }
+
+    function handleCreateAccountClick(): void {
         modal?.close()
         openPopup({ type: 'createAccount', props: { onCreate: onCreateAccount } })
     }


### PR DESCRIPTION
## Summary
Moves the prevent switching logic to inside the account switcher so you can at least open it for the guide

## Relevant Issues
closes #2810

## Type of Change
Please select any type below that applies to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
