### PR TITLE
fix: changes modal interaction timeout

### DIFF
--- a/packages/shared/components/modals/Modal.svelte
+++ b/packages/shared/components/modals/Modal.svelte
@@ -34,7 +34,7 @@
         if (!isBlockedByTimeout) {
             show = bool
             isBlockedByTimeout = true
-            setTimeout(() => (isBlockedByTimeout = false), 500)
+            setTimeout(() => (isBlockedByTimeout = false), 100)
             show ? dispatch('open') : dispatch('close')
         }
     }


### PR DESCRIPTION
## Summary
Switching between wallets something closes the dropdown automatically, and other times it will just stay open, and you need to click the same wallet twice to close the dropdown.
We added before a timeout for modal closing and opening which prevents the race condition between click outside and toggle button (that is outside of modal).
But seems that the amount of time was too high and causes problems when interactions are fast enough, so the timeout milliseconds have changed from 500 to 200 in this PR.

## Relevant Issues
closes #2809

## Type of Change
Please select any type below that applies to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
