### PR TITLE
fix: adds reset and focus function to repeat pin on mount

### DIFF
--- a/packages/shared/routes/setup/protect/views/RepeatPin.svelte
+++ b/packages/shared/routes/setup/protect/views/RepeatPin.svelte
@@ -3,7 +3,7 @@
     import { mobile } from 'shared/lib/app'
     import { Locale } from '@core/i18n'
     import { validatePinFormat } from 'shared/lib/utils'
-    import { createEventDispatcher } from 'svelte'
+    import { createEventDispatcher, onMount } from 'svelte'
 
     export let locale: Locale
 
@@ -12,8 +12,13 @@
 
     let pinInput = ''
     let error = ''
+    let pinRef: Pin
 
     const dispatch = createEventDispatcher()
+
+    onMount(() => {
+        pinRef.resetAndFocus()
+    })
 
     $: pinInput, (error = '')
 
@@ -41,6 +46,7 @@
         <Text type="p" secondary classes="mb-8">{locale('views.confirmPin.body2')}</Text>
         <Pin
             bind:value={pinInput}
+            bind:this={pinRef}
             glimpse
             classes="w-full mx-auto block"
             on:submit={onSubmit}


### PR DESCRIPTION
## Summary
Autofocus is missing on confirm pincode page so I've added the reset and focus function to it on mount

## Relevant Issues
closes #2806

## Type of Change
Please select any type below that applies to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
