### PR TITLE
fix: only inset window controls on mac

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -243,7 +243,7 @@ function createWindow() {
         height: mainWindowState.height,
         minWidth: 1280,
         minHeight: 720,
-        titleBarStyle: 'hiddenInset',
+        titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
         title: app.name,
         frame: process.platform === 'linux',
         icon:
@@ -579,7 +579,7 @@ export const openAboutWindow = () => {
         width: 380,
         height: 230,
         useContentSize: true,
-        titleBarStyle: 'hiddenInset',
+        titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
         show: false,
         fullscreenable: false,
         resizable: false,
@@ -626,7 +626,7 @@ export const openErrorWindow = () => {
 
     windows.error = new BrowserWindow({
         useContentSize: true,
-        titleBarStyle: 'hiddenInset',
+        titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
         show: false,
         fullscreenable: false,
         resizable: true,


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
Because the controls where on mac where previously too close to the top, specifically within the new top navigation. We changed the title bar style, from `hidden` to `hiddenInset`. This change changes that back for all OS accept mac. 

### Changelog
```
Made title bar style for electron widows conditional on os
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
