### PR TITLE
enhancement: add warning emphasis for asset tile 

### DIFF
--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -159,7 +159,7 @@
 <button
     on:click={onClick}
     data-label="transaction-row"
-    class="w-full text-left flex rounded-2xl items-center bg-gray-100 dark:bg-gray-900 dark:bg-opacity-50 p-4 {!confirmed ||
+    class="w-full text-left flex rounded-2xl items-center bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-700 dark:bg-opacity-50 p-4 {!confirmed ||
     hasCachedMigrationTx
         ? 'opacity-50'
         : ''} {hasCachedMigrationTx ? 'pointer-events-none' : ''} overflow-hidden"

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -159,7 +159,7 @@
 <button
     on:click={onClick}
     data-label="transaction-row"
-    class="w-full text-left flex rounded-2xl items-center bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-700 dark:bg-opacity-50 p-4 {!confirmed ||
+    class="w-full text-left flex rounded-2xl items-center bg-gray-50 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-700 dark:bg-opacity-50 p-4 {!confirmed ||
     hasCachedMigrationTx
         ? 'opacity-50'
         : ''} {hasCachedMigrationTx ? 'pointer-events-none' : ''} overflow-hidden"

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -159,19 +159,19 @@
                 <Text secondary smaller>{`≈ ${asset?.fiatBalance}`}</Text>
             {/if}
         </div>
-        {#if showWarningState && tooltipText?.body}
+        {#if showWarningState && tooltipText?.body.length > 0}
             <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
                 <Icon
                     icon="exclamation"
                     width="16"
                     height="16"
-                    classes="mt-0.5 fill-current text-yellow-600 group-hover:text-{assetIconColor}"
+                    classes="fill-current text-yellow-600 group-hover:text-{assetIconColor}"
                 />
             </div>
         {/if}
     </div>
 </button>
-{#if showTooltip && tooltipText?.body}
+{#if showTooltip && tooltipText?.body.length > 0}
     <Tooltip anchor={tooltipAnchor} position="right">
         <Text type="p" classes="text-gray-900 bold mb-2 text-left">{tooltipText?.title}</Text>
         {#each tooltipText?.body as paragraph}
@@ -190,6 +190,25 @@
         background-color: var(--asset-color);
     }
     button {
+        &.airdrop {
+            @apply opacity-50;
+            @apply border;
+            @apply border-solid;
+            @apply border-gray-200;
+            &:not(:hover) {
+                @apply bg-transparent;
+            }
+            &:hover {
+                @apply bg-gray-200;
+            }
+            &.darkmode {
+                @apply bg-gray-900;
+                @apply border-transparent;
+                &:hover {
+                    @apply bg-gray-700;
+                }
+            }
+        }
         &.partial-stake {
             @apply border;
             @apply border-solid;
@@ -222,25 +241,6 @@
         }
         &:not(.disabled-hover):hover {
             background-color: var(--account-color);
-        }
-        &.airdrop {
-            @apply opacity-50;
-            @apply border;
-            @apply border-solid;
-            @apply border-gray-200;
-            &:not(:hover) {
-                @apply bg-transparent;
-            }
-            &:hover {
-                @apply bg-gray-200;
-            }
-            &.darkmode {
-                @apply bg-gray-900;
-                @apply border-transparent;
-                &:hover {
-                    @apply bg-gray-700;
-                }
-            }
         }
     }
 </style>

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -139,7 +139,6 @@
     style="--asset-color: {asset?.color}"
     class="w-full flex flex-row justify-between items-center space-x-2 bg-gray-50 dark:bg-gray-900 p-4 rounded-2xl airdrop"
     class:staked={isActivelyStaking}
-    class:partial-stake={showWarningState}
     class:darkmode={isDarkModeEnabled}
     on:click={handleTileClick}
 >
@@ -207,19 +206,6 @@
                 }
             }
         }
-        //&.partial-stake {
-        //    &:hover {
-        //        @apply border-transparent;
-        //    }
-        //    &.darkmode {
-        //        @apply border;
-        //        @apply border-solid;
-        //        @apply border-yellow-600;
-        //        &:hover {
-        //            @apply border-transparent;
-        //        }
-        //    }
-        //}
         &.staked:not(.partial-stake) {
             @apply border;
             @apply border-solid;

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -48,6 +48,8 @@
     let tooltipText: TooltipText
     let remainingTime: number
 
+    const FIAT_PLACEHOLDER = '---'
+
     $: assetIconColor = isBright(asset?.color) ? 'gray-800' : 'white'
     $: isDarkModeEnabled = $appSettings.darkMode
     $: isActivelyStaking = getAccount($stakedAccounts) && isStakingPossible(stakingEventState)
@@ -145,30 +147,26 @@
         <div class="icon h-8 w-8 rounded-full flex items-center justify-center p-1">
             <Icon classes="text-{assetIconColor}" icon={asset?.name?.toLocaleLowerCase()} height="100%" width="100%" />
         </div>
-        <div class="flex flex-col flex-wrap space-y-1">
+        <div class="flex flex-col flex-wrap space-y-1 text-left">
             <Text classes="font-semibold">{asset?.name}</Text>
-            {#if asset?.fiatPrice}
-                <Text secondary smaller>{asset?.fiatPrice}</Text>
-            {/if}
+            <Text secondary smaller>{asset?.fiatPrice ? asset?.fiatPrice : FIAT_PLACEHOLDER}</Text>
         </div>
     </div>
-    <div class="flex flex-row space-x-2 items-center">
-        <div class="flex flex-col flex-wrap space-y-1 text-right">
-            <Text classes="font-semibold">{asset?.balance}</Text>
-            {#if asset?.fiatBalance}
-                <Text secondary smaller>{`≈ ${asset?.fiatBalance}`}</Text>
+    <div class="flex flex-col flex-wrap space-y-1 text-right">
+        <div class="flex flex-row">
+            {#if showWarningState && tooltipText?.body.length > 0}
+                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
+                    <Icon
+                        icon="exclamation"
+                        width="17"
+                        height="17"
+                        classes="mt-0.5 mr-2 fill-current text-yellow-600 group-hover:text-{assetIconColor}"
+                    />
+                </div>
             {/if}
+            <Text classes="font-semibold">{asset?.balance}</Text>
         </div>
-        {#if showWarningState && tooltipText?.body.length > 0}
-            <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
-                <Icon
-                    icon="exclamation"
-                    width="16"
-                    height="16"
-                    classes="fill-current text-yellow-600 group-hover:text-{assetIconColor}"
-                />
-            </div>
-        {/if}
+        <Text secondary smaller>{asset?.fiatBalance ? `≈ ${asset?.fiatBalance}` : FIAT_PLACEHOLDER}</Text>
     </div>
 </button>
 {#if showTooltip && tooltipText?.body.length > 0}
@@ -191,7 +189,7 @@
     }
     button {
         &.airdrop {
-            @apply opacity-50;
+            @apply opacity-100;
             @apply border;
             @apply border-solid;
             @apply border-gray-200;
@@ -209,22 +207,19 @@
                 }
             }
         }
-        &.partial-stake {
-            @apply border;
-            @apply border-solid;
-            @apply border-yellow-600;
-            &:hover {
-                @apply border-transparent;
-            }
-            &.darkmode {
-                @apply border;
-                @apply border-solid;
-                @apply border-yellow-600;
-                &:hover {
-                    @apply border-transparent;
-                }
-            }
-        }
+        //&.partial-stake {
+        //    &:hover {
+        //        @apply border-transparent;
+        //    }
+        //    &.darkmode {
+        //        @apply border;
+        //        @apply border-solid;
+        //        @apply border-yellow-600;
+        //        &:hover {
+        //            @apply border-transparent;
+        //        }
+        //    }
+        //}
         &.staked:not(.partial-stake) {
             @apply border;
             @apply border-solid;

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -135,7 +135,7 @@
 
 <button
     style="--asset-color: {asset?.color}"
-    class="w-full flex flex-row justify-between items-center space-x-2 bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-700 p-4 rounded-2xl airdrop"
+    class="w-full flex flex-row justify-between items-center space-x-2 bg-gray-50 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-700 p-4 rounded-2xl airdrop"
     class:darkmode={isDarkModeEnabled}
     on:click={handleTileClick}
 >

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -1,7 +1,6 @@
 <script lang="typescript">
     import { Icon, Text, Tooltip } from 'shared/components'
     import { appSettings } from 'shared/lib/appSettings'
-    import { isBright } from 'shared/lib/helpers'
     import { localize } from '@core/i18n'
     import { Asset, Token } from 'shared/lib/typings/assets'
     import {
@@ -50,7 +49,6 @@
 
     const FIAT_PLACEHOLDER = '---'
 
-    $: assetIconColor = isBright(asset?.color) ? 'gray-800' : 'white'
     $: isDarkModeEnabled = $appSettings.darkMode
     $: isActivelyStaking = getAccount($stakedAccounts) && isStakingPossible(stakingEventState)
     $: isPartiallyStakedAndCanStake = $isPartiallyStaked && isStakingPossible(stakingEventState)
@@ -137,14 +135,13 @@
 
 <button
     style="--asset-color: {asset?.color}"
-    class="w-full flex flex-row justify-between items-center space-x-2 bg-gray-50 dark:bg-gray-900 p-4 rounded-2xl airdrop"
-    class:staked={isActivelyStaking}
+    class="w-full flex flex-row justify-between items-center space-x-2 bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-700 p-4 rounded-2xl airdrop"
     class:darkmode={isDarkModeEnabled}
     on:click={handleTileClick}
 >
     <div class="flex flex-row items-center space-x-4">
         <div class="icon h-8 w-8 rounded-full flex items-center justify-center p-1">
-            <Icon classes="text-{assetIconColor}" icon={asset?.name?.toLocaleLowerCase()} height="100%" width="100%" />
+            <Icon classes="text-gray-900" icon={asset?.name?.toLocaleLowerCase()} height="100%" width="100%" />
         </div>
         <div class="flex flex-col flex-wrap space-y-1 text-left">
             <Text classes="font-semibold">{asset?.name}</Text>
@@ -159,7 +156,7 @@
                         icon="exclamation"
                         width="17"
                         height="17"
-                        classes="mt-0.5 mr-2 fill-current text-yellow-600 group-hover:text-{assetIconColor}"
+                        classes="mt-0.5 mr-2 fill-current text-yellow-600 group-hover:text-gray-900"
                     />
                 </div>
             {/if}
@@ -185,43 +182,5 @@
 <style type="text/scss">
     .icon {
         background-color: var(--asset-color);
-    }
-    button {
-        &.airdrop {
-            @apply opacity-100;
-            @apply border;
-            @apply border-solid;
-            @apply border-gray-200;
-            &:not(:hover) {
-                @apply bg-transparent;
-            }
-            &:hover {
-                @apply bg-gray-200;
-            }
-            &.darkmode {
-                @apply bg-gray-900;
-                @apply border-transparent;
-                &:hover {
-                    @apply bg-gray-700;
-                }
-            }
-        }
-        &.staked:not(.partial-stake) {
-            @apply border;
-            @apply border-solid;
-            @apply border-gray-200;
-            &:hover {
-                @apply border-transparent;
-            }
-            &.darkmode {
-                @apply border-gray-900;
-            }
-        }
-        &.disabled-hover {
-            background-color: var(--account-color);
-        }
-        &:not(.disabled-hover):hover {
-            background-color: var(--account-color);
-        }
     }
 </style>


### PR DESCRIPTION
## Summary
The `StakingAssetTile` needed more emphasis when in the warning state.

### Changelog
```
- Stop "airdrop" CSS from overwriting the warning state CSS
- Move warning icon to left of token holdings
- Add hover states for asset tile and transaction item tile
- Add "---" as placeholder for fiat info
- Change presentation logic conditionals because empty arrays are truthy
```

## Relevant Issues
Fixes #2836 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Hard-coded necessary values as true to test CSS.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation