### PR TITLE
fix: make account naming consistent

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -388,7 +388,7 @@ export const asyncCreateAccount = (alias?: string, color?: string): Promise<Wall
                         incoming: 0,
                         outgoing: 0,
                         depositAddress: response.payload.addresses[0].address,
-                    }) as WalletAccount
+                    })
                     get(wallet)?.accounts.update((_accounts) => [..._accounts, preparedAccount])
 
                     setProfileAccount(get(activeProfile), { id: preparedAccount.id, color })
@@ -499,7 +499,7 @@ export const asyncSyncAccountOffline = (account: WalletAccount): Promise<void> =
             onSuccess(response) {
                 getAccountMeta(account.id, (err, meta) => {
                     if (!err) {
-                        const _account = prepareAccountInfo(account, meta) as WalletAccount
+                        const _account = prepareAccountInfo(account, meta)
                         get(wallet)?.accounts.update((_accounts) =>
                             _accounts.map((a) => (a.id === _account.id ? _account : a))
                         )
@@ -835,6 +835,13 @@ export const updateAccounts = (syncedAccounts: SyncedAccount[]): void => {
                         meta
                     )
 
+                    api.setAlias(account?.id, account?.alias, {
+                        onSuccess() {},
+                        onError(err) {
+                            console.error(err)
+                        },
+                    })
+
                     _accounts.push(account)
                 } else {
                     console.error(err)
@@ -1007,7 +1014,7 @@ export const prepareAccountInfo = (
         outgoing: number
         depositAddress: string
     }
-): unknown => {
+): WalletAccount => {
     const { id, index, alias, signerType } = account
     const { balance, depositAddress } = meta
 


### PR DESCRIPTION
## Summary
Account names are not consistent when restoring from a profile.

### Changelog
```
- Add logic to set account aliases upon syncing new accounts
- Change type from unknown to WalletAccount
```

## Relevant Issues
Fixes #2841

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Restore a profile with funds on a wallet whose index is at least 1 or more (using 0-based indices). Upon restoration the names will be "Wallet 1, 2, ..., N" and should be the same after logging out and back in. 

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation