### PR TITLE
chore: change `wallet.rs` revision to cache outputs

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=ec6b3cb5bdf007ab59546505e56425eeec12f215#ec6b3cb5bdf007ab59546505e56425eeec12f215"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=b2cc0b6018325839998c2fc53d86577c62522118#b2cc0b6018325839998c2fc53d86577c62522118"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["/bindings", "/api-wrapper"]
 [dependencies]
 tokio = { version = "1.12.0", default-features = false }
 once_cell = { version = "1.8.0", default-features = false }
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "ec6b3cb5bdf007ab59546505e56425eeec12f215", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator", "participation"] }
+iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "b2cc0b6018325839998c2fc53d86577c62522118", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator", "participation"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 riker = "0.4.2"

--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=ec6b3cb5bdf007ab59546505e56425eeec12f215#ec6b3cb5bdf007ab59546505e56425eeec12f215"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=b2cc0b6018325839998c2fc53d86577c62522118#b2cc0b6018325839998c2fc53d86577c62522118"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.20.3"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=86d983987e7cafce90ad8a147b0b325e6007eba6#86d983987e7cafce90ad8a147b0b325e6007eba6"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.17.0"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=86d983987e7cafce90ad8a147b0b325e6007eba6#86d983987e7cafce90ad8a147b0b325e6007eba6"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
 dependencies = [
  "libc",
  "librocksdb-sys",


### PR DESCRIPTION
## Summary
Previously outputs were not cached, causing nodes to be bombarded with participation-related API requests from all of the Firefly instances.

### Changelog
```
- Change wallet-rs revision to b2cc0b6018325839998c2fc53d86577c62522118
- Change lock files
```

## Relevant Issues
_None_

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
_None_

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation