### PR TITLE
enhancement: persist send and recieve form when switching wallet

### DIFF
--- a/packages/shared/components/modals/AccountSwitcher.svelte
+++ b/packages/shared/components/modals/AccountSwitcher.svelte
@@ -22,7 +22,7 @@
             showWarning(localize('notifications.participating'))
         } else {
             setSelectedAccount(accountId)
-            resetAccountRouter()
+            resetAccountRouter(false)
             modal?.close()
         }
     }

--- a/packages/shared/components/popups/HideAccount.svelte
+++ b/packages/shared/components/popups/HideAccount.svelte
@@ -10,6 +10,8 @@
     import { Locale } from '@core/i18n'
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import { Writable } from 'svelte/store'
+    import { Unit } from '@iota/unit-converter'
+    import { formatUnitPrecision } from '@lib/units'
 
     export let locale: Locale
 
@@ -46,7 +48,12 @@
     }
     function handleMoveFundsClick() {
         closePopup()
-        sendParams.update((params) => ({ ...params, amount: $account.rawIotaBalance, isInternal: true }))
+        sendParams.update((params) => ({
+            ...params,
+            amount: formatUnitPrecision($account.rawIotaBalance, Unit.Mi, false),
+            unit: Unit.Mi,
+            isInternal: true,
+        }))
         $accountRouter.goTo(AccountRoute.Send)
     }
     function handleCancelClick() {

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -47,14 +47,21 @@ export const lastActiveAt = writable<Date>(new Date())
  * Input parameters for sending transactions
  */
 export const sendParams = writable<SendParams>({
-    amount: 0,
+    amount: undefined,
     unit: Unit.Mi,
     address: '',
     message: '',
     isInternal: false,
 })
 export const clearSendParams = (isInternal = false): void =>
-    sendParams.set({ amount: 0, unit: Unit.Mi, address: '', message: '', isInternal })
+    sendParams.set({
+        amount: undefined,
+        unit: Unit.Mi,
+        address: '',
+        message: '',
+        isInternal,
+        toWalletAccount: undefined,
+    })
 
 /**
  * Determines whether a user is logged in

--- a/packages/shared/lib/common/deep-links/types/wallet-context.type.ts
+++ b/packages/shared/lib/common/deep-links/types/wallet-context.type.ts
@@ -5,7 +5,7 @@ import type { Unit } from '@iota/unit-converter'
  */
 export type SendOperationParameters = {
     address: string
-    amount: number
+    amount: string
     unit: Unit
     message: string
 }

--- a/packages/shared/lib/common/deep-links/wallet-context-handler.ts
+++ b/packages/shared/lib/common/deep-links/wallet-context-handler.ts
@@ -118,7 +118,7 @@ const parseSendOperation = (
 
     return {
         address,
-        amount: Math.abs(parsedAmount),
+        amount: String(Math.abs(parsedAmount)),
         unit: parsedUnit,
         message: '',
     }

--- a/packages/shared/lib/core/router/helper.ts
+++ b/packages/shared/lib/core/router/helper.ts
@@ -10,6 +10,7 @@ import { DashboardRouter, dashboardRouter } from './dashboard-router'
 import { DashboardRoute } from './enums'
 import { SettingsRouter, settingsRouter } from './settings-router'
 import { ledgerRouter, LedgerRouter } from './subrouters'
+import { clearSendParams } from '@lib/app'
 
 export const initRouters = (): void => {
     appRouter.set(new AppRouter())
@@ -27,8 +28,11 @@ export const resetRouters = (): void => {
     isDeepLinkRequestActive.set(false)
 }
 
-export const resetAccountRouter = (): void => {
-    get(accountRouter).reset()
+export const resetAccountRouter = (resetPanels: boolean = true): void => {
+    if (resetPanels) {
+        get(accountRouter).reset()
+        clearSendParams()
+    }
     selectedMessage.set(null)
 }
 

--- a/packages/shared/lib/typings/sendParams.ts
+++ b/packages/shared/lib/typings/sendParams.ts
@@ -1,9 +1,11 @@
 import { Unit } from '@iota/unit-converter'
+import { LabeledWalletAccount } from './wallet'
 
 export interface SendParams {
-    amount: number
+    amount: string | undefined
     unit?: Unit
     address: string
     message: string
     isInternal: boolean
+    toWalletAccount?: LabeledWalletAccount
 }

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -41,6 +41,7 @@
     import { NotificationType } from 'shared/lib/typings/notification'
     import { SendParams } from 'shared/lib/typings/sendParams'
     import { LabeledWalletAccount, WalletAccount } from 'shared/lib/typings/wallet'
+    import { account } from '@lib/typings'
 
     export let onSend = (..._: any[]): void => {}
     export let onInternalTransfer = (..._: any[]): void => {}
@@ -277,8 +278,11 @@
     }
 
     const handleSendTypeClick = (type: SEND_TYPE): void => {
-        selectedSendType = type
-        clearErrors()
+        if (selectedSendType !== type) {
+            selectedSendType = type
+            to = undefined
+            clearErrors()
+        }
     }
 
     const handleToSelect = (item) => {
@@ -351,7 +355,7 @@
             // the other accounts, detect it to display the right popup
             // but keep the tx external to keep the original entered address
             const internal = selectedSendType === SEND_TYPE.INTERNAL
-            let accountAlias = internal ? to.alias : undefined
+            let accountAlias = internal ? to?.alias : undefined
 
             if (!internal) {
                 for (const acc of $accounts) {
@@ -405,7 +409,7 @@
 
     const addLabel = (account: WalletAccount): LabeledWalletAccount => ({
         ...account,
-        label: `${account.alias} • ${account.balance}`,
+        label: `${account?.alias} • ${account.balance}`,
     })
 
     const handleMaxClick = (): void => {
@@ -418,10 +422,10 @@
 
     const updateFromSendParams = (sendParams: SendParams): void => {
         selectedSendType = sendParams.isInternal && $liveAccounts.length > 1 ? SEND_TYPE.INTERNAL : SEND_TYPE.EXTERNAL
-        unit = sendParams.unit ?? (sendParams.amount === 0 ? Unit.Mi : Unit.i)
-        const rawAmount = changeUnits(sendParams.amount, unit, Unit.i)
-        amount = sendParams.amount === 0 ? '' : formatUnitPrecision(rawAmount, unit, false)
+        unit = sendParams.unit ?? (Number(sendParams.amount) === 0 ? Unit.Mi : Unit.i)
+        amount = sendParams.amount !== undefined ? String(sendParams.amount) : ''
         address = sendParams.address
+        to = sendParams?.toWalletAccount?.id !== $selectedAccount.id ? sendParams?.toWalletAccount : undefined
         if (accountsDropdownItems) {
             to =
                 $liveAccounts.length === 2
@@ -455,6 +459,20 @@
         if (transactionTimeoutId) clearTimeout(transactionTimeoutId)
         sendSubscription()
     })
+
+    $: address,
+        unit,
+        amount,
+        selectedSendType,
+        to,
+        sendParams.update((_sendParams) => ({
+            ..._sendParams,
+            address,
+            unit,
+            amount: amount ? String(amount) : '',
+            toWalletAccount: to ? addLabel(to) : undefined,
+            isInternal: selectedSendType === SEND_TYPE.INTERNAL,
+        }))
 </script>
 
 <div class="w-full h-full flex flex-col justify-between p-6">


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
As we have deeplinks, and the user could also be initiating a send and then realise they are on the wrong address. We should persist the send and recieve form as well as any inputs when the user switches tabs.

### Changelog
```
- change sendParams.amount to string
- update areas of code to cast or convert amount
- add toWalletAccount to sendParams for internal transactions
- update sendParams when inputs changes
- fix updateFromSendParams on send form so the form accurately gets filled in from sendParams
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Test
- Send form is filled in by deep link
- send form resets when clicking a new tab or wallet tab again
- send form persists for external transaction when switching wallet
- send form persists for internal transaction when switching wallet
- wallet selected resets when switching to wallet that was previously selected
- clicking on internal transaction in hide wallet accurately fills in the send form for internal transaction

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
