### PR TITLE
fix: adjust logic for constructing duration args

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -75,10 +75,10 @@
             body = localize(`${baseLocalePath}.bodies.${stakingEventState}`, { values: { token: Token.IOTA } })
         } else if (stakingEventState === ParticipationEventState.Holding) {
             const isStaking = isAssemblyStaked || isShimmerStaked
-            const durationArguments: LocaleArguments = isStaking
-                ? { values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) } }
-                : {}
             const tokenArguments: LocaleArguments = isStaking ? {} : { values: { token: Token.IOTA } }
+            const durationArguments: LocaleArguments = {
+                values: { duration: getBestTimeDuration($assemblyStakingRemainingTime) },
+            }
 
             header = localize(`${baseLocalePath}.headers.${stakingEventState}`, durationArguments)
             body = localize(


### PR DESCRIPTION
## Summary
In some cases while the wallets were still syncing, the duration argument for a specific locale was missing.

### Changelog
```
- Change logic for constructing duration argument for locale
```

## Relevant Issues
Fixes #2815

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Open staking tab while wallets are still syncing and wait to verify that a proper time duration is shown.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation