### PR TITLE
fix: use dynamic date for staking event

### DIFF
--- a/packages/shared/components/popups/NewStakingPeriodNotification.svelte
+++ b/packages/shared/components/popups/NewStakingPeriodNotification.svelte
@@ -1,12 +1,21 @@
 <script lang="typescript">
-    import { localize } from '@core/i18n'
+    import { formatDate, LocaleArguments, localize } from '@core/i18n'
     import { getAccountParticipationAbility } from '@lib/participation/participation'
     import { assemblyStakingEventState, shimmerStakingEventState } from '@lib/participation/stores'
     import { AccountParticipationAbility } from '@lib/participation/types'
     import { closePopup, openPopup } from '@lib/popup'
     import { selectedAccount } from '@lib/wallet'
     import { Button, Illustration, Text, TextHint } from 'shared/components'
-    import { isStakingPossible } from '@lib/participation'
+    import { ASSEMBLY_EVENT_START_DATE, isStakingPossible, LAST_ASSEMBLY_STAKING_PERIOD } from '@lib/participation'
+
+    function getLocaleArguments(): LocaleArguments {
+        return {
+            values: {
+                periodNumber: LAST_ASSEMBLY_STAKING_PERIOD + 1,
+                date: formatDate(ASSEMBLY_EVENT_START_DATE, { format: 'long' }),
+            },
+        }
+    }
 
     function handleOk(): void {
         const isStakingPossibleForAssembly = isStakingPossible($assemblyStakingEventState)
@@ -25,8 +34,10 @@
 </script>
 
 <Illustration illustration="staking-notification" classes="mb-6 mt-9" />
-<Text type="h3" classes="mb-4">{localize('popups.newStakingPeriodNotification.title')}</Text>
-<Text type="p" secondary classes="mb-6">{localize('popups.newStakingPeriodNotification.body')}</Text>
+<Text type="h3" classes="mb-4">{localize('popups.newStakingPeriodNotification.title', getLocaleArguments())}</Text>
+<Text type="p" secondary classes="mb-6"
+    >{localize('popups.newStakingPeriodNotification.body', getLocaleArguments())}</Text
+>
 <TextHint
     classes="p-4 mb-6 rounded-2xl bg-blue-50 dark:bg-gray-800"
     icon="info"

--- a/packages/shared/components/popups/NewStakingPeriodNotification.svelte
+++ b/packages/shared/components/popups/NewStakingPeriodNotification.svelte
@@ -33,13 +33,13 @@
     }
 </script>
 
-<Illustration illustration="staking-notification" classes="mb-6 mt-9" />
-<Text type="h3" classes="mb-4">{localize('popups.newStakingPeriodNotification.title', getLocaleArguments())}</Text>
-<Text type="p" secondary classes="mb-6"
+<Illustration illustration="staking-notification" classes="mb-4" />
+<Text type="h3" classes="mb-2">{localize('popups.newStakingPeriodNotification.title', getLocaleArguments())}</Text>
+<Text type="p" secondary classes="mb-4"
     >{localize('popups.newStakingPeriodNotification.body', getLocaleArguments())}</Text
 >
 <TextHint
-    classes="p-4 mb-6 rounded-2xl bg-blue-50 dark:bg-gray-800"
+    classes="p-4 mb-4 rounded-2xl bg-blue-50 dark:bg-gray-800"
     icon="info"
     iconClasses="fill-current text-blue-500"
     hint={localize('popups.newStakingPeriodNotification.info')}

--- a/packages/shared/lib/participation/constants.ts
+++ b/packages/shared/lib/participation/constants.ts
@@ -3,6 +3,11 @@ import { MILLISECONDS_PER_SECOND } from '../time'
 import { Participation, StakingAirdrop } from './types'
 
 /**
+ * The starting date of the next staking period.
+ */
+export const ASSEMBLY_EVENT_START_DATE = new Date()
+
+/**
  * The staking event ID for Assembly.
  */
 export const ASSEMBLY_EVENT_ID = '54d85610d2d4077d9554c2ab30f41303cd7e8fb0afc2abf91c04a1ab451bd966'

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -771,8 +771,8 @@
             "estimatedAirdrop": "Estimated rewards"
         },
         "newStakingPeriodNotification": {
-            "title": "Staking round 2 from March 22nd",
-            "body": "Ready for the next round of staking? Participate in the 30 days staking round 2 from March 22nd. Stake your IOTAs and earn ASMB rewards!",
+            "title": "Staking round {periodNumber} from {date}",
+            "body": "Ready for the next round of staking? Participate in the 30 days staking round {periodNumber} from {date}. Stake your IOTAs and earn ASMB rewards!",
             "info": "Shimmer staking is now complete and only ASMB tokens will be distributed."
         },
         "shimmer-info": {


### PR DESCRIPTION
## Summary
Previously, we weren't using a dynamic date for the staking event information. 

### Changelog
```
- Change hard-coded data to locale arguments
- Add ASSEMBLY_EVENT_START_DATE constant, used in the changed locale
```

## Relevant Issues
Fixes #2860

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Hard coded `openPopup({ type: 'newStakingPeriodNotification' })` in the `Staking.svelte` dashboard route file. 

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation