### PR TITLE
chore: Re-enable Crowdin translations on `develop` branch

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,9 +1,9 @@
 name: "Crowdin"
 
 on:
-  # schedule:
-  #   # Daily at 18:00 UTC
-  #   - cron: '0 18 * * *'
+  schedule:
+    # Daily at 18:00 UTC
+    - cron: '0 18 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
Re-enables the Crowdin workflow on the `develop` branch. It was previously disabled so that strings needed for 1.4.x versions would not be removed from Crowdin.

### Changelog
```
- Re-enabled Crowdin workflow on `develop`
```

## Relevant Issues
Closes #2828 

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
N/A

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code