### PR TITLE
fix: leaving dust error message

### DIFF
--- a/packages/shared/lib/shell/walletErrors.ts
+++ b/packages/shared/lib/shell/walletErrors.ts
@@ -55,7 +55,7 @@ const errorMessages: {
     LedgerDeviceNotFound: 'error.ledger.notFound',
     LedgerEssenceTooLarge: 'error.global.generic',
     // Dust output
-    DustError: 'error.send.leavingDust',
+    LeavingDustError: 'error.send.leavingDust',
 }
 
 export const getErrorMessage = (type: ErrorType | ValidatorErrorTypes): string => {

--- a/packages/shared/lib/typings/events.ts
+++ b/packages/shared/lib/typings/events.ts
@@ -83,7 +83,7 @@ export enum ErrorType {
     WrongLedgerSeedError = 'WrongLedgerSeedError',
 
     // Dust output
-    DustError = 'DustError',
+    LeavingDustError = 'LeavingDustError',
 }
 
 export enum LedgerErrorType {


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
Error Type was not aligned with the error type returned from backend. Now changing this gives us the correct error message.

### Changelog
```
Updated error type and link to error message locale.
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Try and send an amount that is less that leaves less than 1Mi in a wallet.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
