### PR TITLE
refactor: pass assembly event id to participationOverview call

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=ec6b3cb5bdf007ab59546505e56425eeec12f215#ec6b3cb5bdf007ab59546505e56425eeec12f215"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=c1fae913dc58e6804ea756ce4c25d5b030513731#c1fae913dc58e6804ea756ce4c25d5b030513731"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["/bindings", "/api-wrapper"]
 [dependencies]
 tokio = { version = "1.12.0", default-features = false }
 once_cell = { version = "1.8.0", default-features = false }
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "ec6b3cb5bdf007ab59546505e56425eeec12f215", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator", "participation"] }
+iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "c1fae913dc58e6804ea756ce4c25d5b030513731", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator", "participation"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 riker = "0.4.2"

--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -354,8 +354,8 @@ export const api = {
     },
 
     // Participation related methods (voting / staking)
-    getParticipationOverview: function (): (__ids: CommunicationIds) => Promise<string> {
-        return (__ids: CommunicationIds) => _getParticipationOverview(sendMessage, __ids)
+    getParticipationOverview: function (assemblyEventId: string): (__ids: CommunicationIds) => Promise<string> {
+        return (__ids: CommunicationIds) => _getParticipationOverview(sendMessage, __ids, assemblyEventId)
     },
     getParticipationEvents: function (): (__ids: CommunicationIds) => Promise<string> {
         return (__ids: CommunicationIds) => _getParticipationEvents(sendMessage, __ids)

--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=ec6b3cb5bdf007ab59546505e56425eeec12f215#ec6b3cb5bdf007ab59546505e56425eeec12f215"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=c1fae913dc58e6804ea756ce4c25d5b030513731#c1fae913dc58e6804ea756ce4c25d5b030513731"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.20.3"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=86d983987e7cafce90ad8a147b0b325e6007eba6#86d983987e7cafce90ad8a147b0b325e6007eba6"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.17.0"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=86d983987e7cafce90ad8a147b0b325e6007eba6#86d983987e7cafce90ad8a147b0b325e6007eba6"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -14,7 +14,7 @@
         getIotasUntilMinimumAirdropReward,
     } from 'shared/lib/participation'
     import { getParticipationOverview, participate, stopParticipating } from 'shared/lib/participation/api'
-    import { STAKING_EVENT_IDS } from 'shared/lib/participation/constants'
+    import { ASSEMBLY_EVENT_ID, STAKING_EVENT_IDS } from 'shared/lib/participation/constants'
     import {
         isPerformingParticipation,
         isPartiallyStaked,
@@ -52,7 +52,7 @@
     $: canStake = canParticipate($assemblyStakingEventState) || canParticipate($shimmerStakingEventState)
 
     $: $participationOverview, resetAccounts()
-    $: $stakedAccounts, $selectedAccount, async () => getParticipationOverview()
+    $: $stakedAccounts, $selectedAccount, async () => getParticipationOverview(ASSEMBLY_EVENT_ID)
 
     $: isCurrentAccountStaked = isAccountStaked($selectedAccount?.id)
 

--- a/packages/shared/lib/participation/api.ts
+++ b/packages/shared/lib/participation/api.ts
@@ -19,9 +19,9 @@ import {
  *
  * @returns {Promise<void>}
  */
-export function getParticipationOverview(): Promise<void> {
+export function getParticipationOverview(assemblyEventId: string): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-        api.getParticipationOverview({
+        api.getParticipationOverview(assemblyEventId, {
             onSuccess(overview: Event<ParticipationOverviewResponse>) {
                 participationOverview.set(overview?.payload.accounts)
 

--- a/packages/shared/lib/participation/bridge.ts
+++ b/packages/shared/lib/participation/bridge.ts
@@ -10,14 +10,20 @@ import { Participation } from './types'
  *
  * @param {Bridge} bridge
  * @param {CommunicationIds} __ids
+ * @apram {string} assemblyEventId
  *
  * @returns {Promise<string>}
  */
-export function getParticipationOverview(bridge: Bridge, __ids: CommunicationIds): Promise<string> {
+export function getParticipationOverview(
+    bridge: Bridge,
+    __ids: CommunicationIds,
+    assemblyEventId: string
+): Promise<string> {
     return bridge({
         actorId: __ids.actorId,
         id: __ids.messageId,
         cmd: 'GetParticipationOverview',
+        payload: { assemblyEventId },
     })
 }
 

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -2,7 +2,7 @@ import { DUST_THRESHOLD, hasValidPendingTransactions } from '../wallet'
 import { WalletAccount } from '../typings/wallet'
 
 import { getParticipationOverview } from './api'
-import { PARTICIPATION_POLL_DURATION } from './constants'
+import { ASSEMBLY_EVENT_ID, PARTICIPATION_POLL_DURATION } from './constants'
 import { canAccountReachMinimumAirdrop } from './staking'
 import {
     isPerformingParticipation,
@@ -25,9 +25,12 @@ let participationPollInterval
 export async function pollParticipationOverview(): Promise<void> {
     clearPollParticipationOverviewInterval()
     try {
-        await getParticipationOverview()
+        await getParticipationOverview(ASSEMBLY_EVENT_ID)
         /* eslint-disable @typescript-eslint/no-misused-promises */
-        participationPollInterval = setInterval(async () => getParticipationOverview(), PARTICIPATION_POLL_DURATION)
+        participationPollInterval = setInterval(
+            async () => getParticipationOverview(ASSEMBLY_EVENT_ID),
+            PARTICIPATION_POLL_DURATION
+        )
     } catch (error) {
         if (error && error?.error.includes('pluginNotFound')) {
             clearPollParticipationOverviewInterval()

--- a/packages/shared/lib/typings/walletApi.ts
+++ b/packages/shared/lib/typings/walletApi.ts
@@ -267,10 +267,13 @@ export interface IWalletApi {
     )
 
     // Participation (voting / staking)
-    getParticipationOverview(callbacks: {
-        onSuccess: (response: Event<ParticipationOverviewResponse>) => void
-        onError: (err: ErrorEventPayload) => void
-    })
+    getParticipationOverview(
+        assemblyEventId: string,
+        callbacks: {
+            onSuccess: (response: Event<ParticipationOverviewResponse>) => void
+            onError: (err: ErrorEventPayload) => void
+        }
+    )
     getParticipationEvents(callbacks: {
         onSuccess: (response: Event<ParticipationEvent[]>) => void
         onError: (err: ErrorEventPayload) => void

--- a/packages/shared/lib/walletApiListeners.ts
+++ b/packages/shared/lib/walletApiListeners.ts
@@ -22,6 +22,7 @@ import { openPopup } from './popup'
 import { isStrongholdLocked, updateProfile } from './profile'
 import type { Message } from './typings/message'
 import type { WalletAccount } from './typings/wallet'
+import { ASSEMBLY_EVENT_ID } from './participation'
 
 /**
  * Initialises event listeners from wallet library
@@ -109,7 +110,7 @@ export const initialiseListeners = (): void => {
             // Checks if this was a message sent for participating in an event
             if (hasPendingParticipation(message.id)) {
                 // Instantly pull in latest participation overview.
-                await getParticipationOverview()
+                await getParticipationOverview(ASSEMBLY_EVENT_ID)
 
                 // If it is a message related to any participation event, display a notification
                 displayParticipationNotification(getPendingParticipation(message.id))

--- a/packages/shared/routes/dashboard/staking/Staking.svelte
+++ b/packages/shared/routes/dashboard/staking/Staking.svelte
@@ -20,6 +20,7 @@
     import { onDestroy, onMount } from 'svelte'
     import { getParticipationEvents, getParticipationOverview } from '@lib/participation/api'
     import { StakingAirdrop, StakingInfo, StakingSummary } from './views'
+    import { ASSEMBLY_EVENT_ID } from '@lib/participation'
 
     const handleNewStakingEvent = (): void => {
         openPopup({
@@ -126,7 +127,7 @@
             handleNewStakingEvent()
         }
         await getParticipationEvents()
-        await getParticipationOverview()
+        await getParticipationOverview(ASSEMBLY_EVENT_ID)
     })
 
     /** Subscribe to transfer state */


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
So that we don't need to store and update the event Id in wallet.rs, this change simply passes the assembly event id to wallet.rs when calling the getParticipationOverview function.

### Changelog
```
Please write an accurate and concise changelog for your changes.
- Update wallet.rs revision
- Update getParticipation bindings
- Update getParticipation call to pass in assembly event Id.
```
wallet.rs changelog
https://github.com/iotaledger/wallet.rs/compare/ec6b3cb5bdf007ab59546505e56425eeec12f215...c1fae913dc58e6804ea756ce4c25d5b030513731

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
