### PR TITLE
fix: improve formatting on staking asset tile

### DIFF
--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -144,22 +144,24 @@
             <Icon classes="text-gray-900" icon={asset?.name?.toLocaleLowerCase()} height="100%" width="100%" />
         </div>
         <div class="flex flex-col flex-wrap space-y-1 text-left">
-            <Text classes="font-semibold">{asset?.name}</Text>
+            <div class="flex flex-row items-center space-x-1">
+                <Text classes="font-semibold">{asset?.name}</Text>
+                {#if showWarningState && tooltipText?.body.length > 0}
+                    <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
+                        <Icon
+                            icon="exclamation"
+                            width="17"
+                            height="17"
+                            classes="fill-current text-yellow-600 group-hover:text-gray-900"
+                        />
+                    </div>
+                {/if}
+            </div>
             <Text secondary smaller>{asset?.fiatPrice ? asset?.fiatPrice : FIAT_PLACEHOLDER}</Text>
         </div>
     </div>
     <div class="flex flex-col flex-wrap space-y-1 text-right">
         <div class="flex flex-row">
-            {#if showWarningState && tooltipText?.body.length > 0}
-                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
-                    <Icon
-                        icon="exclamation"
-                        width="17"
-                        height="17"
-                        classes="mt-0.5 mr-2 fill-current text-yellow-600 group-hover:text-gray-900"
-                    />
-                </div>
-            {/if}
             <Text classes="font-semibold">{asset?.balance}</Text>
         </div>
         <Text secondary smaller>{asset?.fiatBalance ? `≈ ${asset?.fiatBalance}` : FIAT_PLACEHOLDER}</Text>

--- a/packages/shared/lib/assets.ts
+++ b/packages/shared/lib/assets.ts
@@ -45,14 +45,14 @@ export const assets = derived(
         if ($assemblyStakingRewards) {
             assets.push({
                 name: Token.Assembly,
-                balance: formatStakingAirdropReward(StakingAirdrop[Token.Assembly], Number($assemblyStakingRewards), 6),
+                balance: formatStakingAirdropReward(StakingAirdrop[Token.Assembly], Number($assemblyStakingRewards), 2),
                 color: '#DCABE1',
             })
         }
         if ($shimmerStakingRewards) {
             assets.push({
                 name: Token.Shimmer,
-                balance: formatStakingAirdropReward(StakingAirdrop[Token.Shimmer], Number($shimmerStakingRewards), 6),
+                balance: formatStakingAirdropReward(StakingAirdrop[Token.Shimmer], Number($shimmerStakingRewards), 2),
                 color: '#25DFCA',
             })
         }


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
Formatted the stakingRewardTiles so that the warning symbol sticks close to the asset name, and the asset balance is formatted to 2 decimal places.

### Changelog
```
- move warning component to inside the grid column next to the text
- format balance to two decimal places
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
