### PR TITLE
fix: use total rewards for staking animations

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -10,6 +10,8 @@
         currentShimmerStakingRewards,
         currentShimmerStakingRewardsBelowMinimum,
         selectedAccountParticipationOverview,
+        totalAssemblyStakingRewards,
+        totalShimmerStakingRewards,
     } from 'shared/lib/participation/stores'
     import { ParticipationEventState } from 'shared/lib/participation/types'
     import { getBestTimeDuration } from 'shared/lib/time'
@@ -66,12 +68,12 @@
                     animation = StakingAnimation.Neither
                 } else {
                     if (isStakingForAssembly) {
-                        const hasShimmerRewards = $selectedAccountParticipationOverview.shimmerRewards > 0
+                        const hasShimmerRewards = $totalShimmerStakingRewards > 0
                         animation = hasShimmerRewards
                             ? StakingAnimation.AssemblyWithShimmerRewards
                             : StakingAnimation.AssemblyWithoutShimmerRewards
                     } else if (isStakingForShimmer) {
-                        const hasAssemblyRewards = $selectedAccountParticipationOverview.assemblyRewards > 0
+                        const hasAssemblyRewards = $totalAssemblyStakingRewards > 0
                         animation = hasAssemblyRewards
                             ? StakingAnimation.ShimmerWithAssemblyRewards
                             : StakingAnimation.ShimmerWithoutAssemblyRewards


### PR DESCRIPTION
## Summary
If the user has rewards from a previous period, they are not taken into account when determining exactly which zen guy staking animation should be displayed.

### Changelog
```
- Fix staking animation display logic to use total rather than current rewards
```

## Relevant Issues
_None_

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Test with rewards from a previous or current staking period.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation