### PR TITLE
chore: bump Crowdin action to 1.4.8

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Sync translations from Crowdin
-        uses: crowdin/github-action@1.0.20
+        uses: crowdin/github-action@1.4.8
         with:
           upload_sources: true
           download_translations: true


### PR DESCRIPTION
## Summary
Fix Crowdin sync by bumping Crowdin action to 1.4.8.

### Changelog
```
- Bump Crowdin action to 1.4.8
```

## Relevant Issues
https://github.com/actions/checkout/issues/760
https://github.com/crowdin/github-action/issues/114

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
Tested on GitHub Actions

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code