### PR TITLE
fix: enable merging of assembly stake after restoring

### DIFF
--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -30,9 +30,16 @@
     let showTooltip = false
     let tooltipAnchor: unknown
 
-    const activeAirdropsParticipatedIn =
+    // Removed to hardcode event ids for now, as we only have 1 event running and this doesn't work for restoring.
+    /* const activeAirdropsParticipatedIn =
         $selectedAccountParticipationOverview?.participations
             .map((p) => getAirdropFromEventId(p.eventId))
+            // Falsy values (undefined, null, ...) are filtered out from the array
+            .filter(Boolean) || [] */
+
+    // Hardcode to the current event ids for now, and this allows us to merge after restoring
+    const activeAirdropsParticipatedIn =
+        STAKING_EVENT_IDS.map((eventId) => getAirdropFromEventId(eventId))
             // Falsy values (undefined, null, ...) are filtered out from the array
             .filter(Boolean) || []
 


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
Because the wallet backend only stores participations in the local db, when restoring they do not exist in the wallet. And this leads to problems merging stakes. To prevent this, and because there is only one event in the next round of staking, we have hardcoded the staking confirmation screen to use the Assembly staking id when merging stakes.

### Changelog
```
Use STAKING_EVENT_IDS instead of active participations for partial stake (merge).
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Test
1. General staking
2. Merging
3. Unstaking
4. Restoring a profile and unstaking
5. Restroing a profile and merging an existing partial stake

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
