### PR TITLE
fix: attempt rename profile folder everytime app is run

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -2,7 +2,7 @@
     import { onDestroy, onMount } from 'svelte'
     import { Popup, Route, TitleBar, ToastContainer } from 'shared/components'
     import { stage, loggedIn } from 'shared/lib/app'
-    import { appSettings, hasRenamedProfileFoldersToId, initAppSettings } from 'shared/lib/appSettings'
+    import { appSettings, initAppSettings } from 'shared/lib/appSettings'
     import { getVersionDetails, pollVersion, versionDetails } from 'shared/lib/appUpdater'
     import { addError } from 'shared/lib/errors'
     import { goto } from 'shared/lib/helpers'
@@ -11,7 +11,7 @@
     import { showAppNotification } from 'shared/lib/notifications'
     import { Electron } from 'shared/lib/electron'
     import { openPopup, popupState } from 'shared/lib/popup'
-    import { cleanupEmptyProfiles, cleanupInProgressProfiles, renameAllProfileFoldersToId } from 'shared/lib/profile'
+    import { cleanupEmptyProfiles, cleanupInProgressProfiles, renameOldProfileFoldersToId } from 'shared/lib/profile'
     import { AppRoute, DashboardRoute, dashboardRouter, accountRouter, initRouters, openSettings } from '@core/router'
     import {
         Appearance,
@@ -73,18 +73,7 @@
             initRouters()
         }, 3000)
 
-        // This is added to migrate all profile folder names from using the profile name to the id
-        // TEMP: Changed the below condition to always execute and attempt to rename folders in 1.5.0
-        // this is because, due to bugs in 1.4.+ people downgrade to 1.3.3 which delete all the folders,
-        // they make new ones and then when they upgrade to 1.4.+ again this will never execute, and the users
-        // folders/profiles will be wiped again
-        // if (!get(hasRenamedProfileFoldersToId)) {
-        // @ts-ignore
-        /* eslint-disable no-constant-condition */
-        if (true) {
-            await renameAllProfileFoldersToId()
-            hasRenamedProfileFoldersToId.set(true)
-        }
+        await renameOldProfileFoldersToId()
 
         initAppSettings.set($appSettings)
 

--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -74,7 +74,14 @@
         }, 3000)
 
         // This is added to migrate all profile folder names from using the profile name to the id
-        if (!get(hasRenamedProfileFoldersToId)) {
+        // TEMP: Changed the below condition to always execute and attempt to rename folders in 1.5.0
+        // this is because, due to bugs in 1.4.+ people downgrade to 1.3.3 which delete all the folders,
+        // they make new ones and then when they upgrade to 1.4.+ again this will never execute, and the users
+        // folders/profiles will be wiped again
+        // if (!get(hasRenamedProfileFoldersToId)) {
+        // @ts-ignore
+        /* eslint-disable no-constant-condition */
+        if (true) {
             await renameAllProfileFoldersToId()
             hasRenamedProfileFoldersToId.set(true)
         }

--- a/packages/desktop/electron/electronApi.js
+++ b/packages/desktop/electron/electronApi.js
@@ -48,7 +48,7 @@ const ElectronApi = {
             }
         })
     },
-    listProfileFolders(profileStoragePath, profiles) {
+    listProfileFolders(profileStoragePath) {
         return ipcRenderer.invoke('get-path', 'userData').then((userDataPath) => {
             // Check that the profile path matches the user data path
             // so that we don't try and remove things outside our scope

--- a/packages/shared/lib/appSettings.ts
+++ b/packages/shared/lib/appSettings.ts
@@ -70,8 +70,3 @@ export const lastAcceptedPrivacyPolicy = persistent<number>('lastAcceptedPrivacy
  * Note: The initial value must be set to 1 to support existing users and alert them
  */
 export const lastAcceptedTos = persistent<number>('lastAcceptedTos', 1)
-
-/**
- * Have the profile folders been renamed from using profile names to the profile ids?
- */
-export const hasRenamedProfileFoldersToId = persistent<boolean>('hasRenamedProfileFoldersToId', false)

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -468,7 +468,7 @@ async function renameProfileFolder(oldName: string, newName: string): Promise<vo
 export async function renameOldProfileFoldersToId(): Promise<void> {
     const walletPath = await getWalletDataPath()
     const profileFolders = await Platform.listProfileFolders(walletPath)
-    const oldProfiles = get(profiles).filter((profiles) => profileFolders.find((p) => p === profiles.name))
+    const oldProfiles = get(profiles).filter((profile) => profileFolders.find((p) => p === profile.name))
 
     if (oldProfiles.length > 0) {
         await Promise.all(

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -465,11 +465,16 @@ async function renameProfileFolder(oldName: string, newName: string): Promise<vo
     await Platform.renameProfileFolder(oldPath, newPath)
 }
 
-export async function renameAllProfileFoldersToId(): Promise<void> {
-    const _profiles = get(profiles)
-    await Promise.all(
-        _profiles.map(async (profile) => {
-            await renameProfileFolder(profile.name, profile.id)
-        })
-    )
+export async function renameOldProfileFoldersToId(): Promise<void> {
+    const walletPath = await getWalletDataPath()
+    const profileFolders = await Platform.listProfileFolders(walletPath)
+    const oldProfiles = get(profiles).filter((profiles) => profileFolders.find((p) => p === profiles.name))
+
+    if (oldProfiles.length > 0) {
+        await Promise.all(
+            oldProfiles.map(async (profile) => {
+                await renameProfileFolder(profile.name, profile.id)
+            })
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Please summarize your changes, describing __what__ they are and __why__ they were made.
This is needed because in 1.4.+ we rename the profile folders to use the profile index, this means that we can freely name and rename profiles. However, this store is not cleared when downgrading versions so this can only occur once.

in 1.4.0-1.4.2 there are bugs that meant people where downgrading to 1.3.3, because the folders had been renamed they where cleared and in 1.3.3 the user had to make there profiles again. If they then upgrade to 1.5.0, the profiles will wipe again as they are using 1.3.3- naming convention. This change simply attempts to rename profiles everytime the app loads in 1.5.0 so that people are able to upgrade.

We can fix this better or change it back once the majority of users are on a stable build of 1.5.0+

### Changelog
```
- change condition to rename folders on mac to always true on launch.
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
