### PR TITLE
enhancement: add dynamic dates in staking info

### DIFF
--- a/packages/shared/lib/participation/constants.ts
+++ b/packages/shared/lib/participation/constants.ts
@@ -5,7 +5,7 @@ import { Participation, StakingAirdrop } from './types'
 /**
  * The starting date of the next staking period.
  */
-export const ASSEMBLY_EVENT_START_DATE = new Date()
+export const ASSEMBLY_EVENT_START_DATE = new Date('April 19, 2022')
 
 /**
  * The staking event ID for Assembly.

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -771,8 +771,8 @@
             "estimatedAirdrop": "Estimated rewards"
         },
         "newStakingPeriodNotification": {
-            "title": "Staking round {periodNumber} from {date}",
-            "body": "Ready for the next round of staking? Participate in the 30 days staking round {periodNumber} from {date}. Stake your IOTAs and earn ASMB rewards!",
+            "title": "Staking phase {periodNumber} from {date}",
+            "body": "IOTA staking for Assembly continues... Participate in phase {periodNumber} for 90 days. Stake your IOTA tokens and earn ASMB rewards!",
             "info": "Shimmer staking is now complete and only ASMB tokens will be distributed."
         },
         "shimmer-info": {

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -524,8 +524,8 @@
                     "inactive": "No staking events detected"
                 },
                 "bodies": {
-                    "upcoming": "Stake your {token} tokens to automatically receive rewards every 10 seconds once staking starts on April 1st.",
-                    "commencing": "Stake your {token} tokens to automatically receive rewards every 10 seconds once staking starts on April 1st.",
+                    "upcoming": "Stake your {token} tokens to automatically receive rewards every 10 seconds once staking starts on {date}.",
+                    "commencing": "Stake your {token} tokens to automatically receive rewards every 10 seconds once staking starts on {date}.",
                     "holdingAndStaking": "You automatically receive rewards every 10 seconds.",
                     "holdingAndNotStaking": "Stake your {token} tokens to receive rewards every 10 seconds.",
                     "endedAndDidStake": "{token} rewards will be distributed to your wallet once the network launches.",

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { Animation, Link, Text } from 'shared/components'
     import { Platform } from 'shared/lib/platform'
-    import { LocaleArguments, localize } from '@core/i18n'
+    import { formatDate, LocaleArguments, localize } from '@core/i18n'
     import {
         assemblyStakingEventState,
         assemblyStakingRemainingTime,
@@ -17,7 +17,8 @@
     import { getBestTimeDuration } from 'shared/lib/time'
     import { selectedAccountId } from '@lib/wallet'
     import { Token } from '@lib/typings/assets'
-    import { ASSEMBLY_EVENT_ID, SHIMMER_EVENT_ID } from '@lib/participation'
+    import { ASSEMBLY_EVENT_ID, ASSEMBLY_EVENT_START_DATE, SHIMMER_EVENT_ID } from '@lib/participation'
+    import { openPopup } from '../../../../lib/popup'
 
     enum StakingAnimation {
         Prestaking = 'prestaking',
@@ -103,8 +104,11 @@
             stakingEventState === ParticipationEventState.Upcoming ||
             stakingEventState === ParticipationEventState.Commencing
         ) {
+            const dateArgument = formatDate(ASSEMBLY_EVENT_START_DATE, { format: 'long' })
+            const localeArguments = { values: { token: Token.IOTA, date: dateArgument } }
+
             header = localize(`${baseLocalePath}.headers.${stakingEventState}`)
-            body = localize(`${baseLocalePath}.bodies.${stakingEventState}`, { values: { token: Token.IOTA } })
+            body = localize(`${baseLocalePath}.bodies.${stakingEventState}`, localeArguments)
         } else if (stakingEventState === ParticipationEventState.Holding) {
             const isStaking = isAssemblyStaked || isShimmerStaked
             const tokenArguments: LocaleArguments = isStaking ? {} : { values: { token: Token.IOTA } }

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -18,7 +18,6 @@
     import { selectedAccountId } from '@lib/wallet'
     import { Token } from '@lib/typings/assets'
     import { ASSEMBLY_EVENT_ID, ASSEMBLY_EVENT_START_DATE, SHIMMER_EVENT_ID } from '@lib/participation'
-    import { openPopup } from '../../../../lib/popup'
 
     enum StakingAnimation {
         Prestaking = 'prestaking',


### PR DESCRIPTION
## Summary
We need to be using a dynamic date for the locales.

### Changelog
```
- Change to dynamic date for locales used in the StakingInfo component
- Update constant for Assembly staking starting date
```

## Relevant Issues
Closes #2906 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Manually set event state to confirm date was displayed correctly. 

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation