### PR TITLE
enhancement: remove staking animation when participation not detected

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -44,7 +44,12 @@
     $: stakingEventState = $assemblyStakingEventState
 
     $: $selectedAccountParticipationOverview, stakingEventState, setText()
-    $: isAssemblyStaked, isShimmerStaked, stakingEventState, $selectedAccountId, setAnimation()
+    $: isAssemblyStaked,
+        isShimmerStaked,
+        stakingEventState,
+        $selectedAccountParticipationOverview,
+        $selectedAccountId,
+        setAnimation()
 
     function setAnimation(): void {
         if (!$selectedAccountParticipationOverview) {

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -30,7 +30,7 @@
         Ended = 'ended',
     }
 
-    let animation: StakingAnimation = StakingAnimation.Neither
+    let animation: StakingAnimation = null
     let header: string
     let body: string
 
@@ -48,7 +48,7 @@
 
     function setAnimation(): void {
         if (!$selectedAccountParticipationOverview) {
-            animation = StakingAnimation.Neither
+            animation = null
             return
         }
 
@@ -91,7 +91,7 @@
                 break
             case ParticipationEventState.Inactive:
             default:
-                animation = StakingAnimation.Neither
+                animation = null
                 break
         }
     }

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -52,40 +52,39 @@
         setAnimation()
 
     function setAnimation(): void {
-        if (!$selectedAccountParticipationOverview) {
-            animation = null
-            return
-        }
-
         switch (stakingEventState) {
             case ParticipationEventState.Upcoming:
             case ParticipationEventState.Commencing:
                 animation = StakingAnimation.Prestaking
                 break
             case ParticipationEventState.Holding: {
-                const participatingEventIds =
-                    $selectedAccountParticipationOverview?.participations?.map((p) => p.eventId) ?? []
-
-                const isStakingForAssembly = participatingEventIds.includes(ASSEMBLY_EVENT_ID)
-                const isStakingForShimmer = participatingEventIds.includes(SHIMMER_EVENT_ID)
-
-                if (isStakingForAssembly && isStakingForShimmer) {
-                    animation = StakingAnimation.Both
-                } else if (!isStakingForAssembly && !isStakingForShimmer) {
+                if (!$selectedAccountParticipationOverview) {
                     animation = StakingAnimation.Neither
                 } else {
-                    if (isStakingForAssembly) {
-                        const hasShimmerRewards = $totalShimmerStakingRewards > 0
-                        animation = hasShimmerRewards
-                            ? StakingAnimation.AssemblyWithShimmerRewards
-                            : StakingAnimation.AssemblyWithoutShimmerRewards
-                    } else if (isStakingForShimmer) {
-                        const hasAssemblyRewards = $totalAssemblyStakingRewards > 0
-                        animation = hasAssemblyRewards
-                            ? StakingAnimation.ShimmerWithAssemblyRewards
-                            : StakingAnimation.ShimmerWithoutAssemblyRewards
-                    } else {
+                    const participatingEventIds =
+                        $selectedAccountParticipationOverview?.participations?.map((p) => p.eventId) ?? []
+
+                    const isStakingForAssembly = participatingEventIds.includes(ASSEMBLY_EVENT_ID)
+                    const isStakingForShimmer = participatingEventIds.includes(SHIMMER_EVENT_ID)
+
+                    if (isStakingForAssembly && isStakingForShimmer) {
+                        animation = StakingAnimation.Both
+                    } else if (!isStakingForAssembly && !isStakingForShimmer) {
                         animation = StakingAnimation.Neither
+                    } else {
+                        if (isStakingForAssembly) {
+                            const hasShimmerRewards = $totalShimmerStakingRewards > 0
+                            animation = hasShimmerRewards
+                                ? StakingAnimation.AssemblyWithShimmerRewards
+                                : StakingAnimation.AssemblyWithoutShimmerRewards
+                        } else if (isStakingForShimmer) {
+                            const hasAssemblyRewards = $totalAssemblyStakingRewards > 0
+                            animation = hasAssemblyRewards
+                                ? StakingAnimation.ShimmerWithAssemblyRewards
+                                : StakingAnimation.ShimmerWithoutAssemblyRewards
+                        } else {
+                            animation = StakingAnimation.Neither
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
If there is no participation data detected for the selected account nor a participation plugin available on the node then there should be no animation.

### Changelog
```
- Remove staking animation when no participation detected
```

## Relevant Issues
Closes #2931

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation