### PR TITLE
fix: min stake warning tooltip positioning

### DIFF
--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -263,7 +263,7 @@
                     </div>
                 {:else if participationAbility === AccountParticipationAbility.WillNotReachMinAirdrop}
                     <div
-                        bind:this={tooltipAnchors[$selectedAccountId]}
+                        bind:this={tooltipAnchors[$selectedAccount?.index]}
                         on:mouseenter={() => toggleTooltip($selectedAccount)}
                         on:mouseleave={() => toggleTooltip($selectedAccount)}
                     >


### PR DESCRIPTION
## Summary
Below min stake tooltip was positioned wrong due to incorrect variable usage.

### Changelog
```
Fixes below min staking tooltip positioning
```

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
If a wallet does not have enough tokens to reach the minimum airdrop when you try to stay a warning icon/tooltip will appear when trying to stake.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
