### PR TITLE
fix: handle undefined name in account switcher

### DIFF
--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -1,14 +1,17 @@
 <script lang="typescript">
-    import { WalletAccount } from '@lib/typings/wallet'
     import { AccountSwitcherModal, Icon, Text, Modal } from 'shared/components'
     import { activeProfile, getColor, updateProfile } from '@lib/profile'
     import { selectedAccount } from '@lib/wallet'
+    import { WalletAccount } from '@lib/typings/wallet'
 
     export let accounts: WalletAccount[] = []
     export let onCreateAccount = (..._: any[]): void => {}
 
     let modal: Modal
     let isModalOpened: boolean
+
+    let lastSelectedAccount: WalletAccount = null
+    $: if ($selectedAccount) lastSelectedAccount = $selectedAccount
 
     function onClick() {
         modal?.toggle()
@@ -19,8 +22,8 @@
 <svelte:window on:click={() => (isModalOpened = modal?.isOpened())} />
 <div class="relative left-8" style="-webkit-app-region: none;">
     <button on:click={onClick} class="flex flex-row justify-center items-center space-x-2">
-        <div class="circle" style="--account-color: {getColor($activeProfile, $selectedAccount?.id)};" />
-        <Text type="h5">{$selectedAccount?.alias ?? '---'}</Text>
+        <div class="circle" style="--account-color: {getColor($activeProfile, lastSelectedAccount?.id)};" />
+        <Text type="h5">{lastSelectedAccount?.alias ?? '---'}</Text>
         <div class="transform {isModalOpened ? 'rotate-180' : 'rotate-0'}">
             <Icon height="18" width="18" icon="chevron-down" classes="text-gray-800 dark:text-white" />
         </div>

--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -20,7 +20,7 @@
 <div class="relative left-8" style="-webkit-app-region: none;">
     <button on:click={onClick} class="flex flex-row justify-center items-center space-x-2">
         <div class="circle" style="--account-color: {getColor($activeProfile, $selectedAccount?.id)};" />
-        <Text type="h5">{$selectedAccount?.alias}</Text>
+        <Text type="h5">{$selectedAccount?.alias ?? '---'}</Text>
         <div class="transform {isModalOpened ? 'rotate-180' : 'rotate-0'}">
             <Icon height="18" width="18" icon="chevron-down" classes="text-gray-800 dark:text-white" />
         </div>


### PR DESCRIPTION
## Summary
When switching networks, the profile data is restored causing the currently selected account name to become undefined. For a quick fix, this PR simply adds a placeholder as backup.

### Changelog
```
- Add "---" as placeholder backup in case of undefined name 
```

## Relevant Issues
Fixes #3031 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Test switching networks and make sure "undefined" / "null" is NOT displayed.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation