### PR TITLE
Feat: unify wallet balance & staking summary panes

### DIFF
--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -84,11 +84,11 @@
     </div>
     <div class="flex flex-col flex-wrap items-start mt-6">
         <div on:click={togglePreciseStakedAmount}>
-            <Text type="h1" classes="break-all">
+            <h1 class="font-600 text-32 leading-120 text-gray-800 dark:text-white break-all">
                 {showPreciseStakedAmount
                     ? formatUnitPrecision(canParticipateInEvent ? $stakedAmount : 0, Unit.Mi)
                     : formatUnitBestMatch(canParticipateInEvent ? $stakedAmount : 0, true, 3)}
-            </Text>
+            </h1>
         </div>
         {#if canParticipateInEvent}
             <Text type="p">{formatUnitBestMatch($unstakedAmount)} {localize('general.unstaked')}</Text>

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { localize } from '@core/i18n'
+    import { Unit } from '@iota/unit-converter'
     import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'
     import { showAppNotification } from 'shared/lib/notifications'
@@ -16,7 +17,7 @@
     import { AccountParticipationAbility, ParticipationAction } from 'shared/lib/participation/types'
     import { openPopup } from 'shared/lib/popup'
     import { NodePlugin } from 'shared/lib/typings/node'
-    import { formatUnitBestMatch } from 'shared/lib/units'
+    import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
     import { isSyncing, selectedAccount } from 'shared/lib/wallet'
 
     $: showSpinner = !!$participationAction || $isSyncing
@@ -44,6 +45,11 @@
     let tooltipAnchor
     function toggleTooltip(): void {
         showTooltip = !showTooltip
+    }
+
+    let showPreciseStakedAmount = false
+    function togglePreciseStakedAmount() {
+        showPreciseStakedAmount = !showPreciseStakedAmount
     }
 
     function handleStakeFundsClick(): void {
@@ -76,10 +82,18 @@
     <div class="flex flex-row justify-between items-start">
         <Text type="p">{localize('views.staking.summary.stakedFunds')}</Text>
     </div>
-    <Text type="h1" classes="mt-6">{formatUnitBestMatch(canParticipateInEvent ? $stakedAmount : 0)}</Text>
-    {#if canParticipateInEvent}
-        <Text type="p">{formatUnitBestMatch($unstakedAmount)} {localize('general.unstaked')}</Text>
-    {/if}
+    <div class="flex flex-col flex-wrap items-start mt-6">
+        <div on:click={togglePreciseStakedAmount}>
+            <Text type="h1" classes="break-all">
+                {showPreciseStakedAmount
+                    ? formatUnitPrecision(canParticipateInEvent ? $stakedAmount : 0, Unit.Mi)
+                    : formatUnitBestMatch(canParticipateInEvent ? $stakedAmount : 0, true, 3)}
+            </Text>
+        </div>
+        {#if canParticipateInEvent}
+            <Text type="p">{formatUnitBestMatch($unstakedAmount)} {localize('general.unstaked')}</Text>
+        {/if}
+    </div>
     <Button
         classes="w-full text-14 mt-6"
         disabled={showSpinner || !canParticipateInEvent}

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
-    import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
     import { localize } from '@core/i18n'
+    import { Button, Icon, Spinner, Text, Tooltip } from 'shared/components'
     import { hasNodePlugin, networkStatus } from 'shared/lib/networkStatus'
     import { showAppNotification } from 'shared/lib/notifications'
     import { getAccountParticipationAbility, isNewStakingEvent, isStakingPossible } from 'shared/lib/participation'
@@ -72,28 +72,16 @@
     }
 </script>
 
-<div class="p-6 flex flex-col justify-between space-y-6 w-full h-full">
-    <div class="flex flex-col justify-between">
-        <div class="flex flex-row justify-between items-start">
-            <Text type="p" smaller overrideColor classes="mb-3 text-gray-700 dark:text-gray-500">
-                {localize('views.staking.summary.stakedFunds')}
-            </Text>
-            {#if isPartiallyStakedAndCanParticipate}
-                <div bind:this={tooltipAnchor} on:mouseenter={toggleTooltip} on:mouseleave={toggleTooltip}>
-                    <Icon icon="exclamation" classes="fill-current text-yellow-600" />
-                </div>
-            {/if}
-        </div>
-        <Text type="h2">{formatUnitBestMatch(canParticipateInEvent ? $stakedAmount : 0)}</Text>
-        {#if canParticipateInEvent}
-            <Text type="p" smaller secondary classes="mt-2">
-                {formatUnitBestMatch($unstakedAmount)}
-                {localize('general.unstaked')}
-            </Text>
-        {/if}
+<div class="p-6 flex flex-col justify-between w-full h-full relative">
+    <div class="flex flex-row justify-between items-start">
+        <Text type="p">{localize('views.staking.summary.stakedFunds')}</Text>
     </div>
+    <Text type="h1" classes="mt-6">{formatUnitBestMatch(canParticipateInEvent ? $stakedAmount : 0)}</Text>
+    {#if canParticipateInEvent}
+        <Text type="p">{formatUnitBestMatch($unstakedAmount)} {localize('general.unstaked')}</Text>
+    {/if}
     <Button
-        classes="w-full text-14"
+        classes="w-full text-14 mt-6"
         disabled={showSpinner || !canParticipateInEvent}
         caution={isStakedAndCanParticipate && isPartiallyStakedAndCanParticipate}
         secondary={isStakedAndCanParticipate && !isPartiallyStakedAndCanParticipate}
@@ -111,6 +99,16 @@
             <Spinner busy message={localize(getSpinnerMessage())} classes="mx-2 justify-center" />
         {:else}{localize(`actions.${isStakedAndCanParticipate ? 'manageStake' : 'stakeFunds'}`)}{/if}
     </Button>
+    {#if isPartiallyStakedAndCanParticipate}
+        <div
+            bind:this={tooltipAnchor}
+            on:mouseenter={toggleTooltip}
+            on:mouseleave={toggleTooltip}
+            class="absolute top-6 right-6"
+        >
+            <Icon icon="exclamation" classes="fill-current text-yellow-600" />
+        </div>
+    {/if}
 </div>
 {#if showTooltip}
     <Tooltip anchor={tooltipAnchor} position="right">

--- a/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
@@ -40,11 +40,11 @@
         {/if}
         <div class="flex flex-col flex-wrap items-start mt-6">
             <div on:click={togglePreciseBalance}>
-                <Text type="h1" classes="break-all">
+                <h1 class="font-600 text-32 leading-120 text-gray-800 dark:text-white break-all">
                     {showPreciseBalance
                         ? formatUnitPrecision($selectedAccount?.rawIotaBalance, Unit.Mi)
                         : formatUnitBestMatch($selectedAccount?.rawIotaBalance, true, 3)}
-                </Text>
+                </h1>
             </div>
             <Text type="p">
                 {$selectedAccount?.balanceEquiv}

--- a/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
@@ -32,28 +32,28 @@
         : 'pb-12'} {classes}"
 >
     <!-- Balance -->
-    <div data-label="total-balance" class="flex flex-col flex-wrap space-y-1.5">
+    <div data-label="total-balance" class="flex flex-col flex-wrap">
         {#if !$mobile}
-            <p class="text-11 leading-120 text-gray-800 dark:text-white uppercase tracking-widest">
+            <Text type="p">
                 {localize('general.balance')}
-            </p>
+            </Text>
         {/if}
-        <div class="flex flex-col flex-wrap items-start space-y-1.5 mr-12">
+        <div class="flex flex-col flex-wrap items-start mt-6 mr-12">
             <div on:click={togglePreciseBalance}>
-                <Text type="h2">
+                <Text type="h1">
                     {showPreciseBalance
                         ? formatUnitPrecision($selectedAccount?.rawIotaBalance, Unit.Mi)
                         : formatUnitBestMatch($selectedAccount?.rawIotaBalance, true, 3)}
                 </Text>
             </div>
-            <Text type="p" smaller>
+            <Text type="p">
                 {$selectedAccount?.balanceEquiv}
             </Text>
         </div>
     </div>
     {#if $accountRoute === AccountRoute.Init || $mobile}
         <!-- Action Send / Receive -->
-        <div class="flex flex-row justify-between space-x-4 mt-7">
+        <div class="flex flex-row justify-between space-x-4 mt-6">
             <button
                 class="action p-3 w-full text-center rounded-lg font-semibold text-14 bg-blue-500 text-white"
                 on:click={handleReceiveClick}

--- a/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
@@ -38,9 +38,9 @@
                 {localize('general.balance')}
             </Text>
         {/if}
-        <div class="flex flex-col flex-wrap items-start mt-6 mr-12">
+        <div class="flex flex-col flex-wrap items-start mt-6">
             <div on:click={togglePreciseBalance}>
-                <Text type="h1">
+                <Text type="h1" classes="break-all">
                     {showPreciseBalance
                         ? formatUnitPrecision($selectedAccount?.rawIotaBalance, Unit.Mi)
                         : formatUnitBestMatch($selectedAccount?.rawIotaBalance, true, 3)}


### PR DESCRIPTION
## Summary

This PR aims to:
- Unify CSS for wallet balance & staking summary panes
- Add precision toggle to staking summary (staked amount only)

### Changelog
```
feat: unify wallet balance & staking summary panes
```

## Relevant Issues
Close #2986

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
