### PR TITLE
feat: android capacitor webview settings

### DIFF
--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/MainActivity.java
@@ -7,5 +7,6 @@ public class MainActivity extends BridgeActivity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    registerPlugin(WebViewSettingsPlugin.class);
   }
 }

--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
@@ -1,6 +1,5 @@
 package org.iota.firefly.mobile.alpha;
 
-import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
@@ -12,8 +11,9 @@ public class WebViewSettingsPlugin extends Plugin {
     @Override
     public void load() {
         WebView webView = getBridge().getWebView();
-        WebSettings settings = webView.getSettings();
+        webView.clearCache(true);
 
+        WebSettings settings = webView.getSettings();
         settings.setGeolocationEnabled(false);
         settings.setAllowFileAccess(false);
         settings.setAllowContentAccess(false);

--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
@@ -1,17 +1,21 @@
 package org.iota.firefly.mobile.alpha;
 
+import android.content.Context;
+import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.getcapacitor.Plugin;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.io.File;
+
 @CapacitorPlugin(name = "WebViewSettings")
 public class WebViewSettingsPlugin extends Plugin {
     @Override
     public void load() {
         WebView webView = getBridge().getWebView();
-        webView.clearCache(true);
+//        webView.clearCache(true);
 
         WebSettings settings = webView.getSettings();
         settings.setGeolocationEnabled(false);
@@ -22,4 +26,17 @@ public class WebViewSettingsPlugin extends Plugin {
         settings.setJavaScriptCanOpenWindowsAutomatically(false);
         settings.setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
     }
+
+    /**
+     * Clean the RAM cache used by the webView including cache files on:
+     * app/cache/WebView/* folder. Called when the app is no longer visible
+     * to the user, as onDestroy is not called every time the app exit.
+     */
+    @Override
+    public void handleOnStop() {
+        super.handleOnStop();
+        WebView webView = getBridge().getWebView();
+        webView.clearCache(true);
+    }
+
 }

--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
@@ -31,12 +31,40 @@ public class WebViewSettingsPlugin extends Plugin {
      * Clean the RAM cache used by the webView including cache files on:
      * app/cache/WebView/* folder. Called when the app is no longer visible
      * to the user, as onDestroy is not called every time the app exit.
+     * TODO Clean app cache folder too? test the whole app with this change!
      */
     @Override
     public void handleOnStop() {
         super.handleOnStop();
         WebView webView = getBridge().getWebView();
         webView.clearCache(true);
+//        deleteCache(getContext());
+        Log.e("CLEANCACHE", "done!");
     }
 
+    public static void deleteCache(Context context) {
+        try {
+            File dir = context.getCacheDir();
+            deleteDir(dir);
+        } catch (Exception ignored) {}
+    }
+
+    public static boolean deleteDir(File dir) {
+        if (dir != null && dir.isDirectory()) {
+            String[] children = dir.list();
+            if (children != null) {
+                for (String child : children) {
+                    boolean success = deleteDir(new File(dir, child));
+                    if (!success) {
+                        return false;
+                    }
+                }
+            }
+            return dir.delete();
+        } else if (dir!= null && dir.isFile()) {
+            return dir.delete();
+        } else {
+            return false;
+        }
+    }
 }

--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
@@ -15,7 +15,6 @@ public class WebViewSettingsPlugin extends Plugin {
     @Override
     public void load() {
         WebView webView = getBridge().getWebView();
-//        webView.clearCache(true);
 
         WebSettings settings = webView.getSettings();
         settings.setGeolocationEnabled(false);
@@ -31,40 +30,10 @@ public class WebViewSettingsPlugin extends Plugin {
      * Clean the RAM cache used by the webView including cache files on:
      * app/cache/WebView/* folder. Called when the app is no longer visible
      * to the user, as onDestroy is not called every time the app exit.
-     * TODO Clean app cache folder too? test the whole app with this change!
      */
     @Override
     public void handleOnStop() {
         super.handleOnStop();
         WebView webView = getBridge().getWebView();
         webView.clearCache(true);
-//        deleteCache(getContext());
-        Log.e("CLEANCACHE", "done!");
     }
-
-    public static void deleteCache(Context context) {
-        try {
-            File dir = context.getCacheDir();
-            deleteDir(dir);
-        } catch (Exception ignored) {}
-    }
-
-    public static boolean deleteDir(File dir) {
-        if (dir != null && dir.isDirectory()) {
-            String[] children = dir.list();
-            if (children != null) {
-                for (String child : children) {
-                    boolean success = deleteDir(new File(dir, child));
-                    if (!success) {
-                        return false;
-                    }
-                }
-            }
-            return dir.delete();
-        } else if (dir!= null && dir.isFile()) {
-            return dir.delete();
-        } else {
-            return false;
-        }
-    }
-}

--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
@@ -1,0 +1,25 @@
+package org.iota.firefly.mobile.alpha;
+
+import android.util.Log;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
+import com.getcapacitor.Plugin;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "WebViewSettings")
+public class WebViewSettingsPlugin extends Plugin {
+    @Override
+    public void load() {
+        WebView webView = getBridge().getWebView();
+        WebSettings settings = webView.getSettings();
+
+        settings.setGeolocationEnabled(false);
+        settings.setAllowFileAccess(false);
+        settings.setAllowContentAccess(false);
+        settings.setDatabaseEnabled(false);
+        settings.setAppCacheEnabled(false);
+        settings.setJavaScriptCanOpenWindowsAutomatically(false);
+        settings.setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
+    }
+}


### PR DESCRIPTION
## Summary
This PR implement a Capacitor plugin inside the Android project folder to set default settings on webview and delete webview cache at the activity stop state.

### Changelog
```
- Implement "internal" Capacitor plugin only for Android to set default webview settings.
- Implement clean webview cache at `Stop` activity state change.
```

## Relevant Issues
Remember close manually

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [x] __New__ - a change which implements a new feature

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [x] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
