### PR TITLE
refactor: change syncing to per account

### DIFF
--- a/packages/backend/bindings/node/index.ts
+++ b/packages/backend/bindings/node/index.ts
@@ -3,7 +3,7 @@ import {
     AccountToCreate,
     AccountIdentifier,
     ListMessagesFilter,
-    SyncAccountOptions,
+    AccountSyncOptions,
     createAccount as _createAccount,
     removeAccount as _removeAccount,
     getAccount as _getAccount,
@@ -214,7 +214,7 @@ export const api = {
     },
     syncAccount: function (
         accountId: AccountIdentifier,
-        options?: SyncAccountOptions
+        options?: AccountSyncOptions
     ): (__ids: CommunicationIds) => Promise<string> {
         return (__ids: CommunicationIds) => _syncAccount(sendMessage, __ids, accountId, options)
     },

--- a/packages/mobile/capacitor/walletPluginApi.ts
+++ b/packages/mobile/capacitor/walletPluginApi.ts
@@ -21,7 +21,7 @@ import {
     startBackgroundSync as _startBackgroundSync,
     stopBackgroundSync as _stopBackgroundSync,
     syncAccount as _syncAccount,
-    SyncAccountOptions,
+    AccountSyncOptions,
     syncAccounts as _syncAccounts,
 } from '@lib/typings/account'
 import { BridgeMessage, CommunicationIds, MessageResponse } from '@lib/typings/bridge'
@@ -188,7 +188,7 @@ export const api = {
         (__ids) =>
             _latestAddress(sendMessage, __ids, accountId),
     syncAccount:
-        (accountId: AccountIdentifier, options?: SyncAccountOptions): Api =>
+        (accountId: AccountIdentifier, options?: AccountSyncOptions): Api =>
         (__ids) =>
             _syncAccount(sendMessage, __ids, accountId, options),
     isLatestAddressUnused:

--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { AccountSwitcherModal, Icon, Text, Modal } from 'shared/components'
     import { activeProfile, getColor, updateProfile } from '@lib/profile'
-    import { selectedAccount } from '@lib/wallet'
+    import { selectedAccountStore } from '@lib/wallet'
     import { WalletAccount } from '@lib/typings/wallet'
 
     export let accounts: WalletAccount[] = []
@@ -11,7 +11,7 @@
     let isModalOpened: boolean
 
     let lastSelectedAccount: WalletAccount = null
-    $: if ($selectedAccount) lastSelectedAccount = $selectedAccount
+    $: if ($selectedAccountStore) lastSelectedAccount = $selectedAccountStore
 
     function onClick() {
         modal?.toggle()

--- a/packages/shared/components/StakingAssetTile.svelte
+++ b/packages/shared/components/StakingAssetTile.svelte
@@ -27,7 +27,7 @@
     import { getBestTimeDuration } from 'shared/lib/time'
     import { formatUnitBestMatch } from 'shared/lib/units'
     import { capitalize } from 'shared/lib/utils'
-    import { selectedAccount } from 'shared/lib/wallet'
+    import { selectedAccountStore } from 'shared/lib/wallet'
 
     export let asset: Asset
 
@@ -78,7 +78,7 @@
     }
 
     function getAccount(accounts: WalletAccount[]): WalletAccount {
-        return accounts?.find((account) => account.alias === $selectedAccount?.alias)
+        return accounts?.find((account) => account.alias === $selectedAccountStore?.alias)
     }
 
     function getLocalizedTooltipText(): TooltipText {
@@ -103,7 +103,7 @@
                         }),
                     ],
                 }
-            } else if (!isAccountStaked($selectedAccount?.id) && isStakingPossible(stakingEventState)) {
+            } else if (!isAccountStaked($selectedAccountStore?.id) && isStakingPossible(stakingEventState)) {
                 const timeNeeded = getTimeUntilMinimumAirdropReward(airdrop)
                 const _getBody = () => {
                     if (timeNeeded) {

--- a/packages/shared/components/modals/AccountActions.svelte
+++ b/packages/shared/components/modals/AccountActions.svelte
@@ -7,7 +7,7 @@
     import { activeProfile, updateProfile } from 'shared/lib/profile'
     import { accountRouter, resetWalletRoute } from '@core/router'
     import { AccountRoute } from '@core/router/enums'
-    import { asyncRemoveWalletAccount, setSelectedAccount, selectedAccount, wallet } from 'shared/lib/wallet'
+    import { asyncRemoveWalletAccount, setSelectedAccount, selectedAccountStore, wallet } from 'shared/lib/wallet'
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import { SettingsIcons } from 'shared/lib/typings/icons'
 
@@ -18,11 +18,11 @@
     const viewableAccounts = getContext<Readable<WalletAccount[]>>('viewableAccounts')
     const hiddenAccounts = $activeProfile?.hiddenAccounts ?? []
 
-    const hidden = hiddenAccounts.includes($selectedAccount?.id)
+    const hidden = hiddenAccounts.includes($selectedAccountStore?.id)
     const canDelete =
-        $selectedAccount.index === $accounts.length - 1 &&
-        $selectedAccount.rawIotaBalance === 0 &&
-        $selectedAccount.messages.length === 0
+        $selectedAccountStore.index === $accounts.length - 1 &&
+        $selectedAccountStore.rawIotaBalance === 0 &&
+        $selectedAccountStore.messages.length === 0
 
     const handleCustomiseAccountClick = () => {
         $accountRouter.goTo(AccountRoute.Manage)
@@ -30,12 +30,12 @@
     }
 
     const handleViewAddressHistoryClick = () => {
-        openPopup({ type: 'addressHistory', props: { account: selectedAccount } })
+        openPopup({ type: 'addressHistory', props: { account: selectedAccountStore } })
         modal.close()
     }
 
     function handleExportTransactionHistoryClick() {
-        openPopup({ type: 'exportTransactionHistory', props: { account: selectedAccount }, hideClose: false })
+        openPopup({ type: 'exportTransactionHistory', props: { account: selectedAccountStore }, hideClose: false })
         modal.close()
     }
 
@@ -43,7 +43,7 @@
         openPopup({
             type: 'hideAccount',
             props: {
-                account: selectedAccount,
+                account: selectedAccountStore,
                 hasMultipleAccounts: $viewableAccounts.length > 1,
                 hideAccount: (id: string) => {
                     if (!hiddenAccounts.includes(id)) {
@@ -52,7 +52,8 @@
                     }
                     resetWalletRoute()
                     const nextSelectedAccount =
-                        $viewableAccounts[$selectedAccount?.index] ?? $viewableAccounts[$viewableAccounts.length - 1]
+                        $viewableAccounts[$selectedAccountStore?.index] ??
+                        $viewableAccounts[$viewableAccounts.length - 1]
                     setSelectedAccount(nextSelectedAccount?.id)
                 },
             },
@@ -64,10 +65,10 @@
         openPopup({
             type: 'deleteAccount',
             props: {
-                account: selectedAccount,
+                account: selectedAccountStore,
                 hasMultipleAccounts: $viewableAccounts.length > 1,
                 deleteAccount: async (id: string) => {
-                    await asyncRemoveWalletAccount(get(selectedAccount).id)
+                    await asyncRemoveWalletAccount(get(selectedAccountStore).id)
 
                     if (!hiddenAccounts.includes(id)) {
                         hiddenAccounts.push(id)
@@ -82,7 +83,7 @@
     }
 
     const handleShowAccountClick = () => {
-        const idx = hiddenAccounts.indexOf($selectedAccount?.id)
+        const idx = hiddenAccounts.indexOf($selectedAccountStore?.id)
         if (idx >= 0) {
             hiddenAccounts.splice(idx, 1)
             updateProfile('hiddenAccounts', hiddenAccounts)

--- a/packages/shared/components/modals/AccountSwitcher.svelte
+++ b/packages/shared/components/modals/AccountSwitcher.svelte
@@ -1,4 +1,5 @@
 <script lang="typescript">
+    import { HR, Icon, Modal, Text } from 'shared/components'
     import { localize } from '@core/i18n'
     import { resetAccountRouter } from '@core/router'
     import { showAppNotification } from '@lib/notifications'
@@ -6,8 +7,13 @@
     import { openPopup } from '@lib/popup'
     import { activeProfile, getColor } from '@lib/profile'
     import { WalletAccount } from '@lib/typings/wallet'
-    import { isSyncing, isTransferring, selectedAccountStore, setSelectedAccount, wallet } from '@lib/wallet'
-    import { HR, Icon, Modal, Text } from 'shared/components'
+    import {
+        isTransferring,
+        selectedAccountStore,
+        setSelectedAccount,
+        updateAccountSyncingQueue,
+        wallet,
+    } from '@lib/wallet'
 
     export let accounts: WalletAccount[] = []
     export let onCreateAccount = (..._: any[]): void => {}
@@ -16,14 +22,13 @@
     const { balanceOverview } = $wallet
 
     function handleAccountClick(accountId: string): void {
-        if ($isSyncing) {
-            showWarning(localize('notifications.syncing'))
-        } else if ($isTransferring) {
+        if ($isTransferring) {
             showWarning(localize('notifications.transferring'))
         } else if ($participationAction) {
             showWarning(localize('notifications.participating'))
         } else {
             setSelectedAccount(accountId)
+            updateAccountSyncingQueue($selectedAccountStore)
             resetAccountRouter(false)
             modal?.close()
         }

--- a/packages/shared/components/modals/AccountSwitcher.svelte
+++ b/packages/shared/components/modals/AccountSwitcher.svelte
@@ -6,7 +6,7 @@
     import { openPopup } from '@lib/popup'
     import { activeProfile, getColor } from '@lib/profile'
     import { WalletAccount } from '@lib/typings/wallet'
-    import { isSyncing, isTransferring, selectedAccount, setSelectedAccount, wallet } from '@lib/wallet'
+    import { isSyncing, isTransferring, selectedAccountStore, setSelectedAccount, wallet } from '@lib/wallet'
     import { HR, Icon, Modal, Text } from 'shared/components'
 
     export let accounts: WalletAccount[] = []
@@ -52,11 +52,11 @@
                 >
                     <div class="flex flex-row items-center space-x-4">
                         <div class="circle" style="--account-color: {getColor($activeProfile, account.id)};" />
-                        <Text classes={account.id !== $selectedAccount?.id ? 'opacity-50' : ''} type="h5">
+                        <Text classes={account.id !== $selectedAccountStore?.id ? 'opacity-50' : ''} type="h5">
                             {account.alias}
                         </Text>
                     </div>
-                    <Text classes={account.id !== $selectedAccount?.id ? 'opacity-50' : ''} type="h5">
+                    <Text classes={account.id !== $selectedAccountStore?.id ? 'opacity-50' : ''} type="h5">
                         {account.balance}
                     </Text>
                 </button>

--- a/packages/shared/components/popups/NewStakingPeriodNotification.svelte
+++ b/packages/shared/components/popups/NewStakingPeriodNotification.svelte
@@ -4,7 +4,7 @@
     import { assemblyStakingEventState, shimmerStakingEventState } from '@lib/participation/stores'
     import { AccountParticipationAbility } from '@lib/participation/types'
     import { closePopup, openPopup } from '@lib/popup'
-    import { selectedAccount } from '@lib/wallet'
+    import { selectedAccountStore } from '@lib/wallet'
     import { Button, Illustration, Text, TextHint } from 'shared/components'
     import { ASSEMBLY_EVENT_START_DATE, isStakingPossible, LAST_ASSEMBLY_STAKING_PERIOD } from '@lib/participation'
 
@@ -21,7 +21,7 @@
         const isStakingPossibleForAssembly = isStakingPossible($assemblyStakingEventState)
         const isStakingPossibleForShimmer = isStakingPossible($shimmerStakingEventState)
         const cannotStake =
-            getAccountParticipationAbility($selectedAccount) === AccountParticipationAbility.HasDustAmount
+            getAccountParticipationAbility($selectedAccountStore) === AccountParticipationAbility.HasDustAmount
 
         if ((isStakingPossibleForAssembly || isStakingPossibleForShimmer) && !cannotStake) {
             openPopup({

--- a/packages/shared/components/popups/StakingConfirmation.svelte
+++ b/packages/shared/components/popups/StakingConfirmation.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { selectedAccount } from 'shared/lib/wallet'
+    import { selectedAccountStore } from 'shared/lib/wallet'
     import { Button, Checkbox, Icon, Text, Tooltip } from 'shared/components'
     import { ledgerDeviceState } from 'shared/lib/ledger'
     import { showAppNotification } from 'shared/lib/notifications'
@@ -65,7 +65,7 @@
     }
 
     function canReachAirdropMinimum(airdrop: StakingAirdrop): boolean {
-        return canAccountReachMinimumAirdrop($selectedAccount, airdrop)
+        return canAccountReachMinimumAirdrop($selectedAccountStore, airdrop)
     }
 
     function getRewards(airdrop: StakingAirdrop): string {
@@ -74,7 +74,7 @@
         }
         return estimateStakingAirdropReward(
             airdrop,
-            $isPartiallyStaked ? getUnstakedFunds() : $selectedAccount?.rawIotaBalance,
+            $isPartiallyStaked ? getUnstakedFunds() : $selectedAccountStore?.rawIotaBalance,
             true
         )
     }
@@ -154,7 +154,7 @@
         {localize(`popups.stakingConfirmation.subtitle${$isPartiallyStaked ? 'Merge' : 'Stake'}`)}
     </Text>
     <Text type="h1">
-        {$isPartiallyStaked ? formatUnitBestMatch(getUnstakedFunds()) : $selectedAccount.balance}
+        {$isPartiallyStaked ? formatUnitBestMatch(getUnstakedFunds()) : $selectedAccountStore.balance}
     </Text>
 </div>
 {#if showInfoText()}

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -38,7 +38,7 @@
     import { NodePlugin } from 'shared/lib/typings/node'
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import { formatUnitBestMatch } from 'shared/lib/units'
-    import { selectedAccount, selectedAccountId, transferState, wallet } from 'shared/lib/wallet'
+    import { selectedAccountStore, selectedAccountId, transferState, wallet } from 'shared/lib/wallet'
     import { localize } from '@core/i18n'
 
     export let shouldParticipateOnMount = false
@@ -48,13 +48,13 @@
     let previousPendingParticipationsLength = 0
     let { accounts } = $wallet
 
-    $: participationAbility = getAccountParticipationAbility($selectedAccount)
+    $: participationAbility = getAccountParticipationAbility($selectedAccountStore)
     $: canStake = canParticipate($assemblyStakingEventState) || canParticipate($shimmerStakingEventState)
 
     $: $participationOverview, resetAccounts()
-    $: $stakedAccounts, $selectedAccount, async () => getParticipationOverview(ASSEMBLY_EVENT_ID)
+    $: $stakedAccounts, $selectedAccountStore, async () => getParticipationOverview(ASSEMBLY_EVENT_ID)
 
-    $: isCurrentAccountStaked = isAccountStaked($selectedAccount?.id)
+    $: isCurrentAccountStaked = isAccountStaked($selectedAccountStore?.id)
 
     function resetAccounts(): void {
         /**
@@ -117,7 +117,7 @@
 
         switch ($participationAction) {
             case ParticipationAction.Stake: {
-                await participate($selectedAccount?.id, participations)
+                await participate($selectedAccountStore?.id, participations)
                     .then((messageIds) => _sync(messageIds))
                     .catch((err) => {
                         console.error(err)
@@ -128,7 +128,7 @@
                 break
             }
             case ParticipationAction.Unstake:
-                await stopParticipating($selectedAccount?.id, STAKING_EVENT_IDS)
+                await stopParticipating($selectedAccountStore?.id, STAKING_EVENT_IDS)
                     .then((messageIds) => _sync(messageIds))
                     .catch((err) => {
                         console.error(err)
@@ -263,9 +263,9 @@
                     </div>
                 {:else if participationAbility === AccountParticipationAbility.WillNotReachMinAirdrop}
                     <div
-                        bind:this={tooltipAnchors[$selectedAccount?.index]}
-                        on:mouseenter={() => toggleTooltip($selectedAccount)}
-                        on:mouseleave={() => toggleTooltip($selectedAccount)}
+                        bind:this={tooltipAnchors[$selectedAccountStore?.index]}
+                        on:mouseenter={() => toggleTooltip($selectedAccountStore)}
+                        on:mouseleave={() => toggleTooltip($selectedAccountStore)}
                     >
                         <Icon icon="exclamation" width="20" height="20" classes="text-orange-500" />
                     </div>
@@ -287,7 +287,7 @@
                         disabled={$isPerformingParticipation ||
                             participationAbility === AccountParticipationAbility.HasPendingTransaction}
                     >
-                        {$selectedAccount.alias}
+                        {$selectedAccountStore.alias}
                     </Text>
                     {#if $isPartiallyStaked}
                         <Text
@@ -297,7 +297,7 @@
                                 participationAbility === AccountParticipationAbility.HasPendingTransaction}
                             classes="font-extrabold"
                         >
-                            {$isPartiallyStaked ? formatUnitBestMatch(getStakedFunds()) : $selectedAccount.balance}
+                            {$isPartiallyStaked ? formatUnitBestMatch(getStakedFunds()) : $selectedAccountStore.balance}
                             •
                             <Text
                                 type="p"
@@ -308,7 +308,7 @@
                             >
                                 {$isPartiallyStaked
                                     ? getFormattedFiatAmount(getStakedFunds())
-                                    : $selectedAccount.balanceEquiv}
+                                    : $selectedAccountStore.balanceEquiv}
                             </Text>
                         </Text>
                     {:else}
@@ -319,7 +319,7 @@
                                 participationAbility === AccountParticipationAbility.HasPendingTransaction}
                             classes="font-extrabold"
                         >
-                            {$selectedAccount.balance}
+                            {$selectedAccountStore.balance}
                             •
                             <Text
                                 type="p"
@@ -328,7 +328,7 @@
                                     participationAbility === AccountParticipationAbility.HasPendingTransaction}
                                 classes="inline"
                             >
-                                {$selectedAccount.balanceEquiv}
+                                {$selectedAccountStore.balanceEquiv}
                             </Text>
                         </Text>
                     {/if}

--- a/packages/shared/components/popups/StakingManager.svelte
+++ b/packages/shared/components/popups/StakingManager.svelte
@@ -38,7 +38,7 @@
     import { NodePlugin } from 'shared/lib/typings/node'
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import { formatUnitBestMatch } from 'shared/lib/units'
-    import { selectedAccountStore, selectedAccountId, transferState, wallet } from 'shared/lib/wallet'
+    import { selectedAccountStore, selectedAccountIdStore, transferState, wallet } from 'shared/lib/wallet'
     import { localize } from '@core/i18n'
 
     export let shouldParticipateOnMount = false

--- a/packages/shared/lib/assets.ts
+++ b/packages/shared/lib/assets.ts
@@ -6,7 +6,7 @@ import { activeProfile } from 'shared/lib/profile'
 import { Asset, Token } from 'shared/lib/typings/assets'
 import { AvailableExchangeRates, CurrencyTypes } from 'shared/lib/typings/currency'
 import { UNIT_MAP } from 'shared/lib/units'
-import { selectedAccount } from 'shared/lib/wallet'
+import { selectedAccountStore } from 'shared/lib/wallet'
 import { derived } from 'svelte/store'
 import { StakingAirdrop } from 'shared/lib/participation/types'
 
@@ -15,7 +15,7 @@ export const assets = derived(
         exchangeRates,
         currencies,
         activeProfile,
-        selectedAccount,
+        selectedAccountStore,
         totalAssemblyStakingRewards,
         totalShimmerStakingRewards,
     ],

--- a/packages/shared/lib/errors.ts
+++ b/packages/shared/lib/errors.ts
@@ -1,8 +1,25 @@
 import { persistent } from 'shared/lib/helpers'
 import { Error } from './typings/error'
+import { ErrorEventPayload } from '@lib/typings/events'
+import { get } from 'svelte/store'
+import { isLedgerProfile } from '@lib/profile'
+import { displayNotificationForLedgerProfile } from '@lib/ledger'
+import { showAppNotification } from '@lib/notifications'
+import { localize } from '@core/i18n'
 
 export const errorLog = persistent<Error[]>('errorLog', [])
 
 export const addError = (err: Error): void => {
     errorLog.update((log) => [err, ...log])
+}
+
+export function displayErrorEventToUser(error: ErrorEventPayload): void {
+    if (get(isLedgerProfile)) {
+        displayNotificationForLedgerProfile('error', true, true, false, false, error)
+    } else {
+        showAppNotification({
+            type: 'error',
+            message: localize(error.error),
+        })
+    }
 }

--- a/packages/shared/lib/networkStatus.ts
+++ b/packages/shared/lib/networkStatus.ts
@@ -43,8 +43,6 @@ export function clearPollNetworkInterval(): void {
 }
 
 async function pollNetworkStatusInternal(): Promise<void> {
-    let updated = false
-
     const accs = get(get(wallet).accounts)
 
     if (accs.length > 0) {
@@ -66,22 +64,9 @@ async function pollNetworkStatusInternal(): Promise<void> {
 
         try {
             await updateNetworkStatus(account0.id, node)
-
-            updated = true
         } catch (err) {
             console.error(err.name === 'AbortError' ? new Error(`Could not fetch from ${node.url}.`) : err)
         }
-    }
-
-    if (!updated) {
-        networkStatus.set({
-            messagesPerSecond: 0,
-            referencedRate: 0,
-            health: 0,
-            healthText: NetworkStatusHealthText.Down,
-            currentMilestone: -1,
-            nodePlugins: [],
-        })
     }
 }
 

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -8,7 +8,7 @@ import { MILLISECONDS_PER_SECOND, SECONDS_PER_MILESTONE } from '../time'
 import { WalletAccount } from '../typings/wallet'
 import { formatUnitBestMatch } from '../units'
 import { clamp, delineateNumber, getJsonRequestOptions, range } from '../utils'
-import { selectedAccount, wallet } from '../wallet'
+import { selectedAccountStore, wallet } from '../wallet'
 import { addError } from 'shared/lib/errors'
 
 import {
@@ -356,7 +356,7 @@ const calculateTimeUntilMinimumReward = (rewards: number, airdrop: StakingAirdro
  */
 export const getTimeUntilMinimumAirdropReward = (airdrop: StakingAirdrop): number => {
     const rewards = getCurrentRewardsForAirdrop(airdrop)
-    const amountStaked = get(selectedAccount)?.rawIotaBalance
+    const amountStaked = get(selectedAccountStore)?.rawIotaBalance
     return calculateTimeUntilMinimumReward(rewards, airdrop, amountStaked)
 }
 

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -2,7 +2,7 @@ import { derived, get, Readable, writable } from 'svelte/store'
 import { networkStatus } from '../networkStatus'
 import { NodePlugin } from '../typings/node'
 import { MILLISECONDS_PER_SECOND, SECONDS_PER_MILESTONE } from '../time'
-import { selectedAccountStore, selectedAccountId, wallet } from '../wallet'
+import { selectedAccountStore, selectedAccountIdStore, wallet } from '../wallet'
 import { WalletAccount } from '../typings/wallet'
 
 import { ASSEMBLY_EVENT_ID, SHIMMER_EVENT_ID } from './constants'
@@ -205,7 +205,7 @@ export const currentAssemblyStakingRewardsBelowMinimum: Readable<number> = deriv
  * The total accumulated Assembly rewards for the selected account.
  */
 export const totalAssemblyStakingRewards: Readable<number> = derived(
-    [currentAssemblyStakingRewards, selectedAccountId],
+    [currentAssemblyStakingRewards, selectedAccountIdStore],
     ([$currentAssemblyStakingRewards, $selectedAccountId]) =>
         $currentAssemblyStakingRewards + getCachedStakingRewards(StakingAirdrop.Assembly, $selectedAccountId)
 )
@@ -236,7 +236,7 @@ export const currentShimmerStakingRewardsBelowMinimum: Readable<number> = derive
  * The total accumulated Shimmer rewards for the selected account.
  */
 export const totalShimmerStakingRewards: Readable<number> = derived(
-    [currentShimmerStakingRewards, selectedAccountId],
+    [currentShimmerStakingRewards, selectedAccountIdStore],
     ([$currentShimmerStakingRewards, $selectedAccountId]) =>
         $currentShimmerStakingRewards + getCachedStakingRewards(StakingAirdrop.Shimmer, $selectedAccountId)
 )

--- a/packages/shared/lib/participation/stores.ts
+++ b/packages/shared/lib/participation/stores.ts
@@ -2,7 +2,7 @@ import { derived, get, Readable, writable } from 'svelte/store'
 import { networkStatus } from '../networkStatus'
 import { NodePlugin } from '../typings/node'
 import { MILLISECONDS_PER_SECOND, SECONDS_PER_MILESTONE } from '../time'
-import { selectedAccount, selectedAccountId, wallet } from '../wallet'
+import { selectedAccountStore, selectedAccountId, wallet } from '../wallet'
 import { WalletAccount } from '../typings/wallet'
 
 import { ASSEMBLY_EVENT_ID, SHIMMER_EVENT_ID } from './constants'
@@ -71,7 +71,7 @@ export const stakedAccounts: Readable<WalletAccount[]> = derived(
 )
 
 export const selectedAccountParticipationOverview = derived(
-    [participationOverview, selectedAccount],
+    [participationOverview, selectedAccountStore],
     ([$participationOverview, $selectedAccount]) =>
         $participationOverview?.find(({ accountIndex }) => accountIndex === $selectedAccount?.index) ?? null
 )

--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -9,7 +9,7 @@ import {
     getProfileDataPath,
     getWalletDataPath,
     AccountColors,
-    selectedAccountId,
+    selectedAccountIdStore,
 } from 'shared/lib/wallet'
 import { Platform } from './platform'
 import { ProfileType } from './typings/profile'
@@ -46,7 +46,7 @@ activeProfileId.subscribe((profileId) => {
     Platform.updateActiveProfile(profileId)
 })
 
-selectedAccountId?.subscribe((accountId) => {
+selectedAccountIdStore?.subscribe((accountId) => {
     if (accountId) {
         updateProfile('lastUsedAccountId', accountId)
     }

--- a/packages/shared/lib/typings/account.ts
+++ b/packages/shared/lib/typings/account.ts
@@ -20,7 +20,7 @@ export interface ListMessagesFilter {
     from: number
 }
 
-export interface SyncAccountOptions {
+export interface AccountSyncOptions {
     addressIndex?: number
     gapLimit?: number
     accountDiscoveryThreshold?: number
@@ -265,7 +265,7 @@ export function syncAccount(
     bridge: Bridge,
     __ids: CommunicationIds,
     accountId: AccountIdentifier,
-    options?: SyncAccountOptions
+    options?: AccountSyncOptions
 ): Promise<string> {
     return _callAccountMethod(bridge, __ids, AccountMethod.SyncAccount, accountId, options || {})
 }

--- a/packages/shared/lib/typings/account.ts
+++ b/packages/shared/lib/typings/account.ts
@@ -27,7 +27,7 @@ export interface SyncAccountOptions {
     skipPersistance?: boolean
 }
 
-export interface Account {
+export type Account = {
     id: string
     alias: string
     createdAt: string
@@ -38,6 +38,13 @@ export interface Account {
     storagePath: string
     messages: Message[]
     addresses: Address[]
+}
+
+export type AccountMetadata = {
+    balance: number
+    incoming: number
+    outgoing: number
+    depositAddress: string
 }
 
 export type AccountIdentifier = number | string

--- a/packages/shared/lib/typings/walletApi.ts
+++ b/packages/shared/lib/typings/walletApi.ts
@@ -66,15 +66,15 @@ export interface IWalletApi {
         onSuccess: (response: Event<StrongholdStatus>) => void
         onError: (err: ErrorEventPayload) => void
     })
+    syncAccount(
+        accountId: string,
+        callbacks: { onSuccess: (response: Event<SyncedAccount>) => void; onError: (err: ErrorEventPayload) => void }
+    )
     syncAccounts(
         addressIndex: number,
         gapLimit: number,
         accountDiscoveryThreshold: number,
         callbacks: { onSuccess: (response: Event<SyncedAccount[]>) => void; onError: (err: ErrorEventPayload) => void }
-    )
-    syncAccount(
-        accountId: string,
-        callbacks: { onSuccess: (response: Event<void>) => void; onError: (err: ErrorEventPayload) => void }
     )
     startBackgroundSync(
         pollingInterval: Duration,

--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -29,6 +29,7 @@ import resolveConfig from 'tailwindcss/resolveConfig'
 import tailwindConfig from 'shared/tailwind.config.js'
 import { setProfileAccount } from 'shared/lib/profile'
 import { sleep } from '@lib/utils'
+import { displayErrorEventToUser } from '@lib/errors'
 
 const configColors = resolveConfig(tailwindConfig).theme.colors
 
@@ -501,17 +502,6 @@ export async function processAccountSyncingQueue(): Promise<void> {
     }
 }
 
-function displayErrorToUser(error: ErrorEventPayload) {
-    if (get(isLedgerProfile)) {
-        displayNotificationForLedgerProfile('error', true, true, false, false, error)
-    } else {
-        showAppNotification({
-            type: 'error',
-            message: localize(error.error),
-        })
-    }
-}
-
 export function asyncSyncAccount(account: WalletAccount, showErrorNotification: boolean = true): Promise<void> {
     return new Promise((resolve, reject) => {
         currentSyncingAccountStore.set(account)
@@ -538,7 +528,7 @@ export function asyncSyncAccount(account: WalletAccount, showErrorNotification: 
                 currentSyncingAccountStore.set(null)
 
                 if (showErrorNotification) {
-                    displayErrorToUser(err)
+                    displayErrorEventToUser(err)
                 }
 
                 console.error(err)
@@ -582,7 +572,7 @@ export const asyncSyncAccounts = (
                 isSyncing.set(false)
 
                 if (showErrorNotification) {
-                    displayErrorToUser(err)
+                    displayErrorEventToUser(err)
                 }
 
                 console.error(err)

--- a/packages/shared/lib/walletApiListeners.ts
+++ b/packages/shared/lib/walletApiListeners.ts
@@ -2,7 +2,7 @@ import { formatUnitBestMatch } from 'shared/lib/units'
 import {
     addMessagesPair,
     api,
-    getAccountMeta,
+    getAccountMetadata,
     prepareAccountInfo,
     processMigratedTransactions,
     replaceMessage,
@@ -248,7 +248,7 @@ export const initialiseListeners = (): void => {
                     // 3. Only update the account for which the balance change event emitted;
                     // 4. Update balance overview & accounts
                     for (const _account of response.payload) {
-                        getAccountMeta(_account.id, (metaErr, meta) => {
+                        getAccountMetadata(_account.id, (metaErr, meta) => {
                             if (!metaErr) {
                                 // Compute balance overview for each account
                                 totalBalance.balance += meta.balance

--- a/packages/shared/lib/walletApiListeners.ts
+++ b/packages/shared/lib/walletApiListeners.ts
@@ -3,7 +3,7 @@ import {
     aggregateAccountActivity,
     api,
     getAccountMetadataWithCallback,
-    prepareAccountAsWalletAccount,
+    formatAccountWithMetadata,
     processMigratedTransactions,
     replaceMessage,
     saveNewMessage,
@@ -257,7 +257,7 @@ export const initialiseListeners = (): void => {
 
                                 aggregateAccountActivity(_account)
 
-                                const updatedAccountInfo = prepareAccountAsWalletAccount(_account, meta)
+                                const updatedAccountInfo = formatAccountWithMetadata(_account, meta)
 
                                 // Keep the messages as is because they get updated through a different event
                                 // Also, we create pairs for internal messages, so best to keep those rather than reimplementing the logic here

--- a/packages/shared/lib/walletApiListeners.ts
+++ b/packages/shared/lib/walletApiListeners.ts
@@ -1,6 +1,6 @@
 import { formatUnitBestMatch } from 'shared/lib/units'
 import {
-    aggregateWalletActivity,
+    aggregateAccountActivity,
     api,
     getAccountMetadataWithCallback,
     prepareAccountAsWalletAccount,
@@ -255,7 +255,7 @@ export const initialiseListeners = (): void => {
                                 totalBalance.incoming += meta.incoming
                                 totalBalance.outgoing += meta.outgoing
 
-                                aggregateWalletActivity(_account)
+                                aggregateAccountActivity(_account)
 
                                 const updatedAccountInfo = prepareAccountAsWalletAccount(_account, meta)
 

--- a/packages/shared/lib/walletApiListeners.ts
+++ b/packages/shared/lib/walletApiListeners.ts
@@ -1,9 +1,9 @@
 import { formatUnitBestMatch } from 'shared/lib/units'
 import {
-    addMessagesPair,
+    aggregateWalletActivity,
     api,
     getAccountMetadata,
-    prepareAccountInfo,
+    prepareAccountAsWalletAccount,
     processMigratedTransactions,
     replaceMessage,
     saveNewMessage,
@@ -255,9 +255,9 @@ export const initialiseListeners = (): void => {
                                 totalBalance.incoming += meta.incoming
                                 totalBalance.outgoing += meta.outgoing
 
-                                addMessagesPair(_account)
+                                aggregateWalletActivity(_account)
 
-                                const updatedAccountInfo = prepareAccountInfo(_account, meta)
+                                const updatedAccountInfo = prepareAccountAsWalletAccount(_account, meta)
 
                                 // Keep the messages as is because they get updated through a different event
                                 // Also, we create pairs for internal messages, so best to keep those rather than reimplementing the logic here

--- a/packages/shared/lib/walletApiListeners.ts
+++ b/packages/shared/lib/walletApiListeners.ts
@@ -2,7 +2,7 @@ import { formatUnitBestMatch } from 'shared/lib/units'
 import {
     aggregateWalletActivity,
     api,
-    getAccountMetadata,
+    getAccountMetadataWithCallback,
     prepareAccountAsWalletAccount,
     processMigratedTransactions,
     replaceMessage,
@@ -248,7 +248,7 @@ export const initialiseListeners = (): void => {
                     // 3. Only update the account for which the balance change event emitted;
                     // 4. Update balance overview & accounts
                     for (const _account of response.payload) {
-                        getAccountMetadata(_account.id, (metaErr, meta) => {
+                        getAccountMetadataWithCallback(_account.id, (metaErr, meta) => {
                             if (!metaErr) {
                                 // Compute balance overview for each account
                                 totalBalance.balance += meta.balance

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -37,7 +37,7 @@
     import {
         api,
         asyncCreateAccount,
-        asyncSyncAccountOffline,
+        asyncSyncAccount,
         isBackgroundSyncing,
         isFirstSessionSync,
         isSyncing,
@@ -305,7 +305,7 @@
         const _create = async (): Promise<unknown> => {
             try {
                 const account = await asyncCreateAccount(alias, color)
-                await asyncSyncAccountOffline(account)
+                await asyncSyncAccount(account)
 
                 setSelectedAccount(account?.id)
                 $accountRouter.reset()

--- a/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingInfo.svelte
@@ -15,7 +15,7 @@
     } from 'shared/lib/participation/stores'
     import { ParticipationEventState } from 'shared/lib/participation/types'
     import { getBestTimeDuration } from 'shared/lib/time'
-    import { selectedAccountId } from '@lib/wallet'
+    import { selectedAccountIdStore } from '@lib/wallet'
     import { Token } from '@lib/typings/assets'
     import { ASSEMBLY_EVENT_ID, ASSEMBLY_EVENT_START_DATE, SHIMMER_EVENT_ID } from '@lib/participation'
 
@@ -48,7 +48,7 @@
         isShimmerStaked,
         stakingEventState,
         $selectedAccountParticipationOverview,
-        $selectedAccountId,
+        $selectedAccountIdStore,
         setAnimation()
 
     function setAnimation(): void {

--- a/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
+++ b/packages/shared/routes/dashboard/staking/views/StakingSummary.svelte
@@ -18,14 +18,14 @@
     import { openPopup } from 'shared/lib/popup'
     import { NodePlugin } from 'shared/lib/typings/node'
     import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
-    import { isSyncing, selectedAccount } from 'shared/lib/wallet'
+    import { isSyncing, selectedAccountStore } from 'shared/lib/wallet'
 
     $: showSpinner = !!$participationAction || $isSyncing
 
     $: canParticipateInEvent =
         isStakingPossible($assemblyStakingEventState) || isStakingPossible($shimmerStakingEventState)
 
-    $: cannotStake = getAccountParticipationAbility($selectedAccount) === AccountParticipationAbility.HasDustAmount
+    $: cannotStake = getAccountParticipationAbility($selectedAccountStore) === AccountParticipationAbility.HasDustAmount
 
     $: isStakedAndCanParticipate = $stakedAmount > 0 && canParticipateInEvent
 

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -27,7 +27,7 @@
         api,
         asyncSyncAccounts,
         getAccountMessages,
-        getAccountMetadata,
+        getAccountMetadataWithCallback,
         getAccountSyncOptions,
         hasGeneratedALedgerReceiveAddress,
         isFirstSessionSync,
@@ -132,7 +132,7 @@
                     for (const payloadAccount of accountsResponse.payload) {
                         aggregateWalletActivity(payloadAccount)
 
-                        getAccountMetadata(payloadAccount.id, (err, metadata) => {
+                        getAccountMetadataWithCallback(payloadAccount.id, (err, metadata) => {
                             if (!err) {
                                 totalBalance.balance += metadata.balance
                                 totalBalance.incoming += metadata.incoming

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -23,16 +23,16 @@
     import { Message, Transaction } from 'shared/lib/typings/message'
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import {
-        addMessagesPair,
+        aggregateWalletActivity,
         api,
         asyncSyncAccounts,
         getAccountMessages,
         getAccountMetadata,
-        getSyncAccountOptions,
+        getAccountSyncOptions,
         hasGeneratedALedgerReceiveAddress,
         isFirstSessionSync,
         isTransferring,
-        prepareAccountInfo,
+        prepareAccountAsWalletAccount,
         processMigratedTransactions,
         removeEventListeners,
         selectedAccount,
@@ -107,7 +107,7 @@
                 const _continue = async () => {
                     accountsLoaded.set(true)
 
-                    const { gapLimit, accountDiscoveryThreshold } = getSyncAccountOptions()
+                    const { gapLimit, accountDiscoveryThreshold } = getAccountSyncOptions()
 
                     try {
                         await asyncSyncAccounts(0, gapLimit, accountDiscoveryThreshold, false)
@@ -130,7 +130,7 @@
                     let completeCount = 0
                     const newAccounts = []
                     for (const payloadAccount of accountsResponse.payload) {
-                        addMessagesPair(payloadAccount)
+                        aggregateWalletActivity(payloadAccount)
 
                         getAccountMetadata(payloadAccount.id, (err, metadata) => {
                             if (!err) {
@@ -138,7 +138,7 @@
                                 totalBalance.incoming += metadata.incoming
                                 totalBalance.outgoing += metadata.outgoing
 
-                                const account = prepareAccountInfo(payloadAccount, metadata)
+                                const account = prepareAccountAsWalletAccount(payloadAccount, metadata)
                                 newAccounts.push(account)
                             } else {
                                 _onError(err)

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -27,7 +27,7 @@
         api,
         asyncSyncAccounts,
         getAccountMessages,
-        getAccountMeta,
+        getAccountMetadata,
         getSyncAccountOptions,
         hasGeneratedALedgerReceiveAddress,
         isFirstSessionSync,
@@ -79,6 +79,15 @@
         }
     }
 
+    // get the accounts, setting initial state for the store
+    // for each account...
+    // sync the account
+    // process migration transactions
+    // aggregate messages pairs / transactions
+    // prepare as WalletAccount
+    // update specific account in the store
+    // update the balance overview accordingly
+
     function loadAccounts() {
         const _onError = (error: any = null) => {
             if ($isLedgerProfile) {
@@ -123,13 +132,13 @@
                     for (const payloadAccount of accountsResponse.payload) {
                         addMessagesPair(payloadAccount)
 
-                        getAccountMeta(payloadAccount.id, (err, meta) => {
+                        getAccountMetadata(payloadAccount.id, (err, metadata) => {
                             if (!err) {
-                                totalBalance.balance += meta.balance
-                                totalBalance.incoming += meta.incoming
-                                totalBalance.outgoing += meta.outgoing
+                                totalBalance.balance += metadata.balance
+                                totalBalance.incoming += metadata.incoming
+                                totalBalance.outgoing += metadata.outgoing
 
-                                const account = prepareAccountInfo(payloadAccount, meta)
+                                const account = prepareAccountInfo(payloadAccount, metadata)
                                 newAccounts.push(account)
                             } else {
                                 _onError(err)

--- a/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountBalance.svelte
@@ -6,7 +6,7 @@
     import { accountRoute, accountRouter } from '@core/router'
     import { AccountRoute } from '@core/router/enums'
     import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
-    import { selectedAccount } from 'shared/lib/wallet'
+    import { selectedAccountStore } from 'shared/lib/wallet'
 
     export let classes = ''
 
@@ -42,12 +42,12 @@
             <div on:click={togglePreciseBalance}>
                 <h1 class="font-600 text-32 leading-120 text-gray-800 dark:text-white break-all">
                     {showPreciseBalance
-                        ? formatUnitPrecision($selectedAccount?.rawIotaBalance, Unit.Mi)
-                        : formatUnitBestMatch($selectedAccount?.rawIotaBalance, true, 3)}
+                        ? formatUnitPrecision($selectedAccountStore?.rawIotaBalance, Unit.Mi)
+                        : formatUnitBestMatch($selectedAccountStore?.rawIotaBalance, true, 3)}
                 </h1>
             </div>
             <Text type="p">
-                {$selectedAccount?.balanceEquiv}
+                {$selectedAccountStore?.balanceEquiv}
             </Text>
         </div>
     </div>

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -10,11 +10,13 @@
         isSyncing,
         getIncomingFlag,
         isFirstSessionSync,
-        selectedAccount,
+        selectedAccountStore,
         selectedMessage,
         sendAddressFromTransactionPayload,
         receiverAddressesFromTransactionPayload,
         walletSetupType,
+        accountSyncingQueueStore,
+        selectedAccountId,
     } from 'shared/lib/wallet'
     import { Transaction } from 'shared/lib/typings/message'
     import { SetupType } from 'shared/lib/typings/setup'
@@ -32,11 +34,14 @@
         selectedMessage.set(null)
     }
 
+    $: isSelectedAccountSyncing =
+        $accountSyncingQueueStore.findIndex((account) => account.id === $selectedAccountId) === 0 || $isSyncing
+
     const handleSyncAccountClick = () => {
         if (!$isSyncing) {
             const _syncAccount = () => {
                 $isSyncing = true
-                api.syncAccount($selectedAccount?.id, {
+                api.syncAccount($selectedAccountStore?.id, {
                     onSuccess() {
                         $isSyncing = false
                     },
@@ -165,14 +170,12 @@
                     {localize('general.transactions')}
                     <span class="text-gray-500 font-bold">• {queryTransactions.length}</span>
                 </Text>
-                {#if !$selectedMessage}
-                    <button on:click={handleSyncAccountClick} class:pointer-events-none={$isSyncing}>
-                        <Icon
-                            icon="refresh"
-                            classes="{$isSyncing && 'animate-spin-reverse'} text-gray-500 dark:text-white"
-                        />
-                    </button>
-                {/if}
+                <button on:click={handleSyncAccountClick} class:pointer-events-none={isSelectedAccountSyncing}>
+                    <Icon
+                        icon="refresh"
+                        classes="{isSelectedAccountSyncing && 'animate-spin-reverse'} text-gray-500 dark:text-white"
+                    />
+                </button>
             </div>
             <div class="relative flex flex-row items-center justify-between text-white mt-4">
                 <ul class="flex flex-row justify-between space-x-8">

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -16,7 +16,7 @@
         receiverAddressesFromTransactionPayload,
         walletSetupType,
         accountSyncingQueueStore,
-        selectedAccountId,
+        selectedAccountIdStore,
     } from 'shared/lib/wallet'
     import { Transaction } from 'shared/lib/typings/message'
     import { SetupType } from 'shared/lib/typings/setup'
@@ -35,7 +35,7 @@
     }
 
     $: isSelectedAccountSyncing =
-        $accountSyncingQueueStore.findIndex((account) => account.id === $selectedAccountId) === 0 || $isSyncing
+        $accountSyncingQueueStore?.findIndex((account) => account.id === $selectedAccountIdStore) === 0 || $isSyncing
 
     const handleSyncAccountClick = () => {
         if (!$isSyncing) {

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -17,6 +17,7 @@
         walletSetupType,
         accountSyncingQueueStore,
         selectedAccountIdStore,
+        currentSyncingAccountStore,
     } from 'shared/lib/wallet'
     import { Transaction } from 'shared/lib/typings/message'
     import { SetupType } from 'shared/lib/typings/setup'
@@ -34,8 +35,7 @@
         selectedMessage.set(null)
     }
 
-    $: isSelectedAccountSyncing =
-        $accountSyncingQueueStore?.findIndex((account) => account.id === $selectedAccountIdStore) === 0 || $isSyncing
+    $: isSelectedAccountSyncing = $currentSyncingAccountStore?.id === $selectedAccountIdStore || $isSyncing
 
     const handleSyncAccountClick = () => {
         if (!$isSyncing) {

--- a/packages/shared/routes/dashboard/wallet/views/BarChart.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/BarChart.svelte
@@ -2,7 +2,7 @@
     import { Chart, Text } from 'shared/components'
     import { getAccountActivityData } from 'shared/lib/chart'
     import { localize } from '@core/i18n'
-    import { selectedAccount } from 'shared/lib/wallet'
+    import { selectedAccountStore } from 'shared/lib/wallet'
 
     let chartData = {
         incoming: {},
@@ -14,8 +14,8 @@
     $: labels = chartData.labels
 
     $: {
-        if (localize || $selectedAccount) {
-            chartData = getAccountActivityData($selectedAccount)
+        if (localize || $selectedAccountStore) {
+            chartData = getAccountActivityData($selectedAccountStore)
         }
     }
 </script>

--- a/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/LineChart.svelte
@@ -14,11 +14,11 @@
     import { BalanceHistory } from 'shared/lib/typings/wallet'
     import { AvailableExchangeRates, CurrencyTypes } from 'shared/lib/typings/currency'
     import { HistoryDataProps } from 'shared/lib/typings/market'
-    import { getAccountBalanceHistory, selectedAccount } from 'shared/lib/wallet'
+    import { getAccountBalanceHistory, selectedAccountStore } from 'shared/lib/wallet'
     import { onMount } from 'svelte'
 
     let balanceHistory: BalanceHistory
-    $: $selectedAccount, $priceData, (balanceHistory = getAccountBalanceHistory($selectedAccount, $priceData))
+    $: $selectedAccountStore, $priceData, (balanceHistory = getAccountBalanceHistory($selectedAccountStore, $priceData))
 
     let chartData: ChartData = { labels: [], data: [], tooltips: [] }
     const chartTypeDropdownItems: { value: string; label: string }[] = []
@@ -39,14 +39,14 @@
 
     /** Chart data */
     $: {
-        if (localize || $selectedDashboardChart || $activeProfile?.settings.chartSelectors || $selectedAccount) {
+        if (localize || $selectedDashboardChart || $activeProfile?.settings.chartSelectors || $selectedAccountStore) {
             if ($activeProfile?.settings) {
                 // Account value chart
                 switch ($selectedWalletChart) {
                     case WalletChartType.HOLDINGS:
                         chartData = getChartDataFromBalanceHistory({
                             balanceHistory,
-                            currentBalance: $selectedAccount.rawIotaBalance,
+                            currentBalance: $selectedAccountStore.rawIotaBalance,
                             tokenType: CurrencyTypes.IOTA.toLocaleLowerCase(),
                             convertToSelectedCurrency: false,
                         })
@@ -54,7 +54,7 @@
                     case WalletChartType.PORTFOLIO:
                         chartData = getChartDataFromBalanceHistory({
                             balanceHistory,
-                            currentBalance: $selectedAccount.rawIotaBalance,
+                            currentBalance: $selectedAccountStore.rawIotaBalance,
                             tokenType: CurrencyTypes.IOTA.toLocaleLowerCase(),
                             convertToSelectedCurrency: true,
                         })
@@ -117,7 +117,7 @@
     function formatYAxis(value) {
         return formatCurrencyValue(
             value,
-            $selectedAccount && $selectedWalletChart === WalletChartType.HOLDINGS
+            $selectedAccountStore && $selectedWalletChart === WalletChartType.HOLDINGS
                 ? CurrencyTypes.IOTA
                 : $activeProfile?.settings.chartSelectors.currency
                 ? $activeProfile?.settings.chartSelectors.currency
@@ -184,11 +184,11 @@
     <Chart
         type="line"
         {datasets}
-        beginAtZero={$selectedAccount || $selectedDashboardChart !== DashboardChartType.TOKEN}
+        beginAtZero={$selectedAccountStore || $selectedDashboardChart !== DashboardChartType.TOKEN}
         {labels}
         {xMaxTicks}
         {formatYAxis}
-        inlineStyle={$selectedAccount && `height: calc(50vh - ${hasTitleBar ? '190' : '160'}px);`}
+        inlineStyle={$selectedAccountStore && `height: calc(50vh - ${hasTitleBar ? '190' : '160'}px);`}
     />
 </div>
 

--- a/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
@@ -3,7 +3,7 @@
     import { getTrimmedLength } from 'shared/lib/helpers'
     import { localize } from '@core/i18n'
     import { activeProfile, getColor, setProfileAccount } from 'shared/lib/profile'
-    import { api, MAX_ACCOUNT_NAME_LENGTH, selectedAccount, wallet } from 'shared/lib/wallet'
+    import { api, MAX_ACCOUNT_NAME_LENGTH, selectedAccountStore, wallet } from 'shared/lib/wallet'
     import { accountRouter, AccountRoute } from '@core/router'
     import { WalletAccount } from 'shared/lib/typings/wallet'
 
@@ -21,7 +21,7 @@
     $: accountAlias, (error = '')
 
     const handleSaveClick = () => {
-        setProfileAccount($activeProfile, { id: $selectedAccount?.id, color })
+        setProfileAccount($activeProfile, { id: $selectedAccountStore?.id, color })
         const trimmedAccountAlias = accountAlias.trim()
         if (trimmedAccountAlias === alias) {
             $accountRouter.goTo(AccountRoute.Init)
@@ -40,11 +40,11 @@
                 return (error = localize('error.account.duplicate'))
             }
             isBusy = true
-            api.setAlias($selectedAccount?.id, trimmedAccountAlias, {
+            api.setAlias($selectedAccountStore?.id, trimmedAccountAlias, {
                 onSuccess() {
                     accounts.update((_accounts) =>
                         _accounts.map((account) => {
-                            if (account.id === $selectedAccount?.id) {
+                            if (account.id === $selectedAccountStore?.id) {
                                 return Object.assign<WalletAccount, WalletAccount, Partial<WalletAccount>>(
                                     {} as WalletAccount,
                                     account,

--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -4,14 +4,14 @@
     import { localize } from '@core/i18n'
     import { activeProfile, isLedgerProfile } from 'shared/lib/profile'
     import { setClipboard } from 'shared/lib/utils'
-    import { hasGeneratedALedgerReceiveAddress, isSyncing, selectedAccount } from 'shared/lib/wallet'
+    import { hasGeneratedALedgerReceiveAddress, isSyncing, selectedAccountStore } from 'shared/lib/wallet'
 
     export let isGeneratingAddress = false
 
     export let onGenerateAddress: (id: string) => void = () => {}
 
     const generateNewAddress = (): void => {
-        onGenerateAddress($selectedAccount.id)
+        onGenerateAddress($selectedAccountStore.id)
     }
 
     const handleCloseClick = (): void => {
@@ -48,7 +48,7 @@
         </div>
     {:else}
         <div class="flex flex-auto items-center justify-center mb-4">
-            <QR size={98} data={$selectedAccount.depositAddress} classes="w-3/4 h-3/4" />
+            <QR size={98} data={$selectedAccountStore.depositAddress} classes="w-3/4 h-3/4" />
         </div>
         <div class="mb-6">
             <Text secondary smaller classes="mb-1">
@@ -56,12 +56,12 @@
                     ? `${$activeProfile.settings.networkConfig.network.name} ${localize('general.address')}`
                     : localize('general.myAddress')}
             </Text>
-            <Text type="pre">{$selectedAccount.depositAddress}</Text>
+            <Text type="pre">{$selectedAccountStore.depositAddress}</Text>
         </div>
         <Button
             disabled={isGeneratingAddress}
             classes="w-full"
-            onClick={() => setClipboard($selectedAccount.depositAddress)}
+            onClick={() => setClipboard($selectedAccountStore.depositAddress)}
         >
             {localize('general.copyAddress')}
         </Button>

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -36,7 +36,7 @@
     import { LedgerDeviceState } from 'shared/lib/typings/ledger'
     import { changeUnits, formatUnitPrecision } from 'shared/lib/units'
     import { ADDRESS_LENGTH, validateBech32Address } from 'shared/lib/utils'
-    import { DUST_THRESHOLD, isTransferring, selectedAccount, transferState, wallet } from 'shared/lib/wallet'
+    import { DUST_THRESHOLD, isTransferring, selectedAccountStore, transferState, wallet } from 'shared/lib/wallet'
     import { mobile } from 'shared/lib/app'
     import { NotificationType } from 'shared/lib/typings/notification'
     import { SendParams } from 'shared/lib/typings/sendParams'
@@ -49,7 +49,7 @@
     const { accounts } = $wallet
 
     const liveAccounts = getContext<Readable<WalletAccount[]>>('liveAccounts')
-    const addressPrefix = ($selectedAccount ?? $liveAccounts[0])?.depositAddress?.split('1')?.[0]
+    const addressPrefix = ($selectedAccountStore ?? $liveAccounts[0])?.depositAddress?.split('1')?.[0]
 
     enum SEND_TYPE {
         EXTERNAL = 'sendPayment',
@@ -301,11 +301,11 @@
          * amounts to 1 MI to compare them.
          */
         const amountAsMi = changeUnits(amountAsIota, Unit.i, Unit.Mi)
-        const balanceAsMi = changeUnits($selectedAccount.rawIotaBalance, Unit.i, Unit.Mi)
+        const balanceAsMi = changeUnits($selectedAccountStore.rawIotaBalance, Unit.i, Unit.Mi)
         const isMaxAmount = Math.round(amountAsMi) === Math.round(balanceAsMi)
 
-        const hasDustRemaining = Math.abs($selectedAccount.rawIotaBalance - amountAsIota) < DUST_THRESHOLD
-        return isMaxAmount && isFiat && hasDustRemaining ? $selectedAccount.rawIotaBalance : amountAsIota
+        const hasDustRemaining = Math.abs($selectedAccountStore.rawIotaBalance - amountAsIota) < DUST_THRESHOLD
+        return isMaxAmount && isFiat && hasDustRemaining ? $selectedAccountStore.rawIotaBalance : amountAsIota
     }
 
     const handleSendClick = (): void => {
@@ -340,7 +340,7 @@
             } else {
                 amountRaw = setRawAmount(amountAsFloat)
 
-                if (amountRaw > $selectedAccount.rawIotaBalance) {
+                if (amountRaw > $selectedAccountStore.rawIotaBalance) {
                     amountError = localize('error.send.amountTooHigh')
                 } else if (amountRaw <= 0) {
                     amountError = localize('error.send.amountZero')
@@ -370,7 +370,7 @@
             openPopup({
                 type: 'transaction',
                 props: {
-                    accountId: $selectedAccount.id,
+                    accountId: $selectedAccountStore.id,
                     internal: internal || accountAlias,
                     amount: amountRaw,
                     unit,
@@ -391,8 +391,13 @@
              * in another account. Send parameters are reset once the transfer completes.
              */
             isInternal
-                ? onInternalTransfer($selectedAccount.id, to.id, amountRaw, selectedSendType === SEND_TYPE.INTERNAL)
-                : onSend($selectedAccount.id, address, amountRaw)
+                ? onInternalTransfer(
+                      $selectedAccountStore.id,
+                      to.id,
+                      amountRaw,
+                      selectedSendType === SEND_TYPE.INTERNAL
+                  )
+                : onSend($selectedAccountStore.id, address, amountRaw)
 
         if ($isSoftwareProfile) {
             _send(isInternal)
@@ -415,9 +420,13 @@
     const handleMaxClick = (): void => {
         amount = isFiatCurrency(unit)
             ? formatNumber(
-                  convertToFiat($selectedAccount.rawIotaBalance, $currencies[CurrencyTypes.USD], $exchangeRates[unit])
+                  convertToFiat(
+                      $selectedAccountStore.rawIotaBalance,
+                      $currencies[CurrencyTypes.USD],
+                      $exchangeRates[unit]
+                  )
               )
-            : formatUnitPrecision($selectedAccount.rawIotaBalance, unit, false)
+            : formatUnitPrecision($selectedAccountStore.rawIotaBalance, unit, false)
     }
 
     const updateFromSendParams = (sendParams: SendParams): void => {
@@ -425,11 +434,11 @@
         unit = sendParams.unit ?? (Number(sendParams.amount) === 0 ? Unit.Mi : Unit.i)
         amount = sendParams.amount !== undefined ? String(sendParams.amount) : ''
         address = sendParams.address
-        to = sendParams?.toWalletAccount?.id !== $selectedAccount.id ? sendParams?.toWalletAccount : undefined
+        to = sendParams?.toWalletAccount?.id !== $selectedAccountStore.id ? sendParams?.toWalletAccount : undefined
         if (accountsDropdownItems) {
             to =
                 $liveAccounts.length === 2
-                    ? accountsDropdownItems[$selectedAccount.id === $liveAccounts[0].id ? 1 : 0]
+                    ? accountsDropdownItems[$selectedAccountStore.id === $liveAccounts[0].id ? 1 : 0]
                     : to
         }
     }
@@ -529,7 +538,7 @@
                             value={to?.label || null}
                             label={localize('general.to')}
                             placeholder={localize('general.to')}
-                            items={accountsDropdownItems.filter((a) => a.id !== $selectedAccount.id)}
+                            items={accountsDropdownItems.filter((a) => a.id !== $selectedAccountStore.id)}
                             onSelect={handleToSelect}
                             disabled={$isTransferring || $liveAccounts.length === 2}
                             error={toError}


### PR DESCRIPTION
## Summary
To make syncing more efficient and in line with the single wallet refactor, this PR aims to change syncing to be per account on login.

### Changelog
```
- Change to sync per account on login, with account syncing queue and current syncing stores
- Fix behavior of balance finder to handle when opening popup while syncing (including using it previously)
- Add suffix "Store" to relevant store variable names
- Refactor code around loading and syncing accounts, e.g. renaming some variables, cleaning up functions, adding some more error checking, adding specific types, re-adjusting control flow
```

## Relevant Issues
Fixes #2987

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Tested with a profile with at least three accounts, and console logs everywhere.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation