### PR TITLE
fix: text component refactor color back compatibility

### DIFF
--- a/packages/shared/components/Text.svelte
+++ b/packages/shared/components/Text.svelte
@@ -35,8 +35,6 @@
 </script>
 
 <script lang="typescript">
-    import { appSettings } from 'shared/lib/appSettings'
-
     export let type = TextType.p
     export let fontSize: string = ''
     export let fontWeight: FontWeightNumber | FontWeightText | '' = ''
@@ -181,8 +179,8 @@
         ...(fontSize && { fontSize }),
         ...(fontWeight && { fontWeight }),
         ...(lineHeight && { lineHeight }),
-        ...(color && { color }),
-        ...(darkColor && { darkColor }),
+        ...((color || overrideColor) && { color }),
+        ...((darkColor || overrideColor) && { darkColor }),
     }
 
     $: customClassesString = Object.values(customClasses).join(' ')


### PR DESCRIPTION
## Summary
This PR aims to fix the back compatibility with the overrideColor prop after the `Text.svelte` component refactor

### Changelog
```
fix: text component refactor color back compatibility
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
