### PR TITLE
fix: reactive styling for checkbox text

### DIFF
--- a/packages/shared/components/Text.svelte
+++ b/packages/shared/components/Text.svelte
@@ -36,12 +36,12 @@
 
 <script lang="typescript">
     export let type = TextType.p
-    export let fontSize: string = ''
+    export let fontSize = ''
     export let fontWeight: FontWeightNumber | FontWeightText | '' = ''
-    export let lineHeight: string = ''
-    export let secondary: boolean = false
-    export let disabled: boolean = false
-    export let highlighted: boolean = false
+    export let lineHeight = ''
+    export let secondary = false
+    export let disabled = false
+    export let highlighted = false
     export let bold = false
     export let smaller = false
     export let bigger = false
@@ -129,68 +129,77 @@
         },
     }
 
+    $: formattedFontSize = fontSize ? TEXT_PREFIX + fontSize : ''
+    $: formattedLineHeight = lineHeight ? LEADING_PREFIX + lineHeight : ''
+    $: formattedColor = color ? TEXT_PREFIX + color : ''
+    $: formattedDarkColor = darkColor ? DARKMODE_PREFIX + TEXT_PREFIX + darkColor : ''
+
+    let _fontSize
+    let _lineHeight
+    let _color
+    let _darkColor
+
     // Format custom inputs
-    fontSize = fontSize ? TEXT_PREFIX + fontSize : ''
-    lineHeight = lineHeight ? LEADING_PREFIX + lineHeight : ''
-    color = color ? TEXT_PREFIX + color : ''
-    darkColor = darkColor ? DARKMODE_PREFIX + TEXT_PREFIX + darkColor : ''
+    function setCustomStyles() {
+        _fontSize = formattedFontSize
+        _lineHeight = formattedLineHeight
+        _color = formattedColor
+        _darkColor = formattedDarkColor
+    }
 
     // Adjust font for old override classes
     function adjustFont() {
         switch (type) {
             case TextType.p:
-                fontSize = bigger ? 'text-16' : smaller ? 'text-12' : fontSize
-                lineHeight = bigger ? 'leading-140' : smaller ? 'leading-120' : lineHeight
+                _fontSize = bigger ? 'text-16' : smaller ? 'text-12' : _fontSize
+                _lineHeight = bigger ? 'leading-140' : smaller ? 'leading-120' : _lineHeight
                 break
             case TextType.pre:
-                fontSize = bigger ? 'text-13' : smaller ? 'text-11' : fontSize
+                _fontSize = bigger ? 'text-13' : smaller ? 'text-11' : _fontSize
                 break
         }
 
         fontWeight = bold ? FontWeightText.bold : fontWeight
-        lineHeight = overrideLeading ? '' : lineHeight
+        _lineHeight = overrideLeading ? '' : _lineHeight
     }
-    $: smaller, bigger, adjustFont()
 
     // Adjust colours for old override classes
     function adjustColor() {
-        color = overrideColor ? '' : color
-        darkColor = overrideColor ? '' : darkColor
+        _color = overrideColor ? '' : _color
+        _darkColor = overrideColor ? '' : _darkColor
 
         if (error) {
-            color = ERROR_TEXT_COLOUR
-            darkColor = ERROR_TEXT_COLOUR
+            _color = ERROR_TEXT_COLOUR
+            _darkColor = ERROR_TEXT_COLOUR
         } else if (disabled) {
-            color = DISABLED_TEXT_COLOUR
-            darkColor = DISABLED_TEXT_DARK_COLOUR
+            _color = DISABLED_TEXT_COLOUR
+            _darkColor = DISABLED_TEXT_DARK_COLOUR
         } else if (highlighted) {
-            color = HIGHLIGHT_TEXT_COLOUR
-            darkColor = HIGHLIGHT_TEXT_COLOUR
+            _color = HIGHLIGHT_TEXT_COLOUR
+            _darkColor = HIGHLIGHT_TEXT_COLOUR
         } else if (secondary) {
-            color = SECONDARY_TEXT_COLOUR
-            darkColor = SECONDARY_TEXT_COLOUR
-        } else {
-            color = overrideColor ? '' : TEXT_PREFIX + 'gray-800'
-            darkColor = overrideColor ? '' : DARKMODE_PREFIX + TEXT_PREFIX + 'white'
+            _color = SECONDARY_TEXT_COLOUR
+            _darkColor = SECONDARY_TEXT_COLOUR
         }
     }
-    $: error, disabled, highlighted, secondary, adjustColor()
+
+    $: $$props, setCustomStyles(), adjustFont(), adjustColor()
 
     let customClasses: ICustomClass
     $: customClasses = {
         ...DEFAULT_CLASSES_LIST[type],
-        ...(fontSize && { fontSize }),
+        ...(_fontSize && { fontSize: _fontSize }),
         ...(fontWeight && { fontWeight }),
-        ...(lineHeight && { lineHeight }),
-        ...((color || overrideColor) && { color }),
-        ...((darkColor || overrideColor) && { darkColor }),
+        ...(_lineHeight && { lineHeight: _lineHeight }),
+        ...((overrideColor || _color) && { color: _color }),
+        ...((overrideColor || _darkColor) && { darkColor: _darkColor }),
     }
 
     $: customClassesString = Object.values(customClasses).join(' ')
 </script>
 
 <span class="text-component">
-    <svelte:element this={type} class={`${customClassesString} ${classes}`}>
+    <svelte:element this={type} class={`${customClassesString} ${classes}`} {...$$restProps}>
         <slot />
     </svelte:element>
 </span>

--- a/packages/shared/components/Text.svelte
+++ b/packages/shared/components/Text.svelte
@@ -170,8 +170,8 @@
             color = SECONDARY_TEXT_COLOUR
             darkColor = SECONDARY_TEXT_COLOUR
         } else {
-            color = TEXT_PREFIX + 'gray-800'
-            darkColor = DARKMODE_PREFIX + TEXT_PREFIX + 'white'
+            color = overrideColor ? '' : TEXT_PREFIX + 'gray-800'
+            darkColor = overrideColor ? '' : DARKMODE_PREFIX + TEXT_PREFIX + 'white'
         }
     }
     $: error, disabled, highlighted, secondary, adjustColor()

--- a/packages/shared/components/Text.svelte
+++ b/packages/shared/components/Text.svelte
@@ -169,6 +169,9 @@
         } else if (secondary) {
             color = SECONDARY_TEXT_COLOUR
             darkColor = SECONDARY_TEXT_COLOUR
+        } else {
+            color = TEXT_PREFIX + 'gray-800'
+            darkColor = DARKMODE_PREFIX + TEXT_PREFIX + 'white'
         }
     }
     $: error, disabled, highlighted, secondary, adjustColor()

--- a/packages/shared/components/Text.svelte
+++ b/packages/shared/components/Text.svelte
@@ -35,8 +35,6 @@
 </script>
 
 <script lang="typescript">
-    import { appSettings } from 'shared/lib/appSettings'
-
     export let type = TextType.p
     export let fontSize: string = ''
     export let fontWeight: FontWeightNumber | FontWeightText | '' = ''
@@ -181,8 +179,8 @@
         ...(fontSize && { fontSize }),
         ...(fontWeight && { fontWeight }),
         ...(lineHeight && { lineHeight }),
-        ...(color && { color }),
-        ...(darkColor && { darkColor }),
+        ...((color || overrideColor) && { color }),
+        ...((darkColor || overrideColor) && { darkColor }),
     }
 
     $: customClassesString = Object.values(customClasses).join(' ')

--- a/packages/shared/lib/assets.ts
+++ b/packages/shared/lib/assets.ts
@@ -1,5 +1,5 @@
 import { Unit } from '@iota/unit-converter'
-import { convertToFiat, currencies, exchangeRates } from 'shared/lib/currency'
+import { convertToFiat, currencies, exchangeRates, formatNumber } from 'shared/lib/currency'
 import { formatStakingAirdropReward } from 'shared/lib/participation/staking'
 import { totalAssemblyStakingRewards, totalShimmerStakingRewards } from 'shared/lib/participation/stores'
 import { activeProfile } from 'shared/lib/profile'
@@ -9,6 +9,7 @@ import { UNIT_MAP } from 'shared/lib/units'
 import { selectedAccount } from 'shared/lib/wallet'
 import { derived } from 'svelte/store'
 import { StakingAirdrop } from 'shared/lib/participation/types'
+import { getNumberOfDecimalPlaces } from '@lib/utils'
 
 export const assets = derived(
     [
@@ -29,15 +30,20 @@ export const assets = derived(
     ]) => {
         if (!$activeProfile || !$selectedAccount) return []
         const profileCurrency = $activeProfile?.settings.currency ?? AvailableExchangeRates.USD
+
+        const rawFiatPrice = convertToFiat(
+            UNIT_MAP[Unit.Mi].val,
+            $currencies[CurrencyTypes.USD],
+            $exchangeRates[profileCurrency]
+        )
+        const numDecimalPlaces = getNumberOfDecimalPlaces(rawFiatPrice)
+        const formattedFiatPrice = formatNumber(rawFiatPrice, numDecimalPlaces, numDecimalPlaces)
+
         const assets: Asset[] = [
             {
                 name: Token.IOTA,
                 balance: $selectedAccount.balance,
-                fiatPrice: `${convertToFiat(
-                    UNIT_MAP[Unit.Mi].val,
-                    $currencies[CurrencyTypes.USD],
-                    $exchangeRates[profileCurrency]
-                )} ${profileCurrency}`,
+                fiatPrice: `${formattedFiatPrice} ${profileCurrency}`,
                 fiatBalance: $selectedAccount.balanceEquiv,
                 color: '#6E82A4',
             },

--- a/packages/shared/lib/common/deep-links/wallet-context-handler.ts
+++ b/packages/shared/lib/common/deep-links/wallet-context-handler.ts
@@ -7,6 +7,8 @@ import { addError } from '../../errors'
 
 import { DeepLinkContext, SendOperationParameter, WalletOperation } from '@common/deep-links/enums'
 import { DeepLinkRequest, SendOperationParameters } from '@common/deep-links/types'
+import { formatNumber } from '@lib/currency'
+import { getNumberOfDecimalPlaces } from '@lib/utils'
 
 /**
  * Parses a deep link within the wallet context.
@@ -67,6 +69,7 @@ const parseSendOperation = (
     searchParams: URLSearchParams,
     expectedAddressPrefix: string
 ): void | SendOperationParameters => {
+    let numDecimalPlaces = 0
     let parsedAmount: number | undefined
     let parsedUnit: Unit | undefined
 
@@ -87,6 +90,7 @@ const parseSendOperation = (
     const amountParam = searchParams.get(SendOperationParameter.Amount)
     if (amountParam) {
         parsedAmount = Number(amountParam)
+        numDecimalPlaces = getNumberOfDecimalPlaces(parsedAmount)
         if (Number.isNaN(parsedAmount) || !Number.isFinite(parsedAmount)) {
             return addError({ time: Date.now(), type: 'deepLink', message: `Amount is not a number '${amountParam}'` })
         }
@@ -118,7 +122,7 @@ const parseSendOperation = (
 
     return {
         address,
-        amount: String(Math.abs(parsedAmount)),
+        amount: formatNumber(Math.abs(parsedAmount), numDecimalPlaces, numDecimalPlaces),
         unit: parsedUnit,
         message: '',
     }

--- a/packages/shared/lib/tests/utils.test.ts
+++ b/packages/shared/lib/tests/utils.test.ts
@@ -1,6 +1,6 @@
 import './mocks/matchMedia'
 
-import { migrateObjects, range } from '../utils'
+import { getNumberOfDecimalPlaces, migrateObjects, range } from '../utils'
 
 type Simple = {
     prop1?: string
@@ -171,6 +171,24 @@ describe('File: utils.ts', () => {
             expect(range(-1)).toEqual([])
             expect(range(-1, 1)).toEqual([])
             expect(range(undefined, 1)).toEqual([])
+        })
+    })
+
+    describe('Function: getNumberOfDecimalPlaces', () => {
+        it('should handle integers (large and small)', () => {
+            expect(getNumberOfDecimalPlaces(0)).toEqual(0)
+            expect(getNumberOfDecimalPlaces(1000)).toEqual(0)
+            expect(getNumberOfDecimalPlaces(1_000_000_000)).toEqual(0)
+        })
+        it('should handle floats (large and small)', () => {
+            expect(getNumberOfDecimalPlaces(1.0)).toEqual(0)
+            expect(getNumberOfDecimalPlaces(1.01)).toEqual(2)
+            expect(getNumberOfDecimalPlaces(1.000000001)).toEqual(9)
+            expect(getNumberOfDecimalPlaces(1_000_000_000.01)).toEqual(2)
+        })
+        it('should handle invalid arguments', () => {
+            expect(getNumberOfDecimalPlaces(null)).toEqual(0)
+            expect(getNumberOfDecimalPlaces(undefined)).toEqual(0)
         })
     })
 })

--- a/packages/shared/lib/utils.ts
+++ b/packages/shared/lib/utils.ts
@@ -468,3 +468,13 @@ export function range(size: number, start: number = 0): number[] {
 
     return Array.from(Array(size), (_, idx) => idx + start)
 }
+
+/**
+ * Returns the number of decimal places within a number. Only works with numbers
+ * using "." as a decimal separator.
+ */
+export function getNumberOfDecimalPlaces(x: number): number {
+    if (!x || Math.floor(x) === x) return 0
+
+    return x.toString().split('.')[1].length || 0
+}


### PR DESCRIPTION
## Summary
Previously, any checkbox text when unchecked then re-checked, the styling does not update accordingly.

### Changelog
```
- Added logic to ensure text colors are updated properly
```

## Relevant Issues
Closes #3167

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Navigate to where there is a checkbox, and check/uncheck it, making sure the colors update accordingly.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation