### PR TITLE
enhancement: improve transaction confirmation detection speed

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=a084002da15c072f0f7256c74403b05dad3c7d8b#a084002da15c072f0f7256c74403b05dad3c7d8b"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=a65932f3af75e227379821ecdc492f947d9e6f3d#a65932f3af75e227379821ecdc492f947d9e6f3d"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["/bindings", "/api-wrapper"]
 [dependencies]
 tokio = { version = "1.12.0", default-features = false }
 once_cell = { version = "1.8.0", default-features = false }
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "a084002da15c072f0f7256c74403b05dad3c7d8b", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator", "participation"] }
+iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "a65932f3af75e227379821ecdc492f947d9e6f3d", default-features = false, features = ["stronghold", "ledger-nano", "ledger-nano-simulator", "participation"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 riker = "0.4.2"

--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=a084002da15c072f0f7256c74403b05dad3c7d8b#a084002da15c072f0f7256c74403b05dad3c7d8b"
+source = "git+https://github.com/iotaledger/wallet.rs?rev=a65932f3af75e227379821ecdc492f947d9e6f3d#a65932f3af75e227379821ecdc492f947d9e6f3d"
 dependencies = [
  "async-trait",
  "backtrace",


### PR DESCRIPTION
## Summary

After sending a transaction, we currently wait until the next poll cycle before we pick up confirmation (~30 seconds). We can instead poll for the confirmation of that isolated transaction. This visibly improves the experience for users across sending, staking and voting (<=10s).

### Changelog
```
- Update wallet-rs version
- Poll for transaction confirmation 
```

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Try send, stake or vote and observe confirmation speed

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
