### PR TITLE
chore: strip Linux backend debug info and upload to Sentry

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -117,9 +117,22 @@ jobs:
     - name: Install Sentry CLI
       # Yarn has issues putting binaries in the PATH on Windows
       run: npm i -g @sentry/cli
-      if: ${{ startsWith(github.ref, 'refs/tags/desktop') && matrix.os == 'windows-2019' }}
+      if: ${{ startsWith(github.ref, 'refs/tags/desktop') && matrix.os != 'macos-10.15' }}
 
-    - name: Upload backend PDB (Windows)
+    - name: Strip backend debug info and upload to Sentry (Linux)
+      run: |
+        cp index.node index.node.dbg
+        strip -S index.node
+        objcopy --add-gnu-debuglink=index.node.dbg index.node
+        sentry-cli difutil check index.node.dbg
+        sentry-cli upload-dif -o "iota-foundation-h4" -p "firefly-backend" --include-sources index.node.dbg
+        sentry-cli upload-dif -o "iota-foundation-h4" -p "firefly-desktop" --include-sources index.node.dbg
+      working-directory: packages/backend/bindings/node
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      if: ${{ startsWith(github.ref, 'refs/tags/desktop') && matrix.os == 'ubuntu-18.04' }}
+
+    - name: Upload backend debug info to Sentry (Windows)
       run: |
         sentry-cli difutil check node_neon.pdb
         sentry-cli upload-dif -o "iota-foundation-h4" -p "firefly-backend" --include-sources node_neon.pdb 


### PR DESCRIPTION
## Summary
It turns out that even though we include the debug info in the Linux backend bindings that we ship with Firefly, Sentry does not symbolicate errors from them (in the `firefly-desktop` package) without receiving the debug info through a CLI upload. Therefore, we can upload the debug info to Sentry during the CI build and then strip it from the bindings that will be included in a build in Firefly. This reduces the size of the bindings from approximately 701 MB to approximately 37 MB.

### Changelog
```
- Strip debug info from Linux Node.js bindings during CI build
- Upload debug info to Sentry
```

## Relevant Issues
Fixes #2568 

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Triggered crashes to check if Sentry recognized the corresponding debug file. Also tested upload with GHA

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting