### PR TITLE
fix: locale reactivity in back button

### DIFF
--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -31,7 +31,7 @@
     } from '@core/router'
     import { Settings } from 'shared/routes'
     import { versionDetails } from '@lib/appUpdater'
-    import { localize } from '../lib/core/i18n'
+    import { localize } from '@core/i18n'
 
     let networkModal: Modal
     let profileModal: Modal

--- a/packages/shared/components/Sidebar.svelte
+++ b/packages/shared/components/Sidebar.svelte
@@ -32,7 +32,6 @@
     import { Settings } from 'shared/routes'
     import { versionDetails } from '@lib/appUpdater'
     import { localize } from '../lib/core/i18n'
-    import { _, locale } from 'svelte-i18n'
 
     let networkModal: Modal
     let profileModal: Modal

--- a/packages/shared/routes/dashboard/TopNavigation.svelte
+++ b/packages/shared/routes/dashboard/TopNavigation.svelte
@@ -7,6 +7,7 @@
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import { getContext, onMount } from 'svelte'
     import { Readable } from 'svelte/store'
+    import { appSettings } from '@lib/appSettings'
 
     export let onCreateAccount = (..._: any[]): void => {}
     export let classes: string
@@ -17,6 +18,14 @@
 
     $: showBackButton = isCorrectRoute($settingsRoute)
     $: showingPopup = $popupState.active && $popupState.type !== 'busy'
+
+    let backButtonText = localize('actions.back')
+
+    function updateBackButtonText(): void {
+        backButtonText = localize('actions.back')
+    }
+
+    $: $appSettings, updateBackButtonText()
 
     onMount(async () => {
         os = await Platform.getOS()
@@ -47,7 +56,7 @@
         <button on:click={handleBackClick} class="absolute left-2 cursor-pointer" style="-webkit-app-region: none;">
             <div class="flex items-center space-x-2 ">
                 <Icon width="18" icon="arrow-left" classes="text-gray-800 dark:text-gray-500" />
-                <Text overrideColor classes="text-gray-800 dark:text-gray-500">{localize('actions.back')}</Text>
+                <Text overrideColor classes="text-gray-800 dark:text-gray-500">{backButtonText}</Text>
             </div>
         </button>
     {/if}


### PR DESCRIPTION
## Summary
Previously, the back button text was not reactive to the locale changing.

### Changelog
```
- Make back button text reactive to the locale
```

## Relevant Issues
- Closes #3166
- Fixes #3179 

## Type of Change
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Switch between different locales and ensure that back button text updates accordingly.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation