### PR TITLE
chore: update hidapi to 1.3.3

### DIFF
--- a/packages/backend/bindings/node/native/Cargo.lock
+++ b/packages/backend/bindings/node/native/Cargo.lock
@@ -1267,9 +1267,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hidapi"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c4cc7279df8353788ac551186920e44959d5948aec404be02b28544a598bce"
+checksum = "7fd21b5ac4a597bf657ed92a5b078f46a011837bda14afb7a07a5c1157c33ac2"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
Updates `hidapi` to 1.3.3. This update includes https://github.com/libusb/hidapi/commit/5f66a371cad20f1e948b2d20d07509084e4d9d72, which fixes a crash on Windows when we send a message to a Ledger device that has been disconnected.

### Changelog
```
- Update hidapi to 1.3.3
```

## Relevant Issues
Fixes https://github.com/iotaledger/firefly/issues/2728

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting
