### PR TITLE
fix: fix back button on Stronghold password screen

### DIFF
--- a/packages/shared/routes/setup/import/views/BackupPassword.svelte
+++ b/packages/shared/routes/setup/import/views/BackupPassword.svelte
@@ -23,7 +23,7 @@
     }
 
     function handleBackClick(): void {
-        if (!busy && !isGettingMigrationData) {
+        if (!busy && !$isGettingMigrationData) {
             dispatch('previous')
         }
     }


### PR DESCRIPTION
## Summary
The back button on the password screen (after choosing a Stronghold to import) did not work because we were checking `isGettingMigrationData`, which is a store, instead of its value (with `$isGettingMigrationData`).

### Changelog
```
- Fix back button on Stronghold password screen
```

## Relevant Issues
N/A

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Try importing a Stronghold, then click the back button when asked for the password to decrypt the Stronghold

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting