### PR TITLE
chore: remove trailing spaces in strings

### DIFF
--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -88,7 +88,7 @@
         "confirmPin": {
             "title": "Verify your PIN code",
             "body1": "Your PIN keeps your balance and transactions private.",
-            "body2": "Re-enter your PIN code to proceed. "
+            "body2": "Re-enter your PIN code to proceed."
         },
         "backup": {
             "title": "Back up your wallet",
@@ -542,7 +542,7 @@
                 "totalWalletRewards": "Total wallet rewards",
                 "assembly": {
                     "name": "Assembly",
-                    "description": "Assembly is a permissionless, highly scalable multi-chain network to build and deploy composable smart contracts. Assembly is the future of web3. "
+                    "description": "Assembly is a permissionless, highly scalable multi-chain network to build and deploy composable smart contracts. Assembly is the future of web3."
                 },
                 "shimmer": {
                     "name": "Shimmer",
@@ -567,7 +567,7 @@
                     "title": "Your voting weight",
                     "equality": "1000 IOTA = 1 VOTE",
                     "description1": "Your voting weight is derived from your wallet balance. When a voting proposal is in the Counting phase, active votes are counted and accumulated every 10s.",
-                    "description2": "1 Ki of voting weight (1000 IOTA tokens) yields 1 vote every 10s. This means you must keep voting for the full duration of the Counting phase to issue your full voting weight. "
+                    "description2": "1 Ki of voting weight (1000 IOTA tokens) yields 1 vote every 10s. This means you must keep voting for the full duration of the Counting phase to issue your full voting weight."
                 }
             },
             "info": {


### PR DESCRIPTION
## Summary
Removes trailing spaces in translation strings

### Changelog
```
- Remove trailing spaces in translation strings
```

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing


## Testing
### Platforms
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
N/A

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting