### PR TITLE
fix: disable firefly changed popup on setup

### DIFF
--- a/packages/shared/lib/profile.ts
+++ b/packages/shared/lib/profile.ts
@@ -107,6 +107,7 @@ const buildProfile = (profileName: string, isDeveloperProfile: boolean): Profile
     },
     ledgerMigrationCount: 0,
     accounts: [],
+    hasFinishedSingleAccountGuide: true,
 })
 
 /**


### PR DESCRIPTION
## Summary
Disables "Firefly has changed" popup if the user is creating a new profile, or recovering an existing one.

### Changelog
```
- Updates profile builder to set hasFinishedSingleAccountGuide to true
```

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
