### PR TITLE
fix: add lacking function to Electron API

### DIFF
--- a/packages/desktop/electron/electronApi.js
+++ b/packages/desktop/electron/electronApi.js
@@ -84,6 +84,7 @@ const ElectronApi = {
                 return result.filePath
             }),
 
+    saveStrongholdBackup: ({ allowAccess }) => null,
     exportTransactionHistory: async (defaultPath, contents) =>
         ipcRenderer
             .invoke('show-save-dialog', {


### PR DESCRIPTION
## Summary
This PR fixes an error introduced in the previous mobile merge, where the Electron API was lacking a function (saveStrongholdBackup) to avoid an error when saving Stronghold file.

### Changelog
```
Please write an accurate and concise changelog for your changes.
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [x] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
