### PR TITLE
Fix: `isAccountVoting` included staking participations

### DIFF
--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -1,15 +1,17 @@
 <script lang="typescript">
+    import { localize } from '@core/i18n'
     import { Unit } from '@iota/unit-converter'
     import { Button, Icon, Illustration, Text } from 'shared/components'
     import { convertToFiat, currencies, exchangeRates, formatCurrency, isFiatCurrency } from 'shared/lib/currency'
     import { isAccountStaked, isParticipationPossible } from 'shared/lib/participation'
+    import { selectedAccountParticipationOverview } from 'shared/lib/participation/account'
+    import { TREASURY_VOTE_EVENT_ID } from 'shared/lib/participation/constants'
+    import { assemblyStakingEventState, shimmerStakingEventState } from 'shared/lib/participation/stores'
     import { closePopup } from 'shared/lib/popup'
     import { activeProfile } from 'shared/lib/profile'
     import { AvailableExchangeRates, CurrencyTypes } from 'shared/lib/typings/currency'
-    import { localize } from '@core/i18n'
     import { formatUnitBestMatch, formatUnitPrecision } from 'shared/lib/units'
-    import { assemblyStakingEventState, shimmerStakingEventState } from 'shared/lib/participation/stores'
-    import { selectedAccountParticipationOverview } from 'shared/lib/participation/account'
+    import { TrackedParticipationItem } from 'shared/lib/participation/types'
 
     export let accountId: string
     export let internal = false
@@ -28,9 +30,11 @@
     }
 
     $: isAccountVoting =
-        Object.values($selectedAccountParticipationOverview?.trackedParticipations || {})?.find((tp) =>
-            tp?.find((p) => p?.endMilestoneIndex === 0)
-        )?.length > 0 ?? false
+        !!(
+            Object.values(
+                $selectedAccountParticipationOverview?.trackedParticipations?.[TREASURY_VOTE_EVENT_ID] || {}
+            )
+        )?.find((trackedParticipation) => trackedParticipation?.endMilestoneIndex === 0) ?? false
 
     let activeParticipationType: ActiveParticipationType | ''
     $: {

--- a/packages/shared/components/popups/Transaction.svelte
+++ b/packages/shared/components/popups/Transaction.svelte
@@ -29,12 +29,13 @@
         Vote = 'vote',
     }
 
+    let treasuryVoteParticipations: TrackedParticipationItem[]
+    $: treasuryVoteParticipations =
+        Object.values($selectedAccountParticipationOverview?.trackedParticipations?.[TREASURY_VOTE_EVENT_ID] || {}) ??
+        []
     $: isAccountVoting =
-        !!(
-            Object.values(
-                $selectedAccountParticipationOverview?.trackedParticipations?.[TREASURY_VOTE_EVENT_ID] || {}
-            )
-        )?.find((trackedParticipation) => trackedParticipation?.endMilestoneIndex === 0) ?? false
+        !!treasuryVoteParticipations?.find((trackedParticipation) => trackedParticipation?.endMilestoneIndex === 0) ??
+        false
 
     let activeParticipationType: ActiveParticipationType | ''
     $: {


### PR DESCRIPTION
## Summary

This PR aims to calculate `isAccountVoting` only based on the treasury vote participations

### Changelog
```
Fix: `isAccountVoting` included staking participations
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
