### PR TITLE
fix: voting CSS winner&selected not visible in light mode

### DIFF
--- a/packages/shared/routes/dashboard/governance/views/GovernanceEventInfo.svelte
+++ b/packages/shared/routes/dashboard/governance/views/GovernanceEventInfo.svelte
@@ -344,7 +344,7 @@
 
 <style type="text/scss">
     button {
-        &.active:not(.partial) {
+        &.active:not(.partial):not(.winner) {
             @apply border-blue-500;
             @apply bg-blue-500;
             @apply bg-opacity-10;


### PR DESCRIPTION
## Summary
This PR aims to fix this:
![image](https://user-images.githubusercontent.com/3624944/170095527-b100d778-2b2c-4f21-b9c6-8bd2dca150f3.png)

### Changelog
```
fix: voting CSS winner&selected not visible in light mode
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
