### PR TITLE
fix: wallet duplication on first login (after profile creation)

### DIFF
--- a/packages/shared/lib/wallet.ts
+++ b/packages/shared/lib/wallet.ts
@@ -1099,7 +1099,7 @@ export async function processLoadedAccounts(accounts: Account[]): Promise<void> 
 
             const accountMetadata = await asyncGetAccountMetadata(account.id)
             const preparedAccount = formatAccountWithMetadata(account, accountMetadata)
-            // we first need to check if we wallet is already populated with this account
+            // we first need to check if the store is already populated with this account
             const indexExistingAccountInStore = get(accountsStore).findIndex(
                 (_account) => _account.id === preparedAccount.id
             )


### PR DESCRIPTION
## Summary

This PR aims to fix the bug where the first wallet that gets created when you create a profile is duplicated

### Changelog
```
fix: wallet duplication on first login (after profile creation)
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
