### PR TITLE
feat: prevent wallet creation/switch while changing participation

### DIFF
--- a/packages/shared/components/modals/AccountSwitcher.svelte
+++ b/packages/shared/components/modals/AccountSwitcher.svelte
@@ -3,7 +3,7 @@
     import { localize } from '@core/i18n'
     import { resetAccountRouter } from '@core/router'
     import { showAppNotification } from '@lib/notifications'
-    import { participationAction } from '@lib/participation/stores'
+    import { isChangingParticipation, participationAction } from '@lib/participation/stores'
     import { openPopup } from '@lib/popup'
     import { getAccountColor } from '@lib/profile'
     import { WalletAccount } from '@lib/typings/wallet'
@@ -24,7 +24,7 @@
     function handleAccountClick(accountId: string): void {
         if ($isTransferring) {
             showWarning(localize('notifications.transferring'))
-        } else if ($participationAction) {
+        } else if ($participationAction || $isChangingParticipation) {
             showWarning(localize('notifications.participating'))
         } else {
             setSelectedAccount(accountId)
@@ -44,7 +44,7 @@
     function handleCreateAccountClick(): void {
         if ($isTransferring) {
             showWarning(localize('notifications.transferringCreate'))
-        } else if ($participationAction) {
+        } else if ($participationAction || $isChangingParticipation) {
             showWarning(localize('notifications.participatingCreate'))
         } else {
             openPopup({ type: 'createAccount', props: { onCreate: onCreateAccount } })


### PR DESCRIPTION
## Summary

When you change your vote, there is a short time where you can switch wallets and create a new wallet. If you create a wallet mid change vote, the newly created wallet was never reachable, this PR prevents this from happening 

### Changelog
```
feat: prevent wallet creation/switch while changing participation
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
