### PR TITLE
chore: fix building DMG on macOS 12.3+

### DIFF
--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -13,6 +13,7 @@ The following __must__ be installed on all platforms:
 ### MacOS
 
 - Xcode Command Line Tools
+- [Python 2.7](https://www.python.org/downloads/release/python-2718/) for DMG creation (no longer pre-installed on macOS 12.3+ or available through Homebrew)
 
 ### Windows
 

--- a/patches/dmg-builder+22.9.1.patch
+++ b/patches/dmg-builder+22.9.1.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/dmg-builder/out/dmg.js b/node_modules/dmg-builder/out/dmg.js
+index ad0bb2e..e3e9769 100644
+--- a/node_modules/dmg-builder/out/dmg.js
++++ b/node_modules/dmg-builder/out/dmg.js
+@@ -389,7 +389,8 @@ async function customizeDmg(volumePath, specification, packager, backgroundFile)
+   const asyncTaskManager = new (_builderUtil().AsyncTaskManager)(packager.info.cancellationToken);
+   env.iconLocations = await computeDmgEntries(specification, volumePath, packager, asyncTaskManager);
+   await asyncTaskManager.awaitTasks();
+-  await (0, _builderUtil().exec)("/usr/bin/python", [path.join((0, _dmgUtil().getDmgVendorPath)(), "dmgbuild/core.py")], {
++  const pythonPath = (await (0, _builderUtil().exec)("which", ["python"])).trim();
++  await (0, _builderUtil().exec)(pythonPath, [path.join((0, _dmgUtil().getDmgVendorPath)(), "dmgbuild/core.py")], {
+     cwd: (0, _dmgUtil().getDmgVendorPath)(),
+     env
+   });


### PR DESCRIPTION
## Summary
In macOS 12.3, the pre-installed Python 2.7 [was removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). We still need this as the DMG script from our version of `electron-builder` uses Python 2. This PR applies a change similar to https://github.com/electron-userland/electron-builder/pull/6789 so that the path revealed by `which python` is used to execute the DMG script, instead of assuming that Python is located at `/usr/bin/python` (for example, on my computer it's now at `/Library/Frameworks/Python.framework/Versions/2.7/bin/python`). Note that for macOS 12.3+, if you want to build a DMG for macOS, you need to download [Python 2.7.18 from the Python website](https://www.python.org/downloads/release/python-2718/) (it's not available through Homebrew anymore).

### Changelog
```
- Fix Python path for building DMG on macOS 12.3+
- Add Python 2.7 requirement to README
```

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [x] __Docs__ - changes to the documentation


## Testing
### Platforms
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows

### Instructions
Tested locally and on CI

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
