### PR TITLE
Fix: old participations tx history tagging

### DIFF
--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -52,8 +52,6 @@
     $: hasCachedMigrationTx, milestonePayload, txPayload, (messageValue = getMessageValue())
     $: senderAddress = sendAddressFromTransactionPayload(payload)
     $: receiverAddresses = receiverAddressesFromTransactionPayload(payload)
-
-    let participationAction: ParticipationAction
     $: participationAction = getMessageParticipationAction(id, timestamp)
 
     // There can only be one sender address

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -1,9 +1,11 @@
 <script lang="typescript">
+    import { formatDate, localize } from '@core/i18n'
     import { Icon, Text } from 'shared/components'
     import { truncateString } from 'shared/lib/helpers'
-    import { formatDate, localize } from '@core/i18n'
-    import { Payload } from 'shared/lib/typings/message'
+    import { getMessageParticipationAction } from 'shared/lib/participation'
+    import { participationEvents } from 'shared/lib/participation/stores'
     import { ParticipationAction } from 'shared/lib/participation/types'
+    import { Payload, Transaction } from 'shared/lib/typings/message'
     import { formatUnitBestMatch } from 'shared/lib/units'
     import {
         findAccountWithAddress,
@@ -16,8 +18,6 @@
         sendAddressFromTransactionPayload,
         wallet,
     } from 'shared/lib/wallet'
-    import { Transaction } from 'shared/lib/typings/message'
-    import { getMessageParticipationAction } from 'shared/lib/participation'
 
     export let id: string
     export let timestamp: string
@@ -53,7 +53,9 @@
     $: hasCachedMigrationTx, milestonePayload, txPayload, (messageValue = getMessageValue())
     $: senderAddress = sendAddressFromTransactionPayload(payload)
     $: receiverAddresses = receiverAddressesFromTransactionPayload(payload)
-    $: participationAction = getMessageParticipationAction(id)
+
+    let participationAction: ParticipationAction
+    $: ($participationEvents, id), (participationAction = getMessageParticipationAction(id))
 
     // There can only be one sender address
     $: senderAccount = findAccountWithAddress(senderAddress)

--- a/packages/shared/components/ActivityRow.svelte
+++ b/packages/shared/components/ActivityRow.svelte
@@ -3,7 +3,6 @@
     import { Icon, Text } from 'shared/components'
     import { truncateString } from 'shared/lib/helpers'
     import { getMessageParticipationAction } from 'shared/lib/participation'
-    import { participationEvents } from 'shared/lib/participation/stores'
     import { ParticipationAction } from 'shared/lib/participation/types'
     import { Payload, Transaction } from 'shared/lib/typings/message'
     import { formatUnitBestMatch } from 'shared/lib/units'
@@ -55,7 +54,7 @@
     $: receiverAddresses = receiverAddressesFromTransactionPayload(payload)
 
     let participationAction: ParticipationAction
-    $: ($participationEvents, id), (participationAction = getMessageParticipationAction(id))
+    $: participationAction = getMessageParticipationAction(id, timestamp)
 
     // There can only be one sender address
     $: senderAccount = findAccountWithAddress(senderAddress)

--- a/packages/shared/lib/participation/participation.ts
+++ b/packages/shared/lib/participation/participation.ts
@@ -20,6 +20,7 @@ import {
     isFetchingParticipationInfo,
 } from './stores'
 import { AccountParticipationAbility, ParticipationAction, ParticipationEventState, StakingAirdrop } from './types'
+import { getDurationString, milestoneToDate } from '@lib/time'
 
 let shouldPollParticipation = true
 let participationPollTimeout
@@ -144,17 +145,16 @@ export const getAccountParticipationAbility = (account: WalletAccount): AccountP
  *
  * @returns {ParticipationAction}
  */
-export const getMessageParticipationAction = (messageId: string): ParticipationAction => {
+export const getMessageParticipationAction = (messageId: string, timestamp: string): ParticipationAction => {
     const matchedHistoryItem = get(participationHistory)?.find((item) => item.messageId === messageId)
     if (matchedHistoryItem?.action) {
         return matchedHistoryItem.action
     }
-    const stakingEndMilestoneIndexes = get(participationEvents)
-        ?.filter((event) => event.eventId === ASSEMBLY_EVENT_ID || event.eventId === SHIMMER_EVENT_ID)
-        ?.map((event) => event.information?.milestoneIndexEnd)
-    if (stakingEndMilestoneIndexes?.find((milestone) => milestone > LAST_MILESTONE_BEFORE_TREASURY_EVENT)) {
-        return ParticipationAction.Stake
-    } else if (stakingEndMilestoneIndexes?.length) {
-        return ParticipationAction.Vote
+    if (timestamp) {
+        const lastDateBeforeTreasuryEvent = milestoneToDate(LAST_MILESTONE_BEFORE_TREASURY_EVENT)
+        const messageDate = new Date(timestamp)
+        if (messageDate <= lastDateBeforeTreasuryEvent) {
+            return ParticipationAction.Stake
+        }
     }
 }

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -121,7 +121,7 @@
         if (searchValue) {
             queryTransactions = filteredTransactions.filter((transaction) => {
                 const transactionValue = (transaction?.payload as Transaction)?.data?.essence?.data?.value
-                const participationAction = getMessageParticipationAction(transaction.id)
+                const participationAction = getMessageParticipationAction(transaction.id, transaction.timestamp)
                 return (
                     sendAddressFromTransactionPayload(transaction?.payload) === searchValue ||
                     receiverAddressesFromTransactionPayload(transaction?.payload).find(


### PR DESCRIPTION
## Summary

This PR changes the logic to tag correctly an old staking participation: now its based on start of voting & message date

### Changelog
```
Fix: old participations tx history tagging
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
