### PR TITLE
fix: deprecated keyCode

### DIFF
--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -2,6 +2,7 @@
     import { Icon, Text, Error } from 'shared/components'
     import { clickOutside } from 'shared/lib/actions'
     import { onMount } from 'svelte'
+    import { isNumberLetterOrPunctuation } from '@lib/utils/isNumberLetterOrPunctuation'
 
     export let value: string
     export let label: string
@@ -101,14 +102,6 @@
                 search = search.slice(0, -1)
             }
         }
-    }
-
-    function isNumberLetterOrPunctuation(key: string): boolean {
-        if (key.length !== 1) {
-            return false
-        }
-        const code = key.charCodeAt(0)
-        return (code >= 48 && code <= 57) || (code >= 65 && code <= 122)
     }
 
     onMount(() => {

--- a/packages/shared/components/inputs/Dropdown.svelte
+++ b/packages/shared/components/inputs/Dropdown.svelte
@@ -32,11 +32,11 @@
 
     let navWidth: string
 
-    const handleClickOutside = (): void => {
+    function handleClickOutside(): void {
         dropdown = false
     }
 
-    const toggleDropDown = () => {
+    function toggleDropDown(): void {
         dropdown = !dropdown
         isFocused = !isFocused
         if (dropdown) {
@@ -55,52 +55,60 @@
         }
     }
 
-    const focusItem = (itemId: string): void => {
+    function focusItem(itemId: string): void {
         focusedItem = document.getElementById(itemId)
     }
 
-    const handleKey = (e): void => {
+    function handleKey(event: KeyboardEvent): void {
         if (!dropdown) {
             // Note that space uses code not key, this is intentional
-            if (e.key === 'Enter' || e.key === 'ArrowDown' || e.code === 'Space') {
+            if (event.key === 'Enter' || event.key === 'ArrowDown' || event.code === 'Space') {
                 toggleDropDown()
-                e.preventDefault()
+                event.preventDefault()
             }
         } else {
-            if (e.key === 'Escape') {
+            if (event.key === 'Escape') {
                 toggleDropDown()
-                e.preventDefault()
-            } else if (e.key === 'ArrowDown') {
+                event.preventDefault()
+            } else if (event.key === 'ArrowDown') {
                 if (focusedItem) {
                     const children = [...navContainer.children]
                     const idx = children.indexOf(focusedItem)
                     if (idx < children.length - 1) {
                         children[idx + 1].focus()
-                        e.preventDefault()
+                        event.preventDefault()
                     }
                 }
-            } else if (e.key === 'ArrowUp') {
+            } else if (event.key === 'ArrowUp') {
                 if (focusedItem) {
                     const children = [...navContainer.children]
                     const idx = children.indexOf(focusedItem)
                     if (idx > 0) {
                         children[idx - 1].focus()
-                        e.preventDefault()
+                        event.preventDefault()
                     }
                 }
-            } else if ((e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 65 && e.keyCode <= 122)) {
+            } else if (isNumberLetterOrPunctuation(event.key)) {
                 const children = [...navContainer.children]
                 const itemsValues = items.map((item) => item.label.toLowerCase())
-                search += e.key
+                search += event.key
                 const idx = itemsValues.findIndex((item) => item.includes(search.toLowerCase()))
                 if (idx >= 0) {
                     children[idx].focus()
-                    e.preventDefault()
+                    event.preventDefault()
                 }
-            } else if (e.key === 'Backspace') {
+            } else if (event.key === 'Backspace') {
                 search = search.slice(0, -1)
             }
         }
+    }
+
+    function isNumberLetterOrPunctuation(key: string): boolean {
+        if (key.length !== 1) {
+            return false
+        }
+        const code = key.charCodeAt(0)
+        return (code >= 48 && code <= 57) || (code >= 65 && code <= 122)
     }
 
     onMount(() => {

--- a/packages/shared/components/inputs/Dropdown2.svelte
+++ b/packages/shared/components/inputs/Dropdown2.svelte
@@ -61,48 +61,56 @@
         focusedItem = document.getElementById(itemId)
     }
 
-    function handleKey(e): void {
+    function handleKey(event: KeyboardEvent): void {
         if (!dropdown) {
             // Note that space uses code not key, this is intentional
-            if (e.key === 'Enter' || e.key === 'ArrowDown' || e.code === 'Space') {
+            if (event.key === 'Enter' || event.key === 'ArrowDown' || event.code === 'Space') {
                 toggleDropDown()
-                e.preventDefault()
+                event.preventDefault()
             }
         } else {
-            if (e.key === 'Escape') {
+            if (event.key === 'Escape') {
                 toggleDropDown()
-                e.preventDefault()
-            } else if (e.key === 'ArrowDown') {
+                event.preventDefault()
+            } else if (event.key === 'ArrowDown') {
                 if (focusedItem) {
                     const children = [...navContainer.children]
                     const idx = children.indexOf(focusedItem)
                     if (idx < children.length - 1) {
                         children[idx + 1].focus()
-                        e.preventDefault()
+                        event.preventDefault()
                     }
                 }
-            } else if (e.key === 'ArrowUp') {
+            } else if (event.key === 'ArrowUp') {
                 if (focusedItem) {
                     const children = [...navContainer.children]
                     const idx = children.indexOf(focusedItem)
                     if (idx > 0) {
                         children[idx - 1].focus()
-                        e.preventDefault()
+                        event.preventDefault()
                     }
                 }
-            } else if ((e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 65 && e.keyCode <= 122)) {
+            } else if (isNumberLetterOrPunctuation(event.key)) {
                 const children = [...navContainer.children]
                 const itemsValues = items.map((item) => item.label.toLowerCase())
-                search += e.key
+                search += event.key
                 const idx = itemsValues.findIndex((item) => item.includes(search.toLowerCase()))
                 if (idx >= 0) {
                     children[idx].focus()
-                    e.preventDefault()
+                    event.preventDefault()
                 }
-            } else if (e.key === 'Backspace') {
+            } else if (event.key === 'Backspace') {
                 search = search.slice(0, -1)
             }
         }
+    }
+
+    function isNumberLetterOrPunctuation(key: string): boolean {
+        if (key.length !== 1) {
+            return false
+        }
+        const code = key.charCodeAt(0)
+        return (code >= 48 && code <= 57) || (code >= 65 && code <= 122)
     }
 
     onMount(() => {

--- a/packages/shared/components/inputs/Dropdown2.svelte
+++ b/packages/shared/components/inputs/Dropdown2.svelte
@@ -1,7 +1,8 @@
 <script lang="typescript">
+    import { onMount } from 'svelte'
     import { Icon, Text, Error } from 'shared/components'
     import { clickOutside } from 'shared/lib/actions'
-    import { onMount } from 'svelte'
+    import { isNumberLetterOrPunctuation } from '@lib/utils/isNumberLetterOrPunctuation'
 
     export let value: string
     export let label: string
@@ -103,14 +104,6 @@
                 search = search.slice(0, -1)
             }
         }
-    }
-
-    function isNumberLetterOrPunctuation(key: string): boolean {
-        if (key.length !== 1) {
-            return false
-        }
-        const code = key.charCodeAt(0)
-        return (code >= 48 && code <= 57) || (code >= 65 && code <= 122)
     }
 
     onMount(() => {

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -40,6 +40,36 @@
         }
     })
 
+    export function focus(): void {
+        if (!disabled) {
+            selectFirstEmpty()
+        }
+    }
+
+    export function resetAndFocus(): void {
+        if (!disabled) {
+            inputs = new Array(PIN_LENGTH)
+            selectFirstEmpty()
+        } else {
+            setTimeout(() => resetAndFocus(), 100)
+        }
+    }
+
+    function selectFirstEmpty(): void {
+        for (let j = 0; j < PIN_LENGTH; j++) {
+            if (!inputs[j] || j === PIN_LENGTH - 1) {
+                inputElements[j].focus()
+                return
+            }
+        }
+    }
+
+    function selectFirstEmptyRoot(event: KeyboardEvent): void {
+        if (event.target === root) {
+            selectFirstEmpty()
+        }
+    }
+
     function handleBackspace(): void {
         // Search for the last child with a value
         // and remove it
@@ -96,36 +126,6 @@
             inputs[index] = ''
         } else {
             inputElements[index + 1].focus()
-        }
-    }
-
-    function selectFirstEmpty(): void {
-        for (let j = 0; j < PIN_LENGTH; j++) {
-            if (!inputs[j] || j === PIN_LENGTH - 1) {
-                inputElements[j].focus()
-                return
-            }
-        }
-    }
-
-    function selectFirstEmptyRoot(event: KeyboardEvent): void {
-        if (event.target === root) {
-            selectFirstEmpty()
-        }
-    }
-
-    export function focus(): void {
-        if (!disabled) {
-            selectFirstEmpty()
-        }
-    }
-
-    export function resetAndFocus(): void {
-        if (!disabled) {
-            inputs = new Array(PIN_LENGTH)
-            selectFirstEmpty()
-        } else {
-            setTimeout(() => resetAndFocus(), 100)
         }
     }
 </script>

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -10,13 +10,13 @@
 
     const isAndroid = Platform.getOS() === 'android'
 
-    export let value = undefined
     export let classes = ''
     export let disabled = false
     export let autofocus = false
     export let glimpse = false
     export let smaller = false
-    export let error
+    export let value: string
+    export let error: string
 
     let inputs = new Array(PIN_LENGTH)
     $: {
@@ -25,13 +25,13 @@
         }
     }
 
-    let root
-    const inputElements = []
+    let root: HTMLElement
+    const inputElements: HTMLElement[] = []
 
-    const KEYBOARD = {
-        BACKSPACE: 8,
-        ENTER: 13,
-        TAB: 9,
+    enum KEYBOARD {
+        BACKSPACE = 'Backspace',
+        ENTER = 'Enter',
+        TAB = 'Tab',
     }
 
     onMount(() => {
@@ -40,7 +40,7 @@
         }
     })
 
-    const handleBackspace = () => {
+    function handleBackspace(): void {
         // Search for the last child with a value
         // and remove it
         for (let j = 1; j <= PIN_LENGTH; j++) {
@@ -53,27 +53,26 @@
         value = inputs.join('')
     }
 
-    const changeHandler = function (e, i) {
+    function changeHandler(event: KeyboardEvent): void {
         const regex = new RegExp(/^\d+$/)
-
-        if (e.keyCode === KEYBOARD.BACKSPACE) {
+        if (event.key === KEYBOARD.BACKSPACE) {
             handleBackspace()
-        } else if (e.keyCode === KEYBOARD.ENTER) {
+        } else if (event.key === KEYBOARD.ENTER) {
             if (validatePinFormat(inputs.join(''))) {
                 dispatch('submit')
             }
-        } else if (e.keyCode === KEYBOARD.TAB) {
+        } else if (event.key === KEYBOARD.TAB) {
             // Do default tab handling by focusing the root
             // container and allow default processing to happen
             root.focus()
             return
         } else {
-            if (regex.test(e.key)) {
+            if (regex.test(event.key)) {
                 // Search from the first child to find the first
                 // empty value and start filling from there
                 for (let j = 0; j < PIN_LENGTH; j++) {
                     if (!inputs[j]) {
-                        inputs[j] = e.key
+                        inputs[j] = event.key
                         if (j < PIN_LENGTH - 1) {
                             inputElements[j + 1].focus()
                         }
@@ -83,7 +82,7 @@
                 value = inputs.join('')
             }
         }
-        e.preventDefault()
+        event.preventDefault()
     }
 
     /**
@@ -92,14 +91,15 @@
      * the auto-suggest feature or other event might follow
      * the keydown event and invalidate it.
      */
-    const changeHandlerHelper = (e, i: number) => {
-        if (!/^[0-9]$/.test(e.data)) {
-            inputs[i] = ''
+    function changeHandlerHelper(event, index: number): void {
+        if (!/^[0-9]$/.test(event.data)) {
+            inputs[index] = ''
         } else {
-            inputElements[i + 1].focus()
+            inputElements[index + 1].focus()
         }
     }
-    const selectFirstEmpty = () => {
+
+    function selectFirstEmpty(): void {
         for (let j = 0; j < PIN_LENGTH; j++) {
             if (!inputs[j] || j === PIN_LENGTH - 1) {
                 inputElements[j].focus()
@@ -108,8 +108,8 @@
         }
     }
 
-    const selectFirstEmptyRoot = (e): void => {
-        if (e.target === root) {
+    function selectFirstEmptyRoot(event: KeyboardEvent): void {
+        if (event.target === root) {
             selectFirstEmpty()
         }
     }
@@ -144,32 +144,32 @@
     >
         <div class="flex flex-row inputs-wrapper">
             <div class="input-wrapper absolute items-center w-full flex flex-row flex-no-wrap justify-between">
-                {#each inputs as item, i}
+                {#each inputs as input, i}
                     {#if $mobile}
                         <input
-                            bind:value={inputs[i]}
+                            bind:value={input}
                             maxLength="1"
                             id={`input-${i}`}
                             type="tel"
                             bind:this={inputElements[i]}
-                            class:active={!inputs[i] || inputs[i].length === 0}
+                            class:active={!input || input.length === 0}
                             class:glimpse
                             {disabled}
                             on:input={(event) => (isAndroid ? changeHandlerHelper(event, i) : undefined)}
-                            on:keydown={(event) => changeHandler(event, i)}
+                            on:keydown={(event) => changeHandler(event)}
                             on:contextmenu|preventDefault
                         />
                     {:else}
                         <input
-                            bind:value={inputs[i]}
+                            bind:value={input}
                             maxLength="1"
                             id={`input-${i}`}
                             type="text"
                             bind:this={inputElements[i]}
-                            class:active={!inputs[i] || inputs[i].length === 0}
+                            class:active={!input || input.length === 0}
                             class:glimpse
                             {disabled}
-                            on:keydown={(event) => changeHandler(event, i)}
+                            on:keydown={(event) => changeHandler(event)}
                             on:contextmenu|preventDefault
                         />
                     {/if}
@@ -178,8 +178,8 @@
             <div
                 class="input-decorator-wrapper items-center absolute w-full flex flex-row flex-no-wrap justify-between"
             >
-                {#each inputs as item, i}
-                    <input-decorator class:active={inputs[i] && inputs[i].length !== 0} class:disabled />
+                {#each inputs as input}
+                    <input-decorator class:active={input && input.length !== 0} class:disabled />
                 {/each}
             </div>
         </div>

--- a/packages/shared/lib/utils/isNumberLetterOrPunctuation.ts
+++ b/packages/shared/lib/utils/isNumberLetterOrPunctuation.ts
@@ -1,0 +1,7 @@
+export function isNumberLetterOrPunctuation(key: string): boolean {
+    if (key.length !== 1) {
+        return false
+    }
+    const code = key.charCodeAt(0)
+    return (code >= 48 && code <= 57) || (code >= 65 && code <= 122)
+}


### PR DESCRIPTION
## Summary

Replaced `keyCode` with `key`and `code` property of `KeyboardEvent`

### Changelog
```
- replaced `keyCode` with `key`and `code` in Pin/Dropdown/Dropdown2
- replaced arrow functions with regular functions
- added missing types
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/3359

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
