### PR TITLE
chore: fix Pods installation

### DIFF
--- a/packages/mobile/ios/App/Podfile
+++ b/packages/mobile/ios/App/Podfile
@@ -9,6 +9,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../../../node_modules/@capacitor/ios'
+  pod 'CapacitorSecureFilesystemAccess', :path => '../../../../node_modules/capacitor-secure-filesystem-access'
   pod 'CapacitorSplashScreen', :path => '../../../../node_modules/@capacitor/splash-screen'
   pod 'CapacitorCommunityBarcodeScanner', :path => '../../../../node_modules/@capacitor-community/barcode-scanner'
   pod 'CapacitorCommunityPrivacyScreen', :path => '../../../../node_modules/@capacitor-community/privacy-screen'

--- a/packages/mobile/ios/App/Podfile
+++ b/packages/mobile/ios/App/Podfile
@@ -19,7 +19,7 @@ end
 target 'App' do
   capacitor_pods
   # Add your Pods here
-  pod 'IotaWalletInternal', :podspec => 'https://raw.githubusercontent.com/iotaledger/wallet-ios-internal/main/IotaWalletInternal.podspec'
+  pod 'IotaWalletInternal', :podspec => 'https://raw.githubusercontent.com/iotaledger/wallet-ios-internal/v0.2.0/IotaWalletInternal.podspec'
 
 end
 

--- a/packages/mobile/ios/App/Podfile.lock
+++ b/packages/mobile/ios/App/Podfile.lock
@@ -6,6 +6,8 @@ PODS:
   - CapacitorCommunityPrivacyScreen (2.1.1):
     - Capacitor
   - CapacitorCordova (3.4.1)
+  - CapacitorSecureFilesystemAccess (0.0.1):
+    - Capacitor
   - CapacitorSecureStoragePlugin (0.6.2):
     - Capacitor
     - SwiftKeychainWrapper
@@ -21,6 +23,7 @@ DEPENDENCIES:
   - "CapacitorCommunityBarcodeScanner (from `../../../../node_modules/@capacitor-community/barcode-scanner`)"
   - "CapacitorCommunityPrivacyScreen (from `../../../../node_modules/@capacitor-community/privacy-screen`)"
   - "CapacitorCordova (from `../../../../node_modules/@capacitor/ios`)"
+  - CapacitorSecureFilesystemAccess (from `../../../../node_modules/capacitor-secure-filesystem-access`)
   - CapacitorSecureStoragePlugin (from `../../../../node_modules/capacitor-secure-storage-plugin`)
   - "CapacitorSplashScreen (from `../../../../node_modules/@capacitor/splash-screen`)"
   - FireflyActorSystemCapacitorBindings (from `../../node_modules/firefly-actor-system-capacitor-bindings`)
@@ -39,6 +42,8 @@ EXTERNAL SOURCES:
     :path: "../../../../node_modules/@capacitor-community/privacy-screen"
   CapacitorCordova:
     :path: "../../../../node_modules/@capacitor/ios"
+  CapacitorSecureFilesystemAccess:
+    :path: "../../../../node_modules/capacitor-secure-filesystem-access"
   CapacitorSecureStoragePlugin:
     :path: "../../../../node_modules/capacitor-secure-storage-plugin"
   CapacitorSplashScreen:
@@ -53,12 +58,13 @@ SPEC CHECKSUMS:
   CapacitorCommunityBarcodeScanner: fb5a4e2bae89f0a0203cb4809c2f1bfd21579791
   CapacitorCommunityPrivacyScreen: e5c4100887b28805918f92c28d3948b41cb8cc37
   CapacitorCordova: 4cf19cbad01e5a9e143e2f28f66c621c362f0f79
+  CapacitorSecureFilesystemAccess: 0b7ef212124316bf4dd5417c1b3f4a3121a38455
   CapacitorSecureStoragePlugin: b24477bcde4004d0536135fa265c9f3318ec9e7e
   CapacitorSplashScreen: 466ab02fdfcfc0efdb6167631386289e82efe2c6
   FireflyActorSystemCapacitorBindings: 59b64ff1b4cb89779283816f7d2c385849ee5247
   IotaWalletInternal: 7bbe592b3b946075aaa4d52a55df10ba7bfb8281
   SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
 
-PODFILE CHECKSUM: 5985c4d1cbab18ad6b9b2494ae5a6148f42e0f25
+PODFILE CHECKSUM: c05e76dc7faab396110bdded5e9c6b0261dc4a02
 
 COCOAPODS: 1.11.3

--- a/packages/mobile/ios/App/Podfile.lock
+++ b/packages/mobile/ios/App/Podfile.lock
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - CapacitorSecureStoragePlugin (from `../../../../node_modules/capacitor-secure-storage-plugin`)
   - "CapacitorSplashScreen (from `../../../../node_modules/@capacitor/splash-screen`)"
   - FireflyActorSystemCapacitorBindings (from `../../node_modules/firefly-actor-system-capacitor-bindings`)
-  - IotaWalletInternal (from `https://raw.githubusercontent.com/iotaledger/wallet-ios-internal/main/IotaWalletInternal.podspec`)
+  - IotaWalletInternal (from `https://raw.githubusercontent.com/iotaledger/wallet-ios-internal/v0.2.0/IotaWalletInternal.podspec`)
 
 SPEC REPOS:
   trunk:
@@ -46,7 +46,7 @@ EXTERNAL SOURCES:
   FireflyActorSystemCapacitorBindings:
     :path: "../../node_modules/firefly-actor-system-capacitor-bindings"
   IotaWalletInternal:
-    :podspec: https://raw.githubusercontent.com/iotaledger/wallet-ios-internal/main/IotaWalletInternal.podspec
+    :podspec: https://raw.githubusercontent.com/iotaledger/wallet-ios-internal/v0.2.0/IotaWalletInternal.podspec
 
 SPEC CHECKSUMS:
   Capacitor: 9ff0758671daabc97247c8c57a981379bc30bb5f
@@ -59,6 +59,6 @@ SPEC CHECKSUMS:
   IotaWalletInternal: 7bbe592b3b946075aaa4d52a55df10ba7bfb8281
   SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
 
-PODFILE CHECKSUM: 1d4d8bbb149f7bac7a5cb1b8022b43e7575d47c2
+PODFILE CHECKSUM: 5985c4d1cbab18ad6b9b2494ae5a6148f42e0f25
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## Summary
- Lock `IotaWalletInternal` to 0.2.0
- Sync Podfile with iOS Capacitor plugins (`CapacitorSecureFilesystemAccess` was missing)

### Changelog
```
- Lock `IotaWalletInternal` to 0.2.0
- Add missing`CapacitorSecureFilesystemAccess` pod
```

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [ ] Android

### Instructions
Ran `pod install` and built iOS project successfully

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code