### PR TITLE
chore: make Capacitor setup easier and CI-friendly

### DIFF
--- a/packages/mobile/.gitignore
+++ b/packages/mobile/.gitignore
@@ -1,4 +1,3 @@
-capacitor.config.ts
 capacitor.config.json
 capacitor.plugins.json
 capacitor.settings.gradle

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -48,14 +48,18 @@ packages/mobile $ yarn ios:update
 ### Development
 
 Capacitor Live Reload setup:
-```bash
-packages/mobile $ cp capacitor-sample.config.ts capacitor.config.ts 
-# modify the url field "XXX.XXX.XXX.XXX" with your local IP
 
-# or hide "Server" block to build directly on device in next step
+To run Firefly in development mode on a physical device, set an environment variable with your computer's local IP (`CAP_IP=<your local ip>`). Otherwise, `localhost` will be used by default for simulators and emulators.
+```bash
+packages/mobile $ export CAP_IP=192.168.X.X
+```
+Then, copy the Capacitor config to platform you're targeting:
+```bash
+packages/mobile $ yarn cap copy ios
+packages/mobile $ yarn cap copy android
 ```
 
-Run development server, or instead build for device:
+Run a development server, or instead build for device:
 ```bash
 # Run development server with HMR to test on simulators, emulators and phones
 packages/mobile $ yarn dev
@@ -76,8 +80,8 @@ Debug
 Optimized production ready build:
 ```bash
 packages/mobile $ yarn build
+packages/mobile $ NODE_ENV=production yarn cap copy
 packages/mobile $ yarn ios
 packages/mobile $ yarn android
 ```
 Finally build / run in Android Studio / XCode IDE.
-

--- a/packages/mobile/capacitor.config.ts
+++ b/packages/mobile/capacitor.config.ts
@@ -1,7 +1,7 @@
 import { CapacitorConfig } from '@capacitor/cli'
 
 const prod = process.env.NODE_ENV === 'production'
-const ip = process.env.IP || 'localhost'
+const ip = process.env.CAP_IP || 'localhost'
 
 const serverConfig = {
     url: `http://${ip}:8080`,

--- a/packages/mobile/capacitor.config.ts
+++ b/packages/mobile/capacitor.config.ts
@@ -1,5 +1,13 @@
 import { CapacitorConfig } from '@capacitor/cli'
 
+const prod = process.env.NODE_ENV === 'production'
+const ip = process.env.IP || 'localhost'
+
+const serverConfig = {
+    url: `http://${ip}:8080`,
+    cleartext: true,
+}
+
 const config: CapacitorConfig = {
     appId: 'org.iota.firefly.mobile.alpha',
     appName: 'Firefly',
@@ -14,10 +22,7 @@ const config: CapacitorConfig = {
             backgroundColor: '#ffffffff',
         },
     },
-    server: {
-        url: 'http://XXX.XXX.XXX.XXX:8080',
-        cleartext: true,
-    },
+    server: prod ? undefined : serverConfig,
     cordova: {
         preferences: {
             DisableDeploy: 'true',


### PR DESCRIPTION
## Summary
This PR combines `capacitor-sample.config.ts` and the gitignored `capacitor.config.ts`. `capacitor.config.ts` used to contain developer-specific settings such as the local IP, so it was not checked in to Git. By putting it in Git and using environment variables, we can ensure that changes to things such as plugin configurations are mirrored to all developers, but developers can still set their local IP without having to change a file that is under version control. This also makes the workflow easier for CI, because `capacitor.config.ts` would need to be modified with `jq` or `sed` otherwise.

### Changelog
```
- Use environment variables to set Capacitor server
- Update docs
```

## Relevant Issues
N/A

## Type of Change
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [x] __Docs__ - changes to the documentation


## Testing
### Platforms
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [ ] Android

### Instructions
Verified that `capacitor.config.json` is generated properly when using environment variables with `yarn cap copy`

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
