### PR TITLE
fix: init performance on mobile

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -45,7 +45,7 @@
     }
 
     $: if ($isLocaleLoaded) {
-        hideSplashScreen()
+        void hideSplashScreen()
     }
 
     async function hideSplashScreen() {

--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { nativeSplash } from 'capacitor/capacitorApi'
-    import { onMount } from 'svelte'
+    import { onMount, tick } from 'svelte'
     import { QRScanner, Route, ToastContainer, Popup } from 'shared/components'
     import { popupState } from 'shared/lib/popup'
     import { mobile, stage } from 'shared/lib/app'
@@ -44,7 +44,14 @@
         document.dir = $localeDirection
     }
 
-    $: $isLocaleLoaded, nativeSplash.hide()
+    $: if ($isLocaleLoaded) {
+        hideSplashScreen()
+    }
+
+    async function hideSplashScreen() {
+        await tick()
+        nativeSplash.hide()
+    }
 
     void setupI18n()
 
@@ -69,7 +76,6 @@
             locale={$_}
         />
     {/if}
-    <!-- TODO: remove locale={$_} everywhere -->
     <Route route={AppRoute.Welcome}>
         <Welcome locale={$_} />
     </Route>

--- a/packages/mobile/public/index.html
+++ b/packages/mobile/public/index.html
@@ -13,6 +13,8 @@
         <title>Firefly</title>
 
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <link rel="preload" href="/build/index.css" as="style">
+        <link rel="preload" href="/build/index.js" as="script">
         <link rel="stylesheet" href="/build/index.css" />
 
         <script defer src="/build/index.js"></script>

--- a/packages/mobile/public/index.html
+++ b/packages/mobile/public/index.html
@@ -13,7 +13,7 @@
         <title>Firefly</title>
 
         <link rel="icon" type="image/png" href="/favicon.png" />
-        <link type="text/css" rel="stylesheet" href="/build/index.css" />
+        <link rel="stylesheet" href="/build/index.css" />
 
         <script defer src="/build/index.js"></script>
     </head>


### PR DESCRIPTION
## Summary
Current behavior:
1- The splash screen hides before locales are loaded, notably visible at loading them.
2- There is a type mismatch when loading the css main file. Also based on this info:
 - https://web.dev/preload-scanner/
 - https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
seems that there is room for improvment.

This PR uses the `tick` Svelte function to wait until the locales are applied to finally hide the splash screen.
Also removes the `type` property on the `link` tag.
Lastly I added the `link` tags with `preload` value for CSS and JS main files ["...to start loading early in the page lifecycle, before browsers' main rendering machinery kicks in. This ensures they are available earlier and are less likely to block the page's render, improving performance."](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload)

### Changelog
```
- Fix locales sentence and add tick function.
- Add `link` tags for CSS and JS main resources.
```

## Relevant Issues

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [x] Android

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
