### PR TITLE
fix: create password upon recovery

### DIFF
--- a/packages/shared/components/inputs/ImportTextfield.svelte
+++ b/packages/shared/components/inputs/ImportTextfield.svelte
@@ -98,6 +98,7 @@
                         value = trimmedContent
                     } catch (err) {
                         error = true
+                        console.error(err)
                         statusMessage = locale(err.error)
                     }
                 }

--- a/packages/shared/lib/core/profile/actions/new-profile.ts
+++ b/packages/shared/lib/core/profile/actions/new-profile.ts
@@ -29,13 +29,13 @@ export async function createNewProfile(
     }
 
     // TODO: build custom client options for custom network
-    const clientOptions = await getDefaultClientOptions(networkProtocol, networkType)
+    const clientOptions = getDefaultClientOptions(networkProtocol, networkType)
     const profile = buildNewProfile(isDeveloperProfile, networkProtocol, networkType, clientOptions, name)
     newProfile.set(profile)
     const path = await getStorageDirectoryOfProfile(get(newProfile).id)
 
     initialiseProfileManager(path, clientOptions, {
-        Stronghold: { password: '', snapshotPath: `${path}/wallet.stronghold` },
+        Stronghold: { snapshotPath: `${path}/wallet.stronghold` },
     })
 }
 

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -51,6 +51,7 @@
 
                 $appRouter.next({ password })
             } catch (err) {
+                console.error(err)
                 showAppNotification({
                     type: 'error',
                     message: locale(err.error),


### PR DESCRIPTION
## Summary

Fixed the rust error upon importing an existing account with a recovery phrase

### Changelog
```
- Stronghold initiliazed without a password
- Better rust error logging
```

## Relevant Issues

https://github.com/iotaledger/firefly/issues/3432

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
