### PR TITLE
fix: bottom navigation for account history

### DIFF
--- a/packages/shared/components/TransactionTabs.svelte
+++ b/packages/shared/components/TransactionTabs.svelte
@@ -33,93 +33,95 @@
     let isSearching = false
 </script>
 
-<nav class="grid justify-around gap-4 items-center mb-4 mt-7 mx-6">
-    <ul class="relative flex items-center p-0" style="border-radius: 11px;">
-        {#each tabs as tab, i}
-            <li id="tab{i + 1}" class:selected={current === tab} class="z-10 relative">
-                <button on:click={() => (current = tab)}>
-                    <Text
-                        classes="text-13"
-                        bold={current === tab}
-                        highlighted={current === tab}
-                        secondary={current !== tab}
-                    >
-                        {localize(`general.${tab}`)}</Text
-                    >
-                </button>
-            </li>
-        {/each}
-        <span id="check-square" class="absolute z-0 text-blue-500 border-b-2 border-blue-500 border-solid shadow-sm" />
-    </ul>
-    <span
-        id="search"
-        on:click={() => (isSearching = !isSearching)}
-        class="col-start-2 row-start-1 z-10 pr-4 rounded-xl bg-gray-100 dark:bg-gray-900"
-    />
-    <div
-        role="searchbox"
-        class="z-10 absolute right-0 h-10 mr-8 rounded-xl bg-gray-100 dark:bg-gray-900"
-        style="width: {!isSearching ? '0' : '86vw'}; transition: width 0.5s cubic-bezier(0, 0.5, 0, 1.15) {!isSearching
-            ? '0.4s'
-            : '0.1s'};"
-    >
-        <input
-            type="search"
-            spellcheck="false"
-            autocomplete="false"
-            on:input={(e) => dispatch('search', e.data ?? 'BACKSPACE')}
-            class="h-10 w-11/12 pl-10 text-blue-500 dark:text-white"
-            style="-webkit-appearance: none; appearance: none; background: rgba(0,0,0,0); display: {!isSearching
-                ? 'none'
-                : 'block'}"
-        />
-    </div>
-    <svg
-        width={icon.width}
-        height={icon.height}
-        viewBox="0 0 {icon.width} {icon.height}"
-        class="icon col-start-2 row-start-1 z-10 text-blue-500 dark:text-white"
-        style="margin-left: {isSearching ? '-72vw' : '8px'}; transform: rotate({!isSearching ? 0 : 90}deg);"
-    >
-        <path
-            d={icon.path[0].d}
-            fill-rule={icon.path[0].fillRule}
-            clip-rule={icon.path[0].clipRule}
-            class:fill-current={true}
-        />
-    </svg>
-    {#if isSearching}
+<div class="flex flex-auto flex-col h-full space-y-4 p-6">
+    <nav class="grid justify-around gap-4 items-center mt-7 mx-6">
+        <ul class="relative flex items-center p-0" style="border-radius: 11px;">
+            {#each tabs as tab, i}
+                <li id="tab{i + 1}" class:selected={current === tab} class="z-10 relative">
+                    <button on:click={() => (current = tab)}>
+                        <Text
+                            classes="text-13"
+                            bold={current === tab}
+                            highlighted={current === tab}
+                            secondary={current !== tab}
+                        >
+                            {localize(`general.${tab}`)}</Text
+                        >
+                    </button>
+                </li>
+            {/each}
+            <span
+                id="check-square"
+                class="absolute z-0 text-blue-500 border-b-2 border-blue-500 border-solid shadow-sm"
+            />
+        </ul>
         <span
-            class="col-start-2 row-start-1 z-10"
-            in:fade={{ duration: 357, delay: 500, easing: easing.quadOut }}
-            out:fade={{ duration: 150, easing: easing.quadIn }}
+            id="search"
+            on:click={() => (isSearching = !isSearching)}
+            class="col-start-2 row-start-1 z-10 pr-4 rounded-xl bg-gray-100 dark:bg-gray-900"
+        />
+        <div
+            role="searchbox"
+            class="z-10 absolute right-0 h-10 mr-8 rounded-xl bg-gray-100 dark:bg-gray-900"
+            style="width: {!isSearching
+                ? '0'
+                : '86vw'}; transition: width 0.5s cubic-bezier(0, 0.5, 0, 1.15) {!isSearching ? '0.4s' : '0.1s'};"
         >
-            <Icon icon="close" classes="z-10 ml-2 text-blue-500 dark:text-white" width="22" height="22" />
-        </span>
-    {/if}
-    <button id="search" on:click={() => (isSearching = !isSearching)} class="col-start-2 row-start-1 z-10" />
-</nav>
-<main class="flex flex-col overflow-y-auto space-y-2 px-6">
-    {#if filtered.length > 0}
-        {#each filtered as transaction (transaction.timestamp)}
-            <div
-                class="block"
-                in:fly={{ y: 30, duration: 400, easing: easing.sineIn }}
-                out:fly={{ y: 15, duration: 200, easing: easing.sineIn }}
-                animate:flip={{ duration: 700 }}
+            <input
+                type="search"
+                spellcheck="false"
+                autocomplete="false"
+                on:input={(e) => dispatch('search', e.data ?? 'BACKSPACE')}
+                class="h-10 w-11/12 pl-10 text-blue-500 dark:text-white"
+                style="-webkit-appearance: none; appearance: none; background: rgba(0,0,0,0); display: {!isSearching
+                    ? 'none'
+                    : 'block'}"
+            />
+        </div>
+        <svg
+            width={icon.width}
+            height={icon.height}
+            viewBox="0 0 {icon.width} {icon.height}"
+            class="icon col-start-2 row-start-1 z-10 text-blue-500 dark:text-white"
+            style="margin-left: {isSearching ? '-72vw' : '8px'}; transform: rotate({!isSearching ? 0 : 90}deg);"
+        >
+            <path
+                d={icon.path[0].d}
+                fill-rule={icon.path[0].fillRule}
+                clip-rule={icon.path[0].clipRule}
+                class:fill-current={true}
+            />
+        </svg>
+        {#if isSearching}
+            <span
+                class="col-start-2 row-start-1 z-10"
+                in:fade={{ duration: 357, delay: 500, easing: easing.quadOut }}
+                out:fade={{ duration: 150, easing: easing.quadIn }}
             >
-                <slot name="transaction" {transaction} />
-            </div>
-        {/each}
-    {:else}
-        <slot />
-    {/if}
-</main>
+                <Icon icon="close" classes="z-10 ml-2 text-blue-500 dark:text-white" width="22" height="22" />
+            </span>
+        {/if}
+        <button id="search" on:click={() => (isSearching = !isSearching)} class="col-start-2 row-start-1 z-10" />
+    </nav>
+    <main class="flex flex-auto flex-col overflow-y-auto space-y-2 h-1 pr-2">
+        {#if filtered.length > 0}
+            {#each filtered as transaction (transaction.timestamp)}
+                <div
+                    class="block"
+                    in:fly={{ y: 30, duration: 400, easing: easing.sineIn }}
+                    out:fly={{ y: 15, duration: 200, easing: easing.sineIn }}
+                    animate:flip={{ duration: 700 }}
+                >
+                    <slot name="transaction" {transaction} />
+                </div>
+            {/each}
+        {:else}
+            <slot />
+        {/if}
+    </main>
+</div>
 
 <style type="text/scss">
-    main {
-        height: calc(100vh - 35ch);
-    }
     /* clears the 'X' from Chrome */
     input[type='search']::-webkit-search-decoration,
     input[type='search']::-webkit-search-cancel-button,

--- a/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
@@ -6,9 +6,11 @@
     export let classes = ''
 </script>
 
-<div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 p-6 {classes}">
-    <Text classes="text-left" type="h5">{localize('general.myAssets')}</Text>
-    <div class="flex flex-auto flex-col overflow-y-auto h-1 -mr-2 pr-2 scroll-secondary scrollable-y">
+<div class="h-full w-full space-y-4 flex flex-auto flex-col px-9 pt-6 {classes}">
+    <Text type="h5">
+        {localize('general.myAssets')}
+    </Text>
+    <div class="flex flex-auto flex-col overflow-y-auto h-1 pr-2">
         {#each $assets as asset}
             <div class="w-full mb-2.5">
                 <AssetTile {asset} />


### PR DESCRIPTION
## Summary
The bottom navigation was pushed out of the view through the account history

### Changelog
```
- Adjusted markup (AccountAssets, TransactionTabs)
- Adjusted tailwind classes in TransactionTabs component (AccountAssets, TransactionTabs)
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [x] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
