### PR TITLE
feat: handle spent output event

### DIFF
--- a/packages/shared/lib/core/profile-manager/api/events/newOutput.ts
+++ b/packages/shared/lib/core/profile-manager/api/events/newOutput.ts
@@ -7,18 +7,18 @@ import { Converter } from '@lib/converter'
 import { get } from 'svelte/store'
 import { NewOutputEvent } from '../types/newOutputEvent'
 
-export function handleNewOutputEvent(event: NewOutputEvent): void {
-    for (const account of get(activeAccounts)) {
-        const address =
-            event.output.address?.type === 0
-                ? Bech32Helper.toBech32(0, Converter.hexToBytes(event.output.address.pubKeyHash.substring(2)), 'rms')
-                : ''
-        if (event.output.address.type === 0 && account.depositAddress === address && !event.output.remainder) {
-            syncBalance(account.id)
-            addActivityToAccountActivitiesInAllAccountActivities(
-                account.id,
-                new Activity().setFromOutput(event.output.outputId, event.output, account.depositAddress, false, false)
-            )
-        }
+export function handleNewOutputEvent(accountId: string, event: NewOutputEvent): void {
+    const account = get(activeAccounts).find((account) => account.id === accountId)
+
+    const address =
+        event.output.address?.type === 0
+            ? Bech32Helper.toBech32(0, Converter.hexToBytes(event.output.address.pubKeyHash.substring(2)), 'rms')
+            : ''
+    if (event.output.address.type === 0 && account.depositAddress === address && !event.output.remainder) {
+        syncBalance(account.id)
+        addActivityToAccountActivitiesInAllAccountActivities(
+            account.id,
+            new Activity().setFromOutput(event.output.outputId, event.output, account.depositAddress, false, false)
+        )
     }
 }

--- a/packages/shared/lib/core/profile-manager/api/events/newTransactionInclusionEvent.ts
+++ b/packages/shared/lib/core/profile-manager/api/events/newTransactionInclusionEvent.ts
@@ -1,7 +1,7 @@
 import { updateActivityInclusionStateByTransactionId } from '@core/wallet/stores/all-account-activities.store'
 import { TransactionInclusionEvent } from '../types/transactionInclusionEvent'
 
-export function handleTransactionInclusionEvent(event: TransactionInclusionEvent): void {
+export function handleTransactionInclusionEvent(accountId: string, event: TransactionInclusionEvent): void {
     const transactionId = event.transaction_id
     const inclusionState = event.inclusion_state
 

--- a/packages/shared/lib/core/profile-manager/api/events/spentOutput.ts
+++ b/packages/shared/lib/core/profile-manager/api/events/spentOutput.ts
@@ -1,0 +1,6 @@
+import { OutputData } from '@iota/wallet'
+import { syncBalance } from '@core/account/actions/syncBalance'
+
+export async function handleSpentOutput(accountId: string, payload: { output: OutputData }): Promise<void> {
+    await syncBalance(accountId)
+}

--- a/packages/shared/lib/core/profile-manager/api/events/spentOutput.ts
+++ b/packages/shared/lib/core/profile-manager/api/events/spentOutput.ts
@@ -1,6 +1,8 @@
 import { OutputData } from '@iota/wallet'
 import { syncBalance } from '@core/account/actions/syncBalance'
+import { updateActivityClaimStateByTransactionId } from '@core/wallet/stores/all-account-activities.store'
 
 export async function handleSpentOutput(accountId: string, payload: { output: OutputData }): Promise<void> {
     await syncBalance(accountId)
+    updateActivityClaimStateByTransactionId(payload.output.metadata.transactionId)
 }

--- a/packages/shared/lib/core/profile-manager/api/events/subscribe.ts
+++ b/packages/shared/lib/core/profile-manager/api/events/subscribe.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store'
 import { profileManager } from '../../stores'
 import { handleNewOutputEvent } from './newOutput'
 import { handleTransactionInclusionEvent } from './newTransactionInclusionEvent'
+import { handleSpentOutput } from './spentOutput'
 
 export function subscribe(): void {
     const manager = get(profileManager)
@@ -13,6 +14,7 @@ export function subscribe(): void {
             const events = {
                 NewOutput: handleNewOutputEvent,
                 TransactionInclusion: handleTransactionInclusionEvent,
+                SpentOutput: handleSpentOutput,
                 // ...
             }
 
@@ -22,7 +24,7 @@ export function subscribe(): void {
             const eventNames = Object.keys(event)
 
             eventNames.forEach((name) => {
-                events[name](event[name])
+                events[name](accountIndex.toString(), event[name])
             })
         }
     })

--- a/packages/shared/lib/core/wallet/stores/all-account-activities.store.ts
+++ b/packages/shared/lib/core/wallet/stores/all-account-activities.store.ts
@@ -55,3 +55,18 @@ export function updateActivityInclusionStateByTransactionId(
         })
     )
 }
+
+export function updateActivityClaimStateByTransactionId(transactionId: string, isClaimed: boolean = true): void {
+    allAccountActivities.update((state) =>
+        state.map((_accountActivities) => {
+            const activity = _accountActivities.activities.find(
+                (_activity) => _activity.transactionId === transactionId
+            )
+
+            if (activity && activity.isAsync) {
+                activity.isClaimed = isClaimed
+            }
+            return _accountActivities
+        })
+    )
+}


### PR DESCRIPTION
## Summary

Handle spent out event. Update balance when a new spent output event is emitted. 

This PR also removes the iteration over all accounts. We receive `accountId` from wallet-rs so it should be used and only the account for which the event is received should be updated. 

### Changelog
```
Please write an accurate and concise changelog for your changes.
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
- [x] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
