### PR TITLE
feat: add public note to components

### DIFF
--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -15,6 +15,7 @@
     export let rawAmount: number
     export let amount: '0'
     export let unit: string
+    export let publicNote: string
 
     $: internal = recipient.type === 'account'
 
@@ -48,6 +49,7 @@
         amount,
         unit,
         recipient,
+        publicNote,
     }
 </script>
 

--- a/packages/shared/components/popups/SendFormPopup.svelte
+++ b/packages/shared/components/popups/SendFormPopup.svelte
@@ -48,6 +48,7 @@
                         amount,
                         unit,
                         recipient,
+                        publicNote,
                     },
                     overflow: true,
                 })

--- a/packages/shared/lib/core/wallet/classes/activity.class.ts
+++ b/packages/shared/lib/core/wallet/classes/activity.class.ts
@@ -28,6 +28,7 @@ export class Activity implements IActivity {
     expirationDate?: Date
     isHidden?: boolean
     isClaimed?: boolean
+    publicNote?: string
 
     setFromTransaction(transactionId: string, transaction: Transaction): Activity {
         this.id = transactionId

--- a/packages/shared/lib/core/wallet/interfaces/activity.interface.ts
+++ b/packages/shared/lib/core/wallet/interfaces/activity.interface.ts
@@ -19,6 +19,7 @@ export interface IActivity {
     expirationDate?: Date
     isHidden?: boolean
     isClaimed?: boolean
+    publicNote?: string
 
     setFromTransaction(transactionId: string, transaction: Transaction): void
     getAsyncStatus(time: Date): ActivityAsyncStatus


### PR DESCRIPTION
## Summary
Adds publicNote to transactionDetails component, sendConfirmation and activityDetails

### Changelog
```
- Adds publicNote props to components
- Adds publicNote field in activity types
```

## Relevant Issues
closes #3422

## Type of Change
- [x] __New__ - a change that implements a new feature

## Testing
### Platforms
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
