### PR TITLE
Fix: diagnostics crash if user not logged

### DIFF
--- a/packages/shared/components/popups/Diagnostics.svelte
+++ b/packages/shared/components/popups/Diagnostics.svelte
@@ -8,6 +8,7 @@
 
     export let locale: Locale
 
+    const { loggedIn } = $activeProfile ?? {}
     let contentApp = ''
     let contentSystem = ''
 
@@ -17,26 +18,26 @@
     const appVars = [
         {
             label: '',
-            value: locale('views.dashboard.security.version.title', {
+            value: locale('general.version', {
                 values: { version: $appVersionDetails.currentVersion },
             }),
         },
     ]
 
-    if ($activeProfile) {
+    if ($activeProfile && $loggedIn) {
         appVars.push({
             label: 'views.settings.language.title',
             value: $appSettings.language,
         })
         appVars.push({
             label: 'views.settings.currency.title',
-            value: $activeProfile?.settings.currency,
+            value: $activeProfile?.settings?.currency,
         })
         appVars.push({
             label: 'views.settings.networkConfiguration.nodeConfiguration.title',
             value: locale(
                 `views.settings.networkConfiguration.nodeConfiguration.${
-                    $activeProfile?.settings.networkConfig.automaticNodeSelection ? 'automatic' : 'manual'
+                    $activeProfile?.settings?.networkConfig?.automaticNodeSelection ? 'automatic' : 'manual'
                 }`
             ),
         })

--- a/packages/shared/components/popups/Diagnostics.svelte
+++ b/packages/shared/components/popups/Diagnostics.svelte
@@ -1,62 +1,61 @@
 <script lang="typescript">
-    import { Button, Text } from 'shared/components'
     import { appSettings, appVersionDetails } from '@core/app'
-    import { Platform } from 'shared/lib/platform'
+    import { localize } from '@core/i18n'
     import { activeProfile } from '@core/profile'
+    import { Button, Text } from 'shared/components'
+    import { Platform } from 'shared/lib/platform'
     import { setClipboard } from 'shared/lib/utils'
-    import { Locale } from '@core/i18n'
-
-    export let locale: Locale
+    import { onMount } from 'svelte'
 
     const { loggedIn } = $activeProfile ?? {}
+
     let contentApp = ''
     let contentSystem = ''
 
-    const combineValues = (values) =>
-        values.map((c) => (c.label ? `${locale(c.label)}: ${c.value}` : c.value)).join('\r\n')
+    const combineValues = (values): string =>
+        values.map((c) => (c.label ? `${localize(c.label)}: ${c.value}` : c.value)).join('\r\n')
 
-    const appVars = [
-        {
-            label: '',
-            value: locale('general.version', {
-                values: { version: $appVersionDetails.currentVersion },
-            }),
-        },
-    ]
+    onMount(() => {
+        const appVars = [
+            {
+                label: '',
+                value: localize('general.version', {
+                    values: { version: $appVersionDetails.currentVersion },
+                }),
+            },
+        ]
+        if ($activeProfile && $loggedIn) {
+            appVars.push({
+                label: 'views.settings.language.title',
+                value: $appSettings.language,
+            })
+            appVars.push({
+                label: 'views.settings.currency.title',
+                value: $activeProfile?.settings?.currency,
+            })
+            appVars.push({
+                label: 'views.settings.networkConfiguration.nodeConfiguration.title',
+                value: localize(
+                    `views.settings.networkConfiguration.nodeConfiguration.${
+                        $activeProfile?.settings?.networkConfig?.automaticNodeSelection ? 'automatic' : 'manual'
+                    }`
+                ),
+            })
+        }
+        contentApp = combineValues(appVars)
+        void Platform.getDiagnostics().then((values) => (contentSystem = combineValues(values)))
+    })
 
-    if ($activeProfile && $loggedIn) {
-        appVars.push({
-            label: 'views.settings.language.title',
-            value: $appSettings.language,
-        })
-        appVars.push({
-            label: 'views.settings.currency.title',
-            value: $activeProfile?.settings?.currency,
-        })
-        appVars.push({
-            label: 'views.settings.networkConfiguration.nodeConfiguration.title',
-            value: locale(
-                `views.settings.networkConfiguration.nodeConfiguration.${
-                    $activeProfile?.settings?.networkConfig?.automaticNodeSelection ? 'automatic' : 'manual'
-                }`
-            ),
-        })
-    }
-
-    contentApp = combineValues(appVars)
-
-    void Platform.getDiagnostics().then((values) => (contentSystem = combineValues(values)))
-
-    const handleCopyClick = () => {
+    function handleCopyClick(): void {
         setClipboard(contentApp + '\r\n' + contentSystem)
     }
 </script>
 
 <div class="mb-5">
-    <Text type="h4">{locale('popups.diagnostics.title')}</Text>
+    <Text type="h4">{localize('popups.diagnostics.title')}</Text>
 </div>
 <Text type="pre" secondary>{contentApp}</Text>
 <Text type="pre" secondary>{contentSystem}</Text>
 <div class="flex w-full justify-center pt-8">
-    <Button classes="w-1/2" onClick={() => handleCopyClick()}>{locale('actions.copy')}</Button>
+    <Button classes="w-1/2" onClick={() => handleCopyClick()}>{localize('actions.copy')}</Button>
 </div>


### PR DESCRIPTION
## Summary

If you try to access the diagnostics popup from anywhere out of your logged dashboard, the app crashed. 
Additionally, there was a wrong locale

### Changelog

```
fix: diagnostics crash if user not logged
chore: cleanup code
```

## Relevant Issues
Close #3507

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [x] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [x] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
