### PR TITLE
fix: persist unit on back from send confirmation popup

### DIFF
--- a/packages/shared/components/inputs/UnitInput.svelte
+++ b/packages/shared/components/inputs/UnitInput.svelte
@@ -7,7 +7,13 @@
     export let isFocused: boolean
     export let tokenMetadata: ITokenMetadata
 
-    $: unit = tokenMetadata?.unit
+    let previousTokenMetadata: ITokenMetadata = tokenMetadata
+
+    $: if (!unit) unit = tokenMetadata?.unit
+    $: if (tokenMetadata !== previousTokenMetadata) {
+        unit = tokenMetadata?.unit
+        previousTokenMetadata = tokenMetadata
+    }
 
     let items = []
     $: if (!tokenMetadata?.useMetricPrefix && tokenMetadata?.unit) {


### PR DESCRIPTION
## Summary
Needed to add some checks to the unit input so that it would only set the unit if one was not provided or if the token metadata had changed

### Change log
```
- modify reactive setting in UnitInput
```

## Relevant Issues
Please list any related issues (e.g. bug, task).

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [ ] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
