### PR TITLE
fix: fix onboarding route network selection and back buttons

### DIFF
--- a/packages/shared/routes/setup/OnboardingNetwork.svelte
+++ b/packages/shared/routes/setup/OnboardingNetwork.svelte
@@ -1,12 +1,13 @@
 <script lang="typescript">
     import { mobile } from '@core/app'
     import { localize } from '@core/i18n'
-    import { newProfile } from '@core/profile'
-    import { NetworkType, updateNewProfileNetworkType } from '@core/network'
+    import { createNewProfile, newProfile, updateNewProfile } from '@core/profile'
+    import { NetworkType } from '@core/network'
     import { appRouter } from '@core/router'
     import { Button, OnboardingLayout, Text } from 'shared/components'
     import { TextType } from 'shared/components/Text.svelte'
     import features from 'shared/features/features'
+    import { cleanupOnboarding } from '@contexts/onboarding'
 
     const networkIcon = {
         [NetworkType.Mainnet]: $newProfile?.networkProtocol,
@@ -14,11 +15,15 @@
         [NetworkType.PrivateNet]: 'settings',
     }
 
-    function onClick(networkType: NetworkType): void {
-        updateNewProfileNetworkType(networkType)
+    async function onClick(networkType: NetworkType): Promise<void> {
+        await createNewProfile($newProfile?.isDeveloperProfile, $newProfile?.networkProtocol, networkType)
         $appRouter.next({ networkType })
     }
-    function onBackClick(): void {
+
+    async function onBackClick(): Promise<void> {
+        const isDeveloperProfile = $newProfile.isDeveloperProfile
+        await cleanupOnboarding(true)
+        updateNewProfile({ isDeveloperProfile })
         $appRouter.previous()
     }
 </script>

--- a/packages/shared/routes/setup/OnboardingProtocol.svelte
+++ b/packages/shared/routes/setup/OnboardingProtocol.svelte
@@ -37,8 +37,14 @@
                 iconColor={`${NetworkProtocol[protocol]}-highlight`}
                 classes="w-full"
                 secondary
-                hidden={features?.onboarding?.[NetworkProtocol[protocol]]?.hidden}
-                disabled={!features?.onboarding?.[NetworkProtocol[protocol]]?.enabled}
+                hidden={isDeveloperProfile
+                    ? features?.onboarding?.[NetworkProtocol[protocol]]?.hidden
+                    : features?.onboarding?.[NetworkProtocol[protocol]]?.hidden ||
+                      features?.onboarding?.[NetworkProtocol[protocol]]?.[NetworkType.Mainnet]?.hidden}
+                disabled={isDeveloperProfile
+                    ? !features?.onboarding?.[NetworkProtocol[protocol]]?.enabled
+                    : !features?.onboarding?.[NetworkProtocol[protocol]]?.enabled ||
+                      !features?.onboarding?.[NetworkProtocol[protocol]]?.[NetworkType.Mainnet]?.enabled}
                 onClick={() => onClick(NetworkProtocol[protocol])}
             >
                 {protocol}

--- a/packages/shared/routes/setup/OnboardingProtocol.svelte
+++ b/packages/shared/routes/setup/OnboardingProtocol.svelte
@@ -1,21 +1,24 @@
 <script lang="typescript">
     import { appRouter } from '@core/router'
-    import { createNewProfile } from '@core/profile'
+    import { createNewProfile, newProfile, updateNewProfile } from '@core/profile'
     import { localize } from '@core/i18n'
     import { NetworkProtocol, NetworkType } from '@core/network'
-    import { mobile } from '@core/app'
     import { cleanupOnboarding } from '@contexts/onboarding'
     import { Button, OnboardingLayout, Text } from 'shared/components'
     import features from 'shared/features/features'
 
-    const isDeveloperProfile = true // TODO: use real value
+    $: isDeveloperProfile = $newProfile?.isDeveloperProfile
 
     async function onClick(networkProtocol: NetworkProtocol): Promise<void> {
-        await createNewProfile(isDeveloperProfile, networkProtocol, NetworkType.Devnet)
+        if (!isDeveloperProfile) {
+            await createNewProfile(isDeveloperProfile, networkProtocol, NetworkType.Mainnet)
+        } else {
+            updateNewProfile({ networkProtocol })
+        }
         $appRouter.next()
     }
     async function onBackClick(): Promise<void> {
-        await cleanupOnboarding()
+        await cleanupOnboarding(true)
         $appRouter.previous()
     }
 </script>

--- a/packages/shared/routes/setup/Profile.svelte
+++ b/packages/shared/routes/setup/Profile.svelte
@@ -5,6 +5,7 @@
     import { appRouter } from '@core/router'
     import { newProfile, profiles, updateNewProfile, validateProfileName } from '@core/profile'
     import { formatProtocolName } from '@core/network'
+    import { cleanupOnboarding } from '@contexts/onboarding'
 
     let error = ''
     const busy = false
@@ -16,7 +17,11 @@
     $: isProfileNameValid = profileName && profileName.trim()
     $: profileName, (error = '') // Error clears when profileName changes
 
-    function handleBackClick(): void {
+    async function handleBackClick(): Promise<void> {
+        const isDeveloperProfile = $newProfile.isDeveloperProfile
+        const networkProtocol = $newProfile.networkProtocol
+        await cleanupOnboarding(true)
+        updateNewProfile({ isDeveloperProfile, networkProtocol })
         $appRouter.previous()
     }
 


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

Fixed the onboarding routes so it correctly creates a developer or normal profile

## Changelog

```
- Get developer setting from newProfile that is set when navigating to new profile flow
- Change where a profile is created for developer profile after they select network
- Updated feature flags for protocol page to be based of protocol and network when not a developer profile
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
