### PR TITLE
fix: password key submit

### DIFF
--- a/packages/shared/components/Button.svelte
+++ b/packages/shared/components/Button.svelte
@@ -22,7 +22,7 @@
     export let xsmall = false
     export let classes = ''
     export let type = 'button'
-    export let form = ''
+    export let form = undefined
     export let autofocus = false
     export let inlineStyle = ''
     export let showHoverText = undefined

--- a/packages/shared/components/inputs/InputContainer.svelte
+++ b/packages/shared/components/inputs/InputContainer.svelte
@@ -17,6 +17,7 @@
 <div class="w-full flex flex-col space-y-1">
     <button
         class="cursor-text w-full flex flex-row"
+        type="button"
         on:click={() => {
             inputElement && inputElement.focus()
         }}

--- a/packages/shared/components/popups/PasswordPopup.svelte
+++ b/packages/shared/components/popups/PasswordPopup.svelte
@@ -36,7 +36,7 @@
     <Text type="h4">{localize('popups.password.title')}</Text>
     <Text type="p" secondary>{subtitle ?? localize('popups.password.subtitle')}</Text>
 </div>
-<form id="password-popup-form" class="flex justify-center w-full flex-row flex-wrap">
+<form id="password-popup-form" class="flex justify-center w-full flex-row flex-wrap" on:submit={handleSubmit}>
     <PasswordInput
         {error}
         classes="w-full mb-5"
@@ -47,7 +47,7 @@
     />
     <div class="flex flex-row justify-between w-full space-x-4">
         <Button secondary classes="w-1/2" onClick={handleCancelClick}>{localize('actions.cancel')}</Button>
-        <Button classes="w-1/2" type="submit" onClick={handleSubmit} disabled={!password || password.length === 0}>
+        <Button classes="w-1/2" type="submit" disabled={!password || password.length === 0}>
             {localize('actions.unlock')}
         </Button>
     </div>


### PR DESCRIPTION
## Summary
Adds type button to InputContainer's button, because the default is type submit and it was always emitting a submit event when clicked.
Moves the handle submit function call to on:submit of containing form because the button of type submit tries to submit its parent form element and emits the submit event on it.

## Relevant Issues
closes #3582 

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions
- Try any action that shows the password popup
- Write the password and press the Enter key
- It should submit the password correctly

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
