### PR TITLE
fix: input tabbing

### DIFF
--- a/packages/shared/components/inputs/InputContainer.svelte
+++ b/packages/shared/components/inputs/InputContainer.svelte
@@ -12,6 +12,8 @@
     export let clearBackground = false
     export let clearPadding = false
     export let clearBorder = false
+
+    const tabindex = Object.keys($$slots) ? -1 : 0 // if the slot is not empty then makes the button not tabbable
 </script>
 
 <div class="w-full flex flex-col space-y-1">
@@ -20,6 +22,7 @@
         on:click={() => {
             inputElement && inputElement.focus()
         }}
+        {tabindex}
     >
         <Box
             on:click


### PR DESCRIPTION
## Summary
Adds tabindex condition to InputContainer's button, so it is set as -1 when the component's slot is not empty

## Relevant Issues
closes #3584 

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions
Try tabbing inputs in a form like the add node one

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
