### PR TITLE
fix: disables "calt" font feature in Input [develop]

### DIFF
--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -172,6 +172,7 @@
         @apply pr-8;
         @apply pl-3;
         border-radius: 0.625rem; // TODO: add to tailwind
+        font-feature-settings: 'calt' off; // disables 'x' formatting while surrounded by numbers
 
         &::placeholder {
             @apply text-gray-500;


### PR DESCRIPTION
## Summary
Surrounding an `x` by numbers in input causes to format the `x` as a multiplication character because of the OpenType font features

### Changelog
```
- Adds font-feature-settings CSS attribute to Input
```

## Relevant Issues
closes #1037 #2014

## Type of Change
- [x] __Fix__ - a change that fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Type `3x3` inside an input

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
