### PR TITLE
fix: freezing long password [develop]

### DIFF
--- a/packages/shared/components/inputs/Password.svelte
+++ b/packages/shared/components/inputs/Password.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <div class={classes} class:disabled>
-    {#if showStrengthLevel}
+    {#if showStrengthLevel && strength !== undefined}
         <strength-meter class="flex flex-row justify-between items-center mb-2">
             <div class="flex flex-row">
                 <Text smaller secondary>{locale('general.passwordStrength')}:</Text>

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -18,7 +18,7 @@
     let errorConfirm = ''
     let busy = false
 
-    $: passwordStrength = checkPasswordStrength(password)
+    $: passwordStrength = checkPasswordStrength(password) ?? passwordStrength
     $: password, confirmedPassword, ((error = ''), (errorConfirm = ''))
 
     async function handleContinueClick(): Promise<void> {

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -13,11 +13,12 @@
     const existingPassword = $strongholdPassword
     let password = ''
     let confirmedPassword = ''
+    let lastCheckedPassword = ''
     let error = ''
     let errorConfirm = ''
     let busy = false
 
-    $: passwordStrength = zxcvbn(password)
+    $: passwordStrength = checkPasswordStrength(password)
     $: password, confirmedPassword, ((error = ''), (errorConfirm = ''))
 
     async function handleContinueClick(): Promise<void> {
@@ -30,10 +31,10 @@
                     length: MAX_PASSWORD_LENGTH,
                 },
             })
-        } else if (passwordStrength.score !== 4) {
+        } else if (passwordStrength?.score !== 4) {
             let errKey = 'error.password.tooWeak'
-            if (passwordStrength.feedback.warning && passwordInfo[passwordStrength.feedback.warning]) {
-                errKey = `error.password.${passwordInfo[passwordStrength.feedback.warning]}`
+            if (passwordStrength?.feedback.warning && passwordInfo[passwordStrength?.feedback.warning]) {
+                errKey = `error.password.${passwordInfo[passwordStrength?.feedback.warning]}`
             }
             error = locale(errKey)
         } else if (password !== confirmedPassword) {
@@ -61,6 +62,16 @@
     function handleBackClick(): void {
         $appRouter.previous()
     }
+
+    function checkPasswordStrength(password: string): any {
+        const NUMBER_OF_STRENGTH_VALIDATION_CHARS = 64
+        const limitedPassword = password.substring(0, NUMBER_OF_STRENGTH_VALIDATION_CHARS - 1)
+        const hasCheckedPasswordChanged = lastCheckedPassword !== limitedPassword
+        if (hasCheckedPasswordChanged) {
+            lastCheckedPassword = limitedPassword
+            return zxcvbn(limitedPassword)
+        }
+    } // zxcvbn lib recommends to not validate long passwords because of performance issues https://github.com/dropbox/zxcvbn#user-content-performance
 </script>
 
 <OnboardingLayout onBackClick={handleBackClick} {busy}>
@@ -78,7 +89,7 @@
                 strengthLevels={4}
                 showRevealToggle
                 showStrengthLevel
-                strength={passwordStrength.score}
+                strength={passwordStrength?.score}
                 {locale}
                 autofocus={!$mobile}
                 disabled={busy}


### PR DESCRIPTION
## Summary
When long passwords are used to create a new profile, the app freezes because of the zxcvbn password strength algorithm, and I've limited the number of characters being used in this function as [recommended in lib's repo readme](https://github.com/dropbox/zxcvbn#user-content-performance)

### Changelog
```
- adds wrapper function to check password strength
```

## Relevant Issues
closes #1172

## Type of Change
- [x] __Fix__ - a change which fixes an issue

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions
Create a new profile, copy and paste a password with 256 characters like this:
```
qt\V;;W-hÄP".^bWeWjs}Uds"^.9eGUa;{lV|E?u3ü)l-7~cmzZ4SfggQsYzi.1^hWZVU!NsLICj0X*%>epd\ÜmcZPS!eBLQ P>NKIDh71?Zvb_<Cbgs%yöyoyX4Q8taü${8|'Xf+HJ9{V0"3kREfSAOßÜ@_&1ku3Gßö8;9LPlPIo{BPB<5N 5|(9cHJx3?k.c}%*q7Z2PKÄö(BAb/t%gv%bFfJ!6zü7e8ä9apqV'574v@''ü}{W_eCN%O7e
```

## Checklist
Please tick all of the following boxes that are relevant to your changes, and delete those that are not.
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting