### PR TITLE
Add an expiration date if a storage deposit is needed for a transaction

### DIFF
--- a/packages/shared/components/molecules/TransactionDetails.svelte
+++ b/packages/shared/components/molecules/TransactionDetails.svelte
@@ -30,16 +30,16 @@
     export let type: ActivityType
     export let direction: ActivityDirection
     export let inclusionState: InclusionState = InclusionState.Pending
-    export let asyncStatus: ActivityAsyncStatus = undefined
-    export let formattedFiatValue: string
-    export let time: Date
-    export let metadata: string
-    export let tag: string
+    export let asyncStatus: ActivityAsyncStatus = null
+    export let formattedFiatValue: string = null
+    export let time: Date = null
+    export let metadata: string = null
+    export let tag: string = null
     export let storageDeposit = 0
-    export let expirationDate: Date
-    export let subject: Subject
-    export let claimingTransactionId: string
-    export let claimedDate: Date
+    export let expirationDate: Date = null
+    export let subject: Subject = null
+    export let claimingTransactionId: string = null
+    export let claimedDate: Date = null
 
     const explorerUrl = getOfficialExplorerUrl($activeProfile?.networkProtocol, $activeProfile?.networkType)
 

--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -121,6 +121,7 @@
         unit,
         subject: recipient,
         metadata,
+        expirationDate,
         tag,
         storageDeposit: storageDeposit,
     }

--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -33,6 +33,10 @@
     export let metadata: string
     export let tag: string
 
+    // If storage deposit is 0, then set expiration date to tomorrow
+    const defaultExpirationDate = new Date()
+    defaultExpirationDate.setDate(defaultExpirationDate.getDate() + 1)
+
     let expirationDate: Date
     let storageDeposit = 0
 
@@ -42,7 +46,7 @@
     $: internal = recipient.type === 'account'
     $: recipientAddress = recipient.type === 'account' ? recipient.account.depositAddress : recipient.address
 
-    async function _prepareOutput() {
+    async function _prepareOutput(): Promise<void> {
         outputOptions = getOutputOptions(expirationDate, recipientAddress, rawAmount, metadata, tag)
         preparedOutput = await prepareOutput($selectedAccount.id, outputOptions, {
             remainderValueStrategy: {
@@ -51,6 +55,9 @@
             },
         })
         storageDeposit = calculateStorageDepositFromOutput(preparedOutput, rawAmount)
+        if (storageDeposit && !expirationDate) {
+            expirationDate = defaultExpirationDate
+        }
     }
 
     $: $$props, expirationDate, _prepareOutput()

--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -121,7 +121,6 @@
         unit,
         subject: recipient,
         metadata,
-        expirationDate,
         tag,
         storageDeposit: storageDeposit,
     }


### PR DESCRIPTION
## Summary
Add a default expiration date for transactions with storage deposit

## Changelog

```
- If storage deposit is required, the transaction gets a default expiration date as tomorrow at the same time
```

## Relevant Issues
Closes #3591 


## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
