### PR TITLE
fix: don't restore accounts on new profile

### DIFF
--- a/packages/shared/lib/core/profile/actions/active-profile/login.ts
+++ b/packages/shared/lib/core/profile/actions/active-profile/login.ts
@@ -15,13 +15,13 @@ import { activeProfile, setTimeStrongholdLastUnlocked } from '../../stores'
 import { loadAccounts } from './loadAccounts'
 import { recoverAndLoadAccounts } from './recoverAndLoadAccounts'
 
-export async function login(firstTime: boolean = false): Promise<void> {
+export async function login(recoverAccounts: boolean = false): Promise<void> {
     const { loggedIn, lastActiveAt, id, isStrongholdLocked, type } = get(activeProfile)
     if (id) {
         loggedIn.set(true)
         await getAndUpdateNodeInfo()
 
-        if (firstTime) {
+        if (recoverAccounts) {
             void recoverAndLoadAccounts(INITIAL_ACCOUNT_GAP_LIMIT[type], INITIAL_ADDRESS_GAP_LIMIT[type])
         } else {
             void loadAccounts()

--- a/packages/shared/routes/setup/Congratulations.svelte
+++ b/packages/shared/routes/setup/Congratulations.svelte
@@ -100,7 +100,8 @@
             loadPersistedProfileIntoActiveProfile($newProfile.id)
             newProfile.set(null)
             await createNewAccount()
-            void login(true)
+            const shouldRecoverAccounts = $walletSetupType !== SetupType.New
+            void login(shouldRecoverAccounts)
         } else {
             if ($walletSetupType === SetupType.TrinityLedger) {
                 localizedBody = 'trinityLedgerBody'


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

When we make a new profile with a new seed then we will only have 1 account and no addresses used, therefore we don't need to use the recoverAccounts method to find accounts.

## Changelog

```
- check if profile is not new setup type before recovering accoutns
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
