### PR TITLE
ui: persist activity tile width

### DIFF
--- a/packages/shared/components/atoms/tiles/ActivityTile.svelte
+++ b/packages/shared/components/atoms/tiles/ActivityTile.svelte
@@ -78,21 +78,21 @@
                         >
                     {/if}
                 </div>
-                <div class="flex justify-end flex-row space-x-2">
+                <div class="flex flex-row justify-end w-1/2 space-x-2">
                     {#if isIncomingActivityUnclaimed}
                         <button
                             disabled={activity.isClaiming}
-                            class="action px-3 py-1 w-full text-center rounded-4 font-normal text-14 text-blue-500 bg-transparent hover:bg-blue-200"
+                            class="action px-3 py-1 w-1/2 text-center rounded-4 font-normal text-14 text-blue-500 bg-transparent hover:bg-blue-200"
                             on:click|stopPropagation={() => hideActivity(activity?.id)}
                         >
                             {localize('actions.reject')}
                         </button>
                         <button
-                            class="action px-3 py-1 w-full text-center rounded-4 font-normal text-14 text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-400"
+                            class="action px-3 py-1 w-1/2 text-center rounded-4 font-normal text-14 text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-400"
                             on:click|stopPropagation={() => claimActivity(activity)}
                         >
                             {#if activity.isClaiming}
-                                <Spinner busy={true} classes="justify-center" />
+                                <Spinner busy={true} classes="justify-center h-fit" />
                             {:else}
                                 {localize('actions.claim')}
                             {/if}

--- a/packages/shared/components/atoms/tiles/ActivityTile.svelte
+++ b/packages/shared/components/atoms/tiles/ActivityTile.svelte
@@ -88,7 +88,7 @@
                             {localize('actions.reject')}
                         </button>
                         <button
-                            class="action px-3 py-1 w-1/2 text-center rounded-4 font-normal text-14 text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-400"
+                            class="action px-3 py-1 w-1/2 h-8 text-center rounded-4 font-normal text-14 text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-400"
                             on:click|stopPropagation={() => claimActivity(activity)}
                         >
                             {#if activity.isClaiming}


### PR DESCRIPTION
## Summary

Claiming button doesn't jolt vertically or horizontally if spinner is loading.

...

## Changelog

```
- Fixed horizontal spacing (relative spacing)
- Fixed vertical spacing (set pixels)
```

## Relevant Issues

closes: #3594 

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
