### PR TITLE
chore: add close buttons to mobile popups

### DIFF
--- a/packages/shared/components/Drawer.svelte
+++ b/packages/shared/components/Drawer.svelte
@@ -13,8 +13,9 @@
 	@function {() => Promise<void>} close - Closes drawer.
 -->
 <script lang="typescript">
-    import { Icon } from 'shared/components'
+    import { Text } from 'shared/components'
     import { appSettings } from 'shared/lib/appSettings'
+    import { localize } from '@core/i18n'
     import { createEventDispatcher, onMount } from 'svelte'
     import { quintIn, quintInOut, quintOut } from 'svelte/easing'
     import { tweened } from 'svelte/motion'
@@ -183,12 +184,17 @@
 			--border-radius: {fromLeft ? '0' : '24px 24px 0 0'};
 			--display-indicator: {fromLeft || preventClose ? 'none' : 'block'}"
     >
-        {#if closeButton}
-            <button on:click={close} class="absolute top-10 right-8">
-                <Icon icon="close" classes="text-gray-800 dark:text-white" />
-            </button>
-        {/if}
         <slot />
+        {#if closeButton}
+            <div class="mb-5 mx-6 flex justify-center">
+                <button
+                    class="close w-full p-3 text-center rounded-lg font-semibold text-14 bg-white dark:bg-gray-800 text-blue-500"
+                    on:click={close}
+                >
+                    <Text fontWeight="font-500" highlighted>{localize('general.close')}</Text>
+                </button>
+            </div>
+        {/if}
     </main>
 </drawer>
 
@@ -227,5 +233,10 @@
 
     .invisible {
         display: none;
+    }
+
+    .close {
+        /* Tailwind border classes doesn't have an effect */
+        border: 1px solid rgba(154, 173, 206, 0.25);
     }
 </style>

--- a/packages/shared/components/Drawer.svelte
+++ b/packages/shared/components/Drawer.svelte
@@ -13,6 +13,7 @@
 	@function {() => Promise<void>} close - Closes drawer.
 -->
 <script lang="typescript">
+    import { Icon } from 'shared/components'
     import { appSettings } from 'shared/lib/appSettings'
     import { createEventDispatcher, onMount } from 'svelte'
     import { quintIn, quintInOut, quintOut } from 'svelte/easing'
@@ -26,6 +27,7 @@
     export let fullScreen = false
     export let preventClose = false
     export let zIndex = 'z-30'
+    export let closeButton = false
     export let onClose = (): void => {}
 
     const dispatch = createEventDispatcher()
@@ -181,6 +183,11 @@
 			--border-radius: {fromLeft ? '0' : '24px 24px 0 0'};
 			--display-indicator: {fromLeft || preventClose ? 'none' : 'block'}"
     >
+        {#if closeButton}
+            <button on:click={close} class="absolute top-10 right-8">
+                <Icon icon="close" classes="text-gray-800 dark:text-white" />
+            </button>
+        {/if}
         <slot />
     </main>
 </drawer>

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -185,7 +185,13 @@
 
 <svelte:window on:keydown={onKey} />
 {#if $mobile && !fullScreen}
-    <Drawer opened zIndex="z-40" preventClose={hideClose} on:close={() => closePopup($popupState?.preventClose)}>
+    <Drawer
+        opened
+        closeButton
+        zIndex="z-40"
+        preventClose={hideClose}
+        on:close={() => closePopup($popupState?.preventClose)}
+    >
         <div bind:this={popupContent} class="py-10 px-6">
             <svelte:component this={types[type]} {...props} {locale} />
         </div>

--- a/packages/shared/locales/de.json
+++ b/packages/shared/locales/de.json
@@ -1055,6 +1055,7 @@
     },
     "general": {
         "password": "Passwort",
+        "close": "Schließen",
         "confirmPassword": "Passwort bestätigen",
         "currentPassword": "Aktuelles Passwort",
         "newPassword": "Neues Passwort",

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1061,6 +1061,7 @@
     },
     "general": {
         "password": "Password",
+        "close": "Close",
         "confirmPassword": "Confirm password",
         "currentPassword": "Current password",
         "newPassword": "New password",


### PR DESCRIPTION
## Summary

Added close buttons to mobile popups.

## Changelog

```
- Added an option to enable a close button for the drawer component
```

## Relevant Issues

Closes #3656

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
