### PR TITLE
fix: align close button of QR code screen

### DIFF
--- a/packages/shared/components/QRScanner.svelte
+++ b/packages/shared/components/QRScanner.svelte
@@ -13,7 +13,7 @@
                 </div>
             </div>
         </div>
-        <button on:click={stopQRScanner} class="absolute top-6 right-8 text-white">
+        <button on:click={stopQRScanner} class="close absolute top-6 right-8 text-white">
             <Icon icon="close" />
         </button>
     </div>
@@ -82,5 +82,9 @@
             @apply bottom-0;
             @apply border-b-blue-500;
         }
+    }
+
+    .close {
+        margin-top: calc(env(safe-area-inset-top) / 2 + 5px);
     }
 </style>


### PR DESCRIPTION
## Summary

Close button of the QR code scanner overlaps with the native upper toolbar (mainly if not always on IOS)

## Changelog

```
- Aligned the close button of the QR code scanner for curved screens
```

## Relevant Issues

Closes #3541

## Testing

### Platforms

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions
...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
