### PR TITLE
fix: change reject activity wording to hide

### DIFF
--- a/packages/shared/components/atoms/tiles/ActivityTile.svelte
+++ b/packages/shared/components/atoms/tiles/ActivityTile.svelte
@@ -99,7 +99,7 @@
                             class="action px-3 py-1 w-1/2 text-center rounded-4 font-normal text-14 text-blue-500 bg-transparent hover:bg-blue-200"
                             on:click|stopPropagation={reject}
                         >
-                            {localize('actions.reject')}
+                            {localize('actions.hide')}
                         </button>
                         <button
                             class="action px-3 py-1 w-1/2 h-8 text-center rounded-4 font-normal text-14 text-white bg-blue-500 hover:bg-blue-600 dark:hover:bg-blue-400"

--- a/packages/shared/components/popups/ActivityDetailsPopup.svelte
+++ b/packages/shared/components/popups/ActivityDetailsPopup.svelte
@@ -91,7 +91,7 @@
                 class="action p-4 w-full text-center font-medium text-15 text-blue-500 rounded-lg border border-solid border-gray-300"
                 on:click={reject}
             >
-                {localize('actions.reject')}
+                {localize('actions.hide')}
             </button>
             <button
                 disabled={activity.isClaiming}

--- a/packages/shared/lib/core/wallet/actions/hideActivity.ts
+++ b/packages/shared/lib/core/wallet/actions/hideActivity.ts
@@ -20,13 +20,13 @@ export function hideActivity(id: string): void {
 
         showAppNotification({
             type: 'info',
-            message: localize('notifications.rejected.success'),
+            message: localize('notifications.hideActivity.success'),
         })
     } catch (err) {
         console.error(err)
         showAppNotification({
             type: 'error',
-            message: localize('notifications.rejected.error'),
+            message: localize('notifications.hideActivity.error'),
         })
     }
 }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -933,8 +933,8 @@
         "claiming": "Claiming",
         "reject": "Reject",
         "confirmRejection": {
-            "title": "Reject Transaction",
-            "description": "Do you want to reject this transaction"
+            "title": "Hide Transaction",
+            "description": "Do you want to hide this transaction from your activity?"
         },
         "proceedAnyway": "Proceed anyway",
         "save": "Save",
@@ -1272,10 +1272,10 @@
             "success": "Transaction claimed",
             "error": "Claiming transaction failed"
         },
-         "rejected": {
-             "success": "Transaction rejected",
-             "error": "Rejecting transaction failed"
-         }
+        "hideActivity": {
+            "success": "Successfully hidden activity",
+            "error": "Failed to hide activity"
+        }
     },
     "error": {
         "profile": {


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

Temporarily changing the reject wording to hide until we implement the hide or return functionality.

## Changelog

```
- Rename reject to hide in the activity tile and popup button as well as on confirmation popup and notifications.
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
