### PR TITLE
fix: wrong locals are loaded on mobile

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -53,7 +53,7 @@
         nativeSplash.hide()
     }
 
-    void setupI18n()
+    void setupI18n({ fallbackLocale: 'en', initialLocale: $appSettings.language })
 
     onMount(async () => {
         initRouters()


### PR DESCRIPTION
## Summary

On mobile devices, the navigator language is loaded regardless of whether another language is configured or not.

## Changelog

```
- Changed the language setup
```

## Relevant Issues
...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
