### PR TITLE
fix: desktop settings homepage wrong icons color

### DIFF
--- a/packages/shared/components/SettingsMenu.svelte
+++ b/packages/shared/components/SettingsMenu.svelte
@@ -31,7 +31,10 @@
             ).includes(setting) && 'opacity-20 pointer-events-none'}"
             disabled={!Object.values(activeSettings).includes(setting)}
         >
-            <Icon icon={icons[setting]} classes="text-blue-500 ml-1 mr-3 group-hover:text-blue-500" />
+            <Icon
+                icon={icons[setting]}
+                classes="{$mobile ? 'text-blue-500' : 'text-gray-500'} ml-1 mr-3 group-hover:text-blue-500"
+            />
             <Text type="p" secondary classes="group-hover:text-blue-500">
                 {localize(`views.settings.${setting}.title`)}
             </Text>


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

In desktop the icons in the settings homepage are gray, and blue when hovered. This PR brings that back

## Changelog

```
fix: desktop settings homepage wrong icons color
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
