### PR TITLE
fix: top navigation wallet color no updating, wrong reactivity

### DIFF
--- a/packages/shared/components/AccountNavigation.svelte
+++ b/packages/shared/components/AccountNavigation.svelte
@@ -1,10 +1,11 @@
 <script lang="typescript">
-    import { AccountSwitcher } from 'shared/components/drawerContent'
     import { mobileHeaderAnimation } from '@lib/animation'
-    import { getAccountColor } from '@lib/profile'
-    import { selectedAccountStore } from '@lib/wallet'
+    import { activeProfile, getAccountColor } from '@lib/profile'
+    import { AccountColor } from '@lib/typings/color'
     import { createAccountCallback, WalletAccount } from '@lib/typings/wallet'
+    import { selectedAccountStore } from '@lib/wallet'
     import { Drawer, Icon, Text } from 'shared/components'
+    import { AccountSwitcher } from 'shared/components/drawerContent'
     import CreateAccount from 'shared/components/popups/CreateAccount.svelte'
     import { onDestroy } from 'svelte'
 
@@ -20,6 +21,9 @@
     let isDrawerOpened = false
     let drawerRoute = DrawerRoutes.Init
     let unsubscribeAnimateTranslationLeft = () => {}
+
+    let accountColor: string | AccountColor
+    $: $activeProfile?.accounts, (accountColor = getAccountColor($selectedAccountStore?.id))
 
     function toggleAccountSwitcher(): void {
         setDrawerRoute(DrawerRoutes.Init)
@@ -54,7 +58,7 @@
             "
         use:animateTranslationLeft
     >
-        <span class="circle" style="--account-color: {getAccountColor($selectedAccountStore?.id)}" />
+        <span class="circle" style="--account-color: {accountColor}" />
         <Text type="h4">{$selectedAccountStore?.alias}</Text>
         <div class="transform transition-transform {isDrawerOpened ? 'rotate-180' : 'rotate-0'}">
             <Icon icon="chevron-down" height="18" width="18" classes="text-gray-800 dark:text-white" />

--- a/packages/shared/components/AccountSwitcher.svelte
+++ b/packages/shared/components/AccountSwitcher.svelte
@@ -1,8 +1,9 @@
 <script lang="typescript">
     import { AccountSwitcherModal, Icon, Text, Modal } from 'shared/components'
-    import { getAccountColor, updateProfile } from '@lib/profile'
+    import { activeProfile, getAccountColor, updateProfile } from '@lib/profile'
     import { selectedAccountStore } from '@lib/wallet'
     import { WalletAccount } from '@lib/typings/wallet'
+    import { AccountColor } from '@lib/typings/color'
 
     export let accounts: WalletAccount[] = []
     export let onCreateAccount = (..._: any[]): void => {}
@@ -13,6 +14,9 @@
     let lastSelectedAccount: WalletAccount = null
     $: if ($selectedAccountStore) lastSelectedAccount = $selectedAccountStore
 
+    let accountColor: string | AccountColor
+    $: $activeProfile?.accounts, (accountColor = getAccountColor(lastSelectedAccount?.id))
+
     function onClick() {
         modal?.toggle()
         updateProfile('hasFinishedSingleAccountGuide', true)
@@ -22,7 +26,7 @@
 <svelte:window on:click={() => (isModalOpened = modal?.isOpened())} />
 <div class="relative left-8" style="-webkit-app-region: none;">
     <button on:click={onClick} class="flex flex-row justify-center items-center space-x-2">
-        <div class="circle" style="--account-color: {getAccountColor(lastSelectedAccount?.id)};" />
+        <div class="circle" style="--account-color: {accountColor};" />
         <Text type="h5">{lastSelectedAccount?.alias ?? '---'}</Text>
         <div class="transform {isModalOpened ? 'rotate-180' : 'rotate-0'}">
             <Icon height="18" width="18" icon="chevron-down" classes="text-gray-800 dark:text-white" />


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

This PR aims to add reactivity to the wallet color "circle" in the top navigation for both desktop and mobile (mobile untested, please test 🙏🏼 )

## Changelog

```
fix: top navigation wallet color no updating, wrong reactivity
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Close #3669

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
