### PR TITLE
style: set profile icon circle always blue

### DIFF
--- a/packages/shared/components/MainMenu.svelte
+++ b/packages/shared/components/MainMenu.svelte
@@ -1,8 +1,7 @@
 <script lang="typescript">
     import { Drawer, Icon, Text, ProfileActions } from 'shared/components'
     import { getInitials } from 'shared/lib/helpers'
-    import { activeProfile, getAccountColor } from 'shared/lib/profile'
-    import { selectedAccountStore } from 'shared/lib/wallet'
+    import { activeProfile } from 'shared/lib/profile'
     import { Settings } from 'shared/routes'
     import {
         profileRoute,
@@ -13,11 +12,11 @@
         SettingsRoute,
     } from '@core/router'
     import { localize } from '@core/i18n'
+    import { AccountColor } from '@lib/typings/color'
 
     export let opacity = 1
 
-    $: profileColor = getAccountColor($selectedAccountStore?.id) as string
-
+    const profileColor = AccountColor.Blue // TODO: each profile will have a different color
     let drawer: Drawer
 
     $: profileInitial = getInitials($activeProfile?.name, 1)
@@ -47,8 +46,7 @@
     style="--background-color: {profileColor}; --opacity: {opacity}"
     on:click={handleClick}
 >
-    <Text type="h4" overrideColor classes="z-10 uppercase">{profileInitial || 'A'}</Text>
-    <div class="w-11 h-11 flex rounded-full bg-white leading-100 opacity-20 absolute" />
+    <span class="text-14 font-600 text-center text-white uppercase">{profileInitial || 'A'}</span>
 </button>
 <Drawer bind:this={drawer} fromLeft fullScreen classes="flex">
     <div class="flex flex-col flex-1 mx-4">


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

This PR aims to set the profile circle always blue because Firefly is not yet compatible.
Additionally, I polished a bit the style of the profile circle to match figma

## Changelog

```
style: set profile icon circle always blue
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Close #3714

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
