### PR TITLE
fix: route components mounted before locale loaded (mobile)

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -7,7 +7,7 @@
     import { appSettings } from 'shared/lib/appSettings'
     import { goto } from 'shared/lib/helpers'
     import { localeDirection, isLocaleLoaded, setupI18n, _ } from '@core/i18n'
-    import { fetchMarketData } from 'shared/lib/market'
+    import { pollMarketData } from 'shared/lib/market'
     import { pollNetworkStatus } from 'shared/lib/networkStatus'
     import { AppRoute, initRouters } from '@core/router'
     import { Platforms } from 'shared/lib/typings/platform'
@@ -28,13 +28,14 @@
         Protect,
         Secure,
         Setup,
-        Settings,
         Welcome,
     } from 'shared/routes'
     import { Stage } from 'shared/lib/typings/stage'
 
     mobile.set(process.env.PLATFORM == Platforms.MOBILE)
     stage.set(Stage[process.env.STAGE?.toUpperCase()] ?? Stage.ALPHA)
+
+    let showSplash = true
 
     $: $appSettings.darkMode
         ? document.body.classList.add('scheme-dark')
@@ -56,82 +57,89 @@
     void setupI18n({ fallbackLocale: 'en', initialLocale: $appSettings.language })
 
     onMount(async () => {
+        // Display splash screen at least for 3 seconds
+        setTimeout(() => {
+            showSplash = false
+        }, 3000)
+
         initRouters()
-        await fetchMarketData()
+        await pollMarketData()
         await pollNetworkStatus()
     })
 </script>
 
-<!-- empty div to avoid auto-purge removing dark classes -->
-<div class="scheme-dark" />
-<div class="scanner-hide">
-    {#if $popupState.active}
-        <Popup
-            type={$popupState.type}
-            props={$popupState.props}
-            hideClose={$popupState.hideClose}
-            fullScreen={$popupState.fullScreen}
-            transition={$popupState.transition}
-            overflow={$popupState.overflow}
-            locale={$_}
-        />
-    {/if}
-    <Route route={AppRoute.Welcome}>
-        <Welcome locale={$_} />
-    </Route>
-    <Route route={AppRoute.Legal}>
-        <Legal locale={$_} />
-    </Route>
-    <Route route={AppRoute.CrashReporting}>
-        <CrashReporting locale={$_} />
-    </Route>
-    <Route route={AppRoute.Appearance}>
-        <Appearance locale={$_} />
-    </Route>
-    <Route route={AppRoute.Profile}>
-        <Profile locale={$_} />
-    </Route>
-    <Route route={AppRoute.Setup}>
-        <Setup locale={$_} />
-    </Route>
-    <Route route={AppRoute.Create}>
-        <Create locale={$_} />
-    </Route>
-    <Route route={AppRoute.Secure}>
-        <Secure locale={$_} />
-    </Route>
-    <Route route={AppRoute.Password}>
-        <Password locale={$_} />
-    </Route>
-    <Route route={AppRoute.Protect} transition={false}>
-        <Protect locale={$_} />
-    </Route>
-    <Route route={AppRoute.Backup} transition={false}>
-        <Backup locale={$_} />
-    </Route>
-    <Route route={AppRoute.Import} transition={false}>
-        <Import locale={$_} />
-    </Route>
-    <Route route={AppRoute.Balance}>
-        <Balance locale={$_} />
-    </Route>
-    <Route route={AppRoute.Migrate}>
-        <Migrate locale={$_} {goto} />
-    </Route>
-    <Route route={AppRoute.Congratulations}>
-        <Congratulations locale={$_} {goto} />
-    </Route>
-    <Route route={AppRoute.Dashboard}>
-        <Dashboard locale={$_} {goto} />
-    </Route>
-    <Route route={AppRoute.Login}>
-        <Login locale={$_} {goto} />
-    </Route>
-    <ToastContainer />
-</div>
-<div class="scanner-ui">
-    <QRScanner />
-</div>
+{#if $isLocaleLoaded && !showSplash}
+    <!-- empty div to avoid auto-purge removing dark classes -->
+    <div class="scheme-dark" />
+    <div class="scanner-hide">
+        {#if $popupState.active}
+            <Popup
+                type={$popupState.type}
+                props={$popupState.props}
+                hideClose={$popupState.hideClose}
+                fullScreen={$popupState.fullScreen}
+                transition={$popupState.transition}
+                overflow={$popupState.overflow}
+                locale={$_}
+            />
+        {/if}
+        <Route route={AppRoute.Welcome}>
+            <Welcome locale={$_} />
+        </Route>
+        <Route route={AppRoute.Legal}>
+            <Legal locale={$_} />
+        </Route>
+        <Route route={AppRoute.CrashReporting}>
+            <CrashReporting locale={$_} />
+        </Route>
+        <Route route={AppRoute.Appearance}>
+            <Appearance locale={$_} />
+        </Route>
+        <Route route={AppRoute.Profile}>
+            <Profile locale={$_} />
+        </Route>
+        <Route route={AppRoute.Setup}>
+            <Setup locale={$_} />
+        </Route>
+        <Route route={AppRoute.Create}>
+            <Create locale={$_} />
+        </Route>
+        <Route route={AppRoute.Secure}>
+            <Secure locale={$_} />
+        </Route>
+        <Route route={AppRoute.Password}>
+            <Password locale={$_} />
+        </Route>
+        <Route route={AppRoute.Protect} transition={false}>
+            <Protect locale={$_} />
+        </Route>
+        <Route route={AppRoute.Backup} transition={false}>
+            <Backup locale={$_} />
+        </Route>
+        <Route route={AppRoute.Import} transition={false}>
+            <Import locale={$_} />
+        </Route>
+        <Route route={AppRoute.Balance}>
+            <Balance locale={$_} />
+        </Route>
+        <Route route={AppRoute.Migrate}>
+            <Migrate locale={$_} {goto} />
+        </Route>
+        <Route route={AppRoute.Congratulations}>
+            <Congratulations locale={$_} {goto} />
+        </Route>
+        <Route route={AppRoute.Dashboard}>
+            <Dashboard locale={$_} {goto} />
+        </Route>
+        <Route route={AppRoute.Login}>
+            <Login locale={$_} {goto} />
+        </Route>
+        <ToastContainer />
+    </div>
+    <div class="scanner-ui">
+        <QRScanner />
+    </div>
+{/if}
 
 <style global type="text/scss">
     @tailwind base;


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

On app start, the locales where not being loaded on the first screen and that was before the components were mounted before the locale was ready. This PR aims to fix that by making sure it first loads the locale and then mounts the components.

Additionally, in this PR I added some minor changes that I felt were needed in `App.svelte `: 
- Show splash screen for 3 seconds at least to avoid quick flashes (this can be reduced if we want)
- Replace `fetchMarketData` with `pollMarketData`

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Close #3721

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
