### PR TITLE
fix: settings bottom safe area

### DIFF
--- a/packages/shared/routes/dashboard/settings/Settings.svelte
+++ b/packages/shared/routes/dashboard/settings/Settings.svelte
@@ -24,7 +24,9 @@
 
 <div
     class="relative h-full w-full px-6 pb-10 md:px-16 md:py-12 md:bg-white md:dark:bg-gray-900 flex flex-1 {$settingsRoute !==
-        SettingsRoute.Init && 'md:pt-20'} {$mobile && 'overflow-y-auto'} "
+        SettingsRoute.Init && 'md:pt-20'} {$mobile && 'overflow-y-auto'} {$settingsRoute === SettingsRoute.Init &&
+        $mobile &&
+        'settings-wrapper'}"
     in:fly={{ duration: $mobile ? 200 : 0, x: 200 }}
 >
     {#if !$mobile}
@@ -38,3 +40,9 @@
         <SettingsViewer />
     {/if}
 </div>
+
+<style>
+    .settings-wrapper {
+        margin-bottom: calc(env(safe-area-inset-bottom) + 20px);
+    }
+</style>


### PR DESCRIPTION
## Summary

Adjusted the bottom margin of the settings list with a css safe-area variable

## Changelog

```
- Changed the bottom margin calculation of the settings component
```

## Relevant Issues

Closes #3699

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
