### PR TITLE
fix: crash idle logout & mobile initialization

### DIFF
--- a/packages/shared/components/Idle.svelte
+++ b/packages/shared/components/Idle.svelte
@@ -1,10 +1,10 @@
 <script lang="typescript">
     import { lastActiveAt, logout } from 'shared/lib/app'
     import { activeProfile } from 'shared/lib/profile'
-    import { debounce } from 'shared/lib/utils'
-    import { onDestroy } from 'svelte'
-    import { get } from 'svelte/store'
     import { MILLISECONDS_PER_SECOND, SECONDS_PER_MINUTE } from 'shared/lib/time'
+    import { debounce } from 'shared/lib/utils'
+    import { onDestroy, onMount } from 'svelte'
+    import { get } from 'svelte/store'
 
     let timeout
     let isDestroyed = false
@@ -55,6 +55,9 @@
         void logout()
     }
 
+    // Initialize idle time when the component is mounted in case the user doesnt do anything at all.
+    // Important for mobile as the user can simply login and not touch the screen for a while.
+    onMount(updateIdleTime)
     onDestroy(() => {
         isDestroyed = true
         clearTimeout(timeout)

--- a/packages/shared/components/Idle.svelte
+++ b/packages/shared/components/Idle.svelte
@@ -3,11 +3,20 @@
     import { activeProfile } from 'shared/lib/profile'
     import { MILLISECONDS_PER_SECOND, SECONDS_PER_MINUTE } from 'shared/lib/time'
     import { debounce } from 'shared/lib/utils'
-    import { onDestroy, onMount } from 'svelte'
+    import { wallet } from 'shared/lib/wallet'
+    import { onDestroy } from 'svelte'
     import { get } from 'svelte/store'
+
+    const { accountsLoaded } = $wallet
 
     let timeout
     let isDestroyed = false
+
+    // Initialize idle time when the accounts are loaded.
+    // Important for mobile as the user can simply login and not touch the screen for a while.
+    $: if ($accountsLoaded) {
+        debounce(updateIdleTime)()
+    }
 
     function updateIdleTime(): void {
         /**
@@ -55,9 +64,6 @@
         void logout()
     }
 
-    // Initialize idle time when the component is mounted in case the user doesnt do anything at all.
-    // Important for mobile as the user can simply login and not touch the screen for a while.
-    onMount(updateIdleTime)
     onDestroy(() => {
         isDestroyed = true
         clearTimeout(timeout)

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -482,7 +482,7 @@
                 >
                     <DashboardPane classes="w-full">
                         {#if $walletRoute === WalletRoute.Assets}
-                            <div class="h-full" in:fade={{ duration: 200 }} out:fade={{ duration: 200 }}>
+                            <div class="h-full" in:fade|local={{ duration: 200 }} out:fade|local={{ duration: 200 }}>
                                 <AccountAssets
                                     {scroll}
                                     {scrollDetection}
@@ -490,7 +490,7 @@
                                 />
                             </div>
                         {:else if $walletRoute === WalletRoute.AccountHistory}
-                            <div class="h-full" in:fade={{ duration: 200 }} out:fade={{ duration: 200 }}>
+                            <div class="h-full" in:fade|local={{ duration: 200 }} out:fade|local={{ duration: 200 }}>
                                 <AccountHistory
                                     {scroll}
                                     {scrollDetection}


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

This PR aims to fix 2 issues:
- If you had the receive QR drawer open when the idle timeout was triggered, the app crashed because the `Wallet.svelte` component wasnt destroyed at a right time because of the child transitions. Adding `|local` to the transitions fixes the issue and allows the component to destroy on time without the need to wait for the transitions. [Source](https://svelte.dev/docs#template-syntax-element-directives-transition-fn-transition-events): `Local transitions only play when the block they belong to is created or destroyed, not when parent blocks are created or destroyed.`
- On mobile, for the idle timeout to start, the user had to do some explicit interaction to the screen, which in mobile is a touch event. This PR fixes the issue by updating the timeout when the accounts are loaded. 

## Changelog

```
- fix: idle logout crash due to transitioned component not being destroyed
- fix: idle timeout not starting until the user touches the screen
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Close #3657

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
