### PR TITLE
feat: initialize firefly theme to `system` by default on every platform

### DIFF
--- a/packages/shared/lib/appSettings.ts
+++ b/packages/shared/lib/appSettings.ts
@@ -3,19 +3,6 @@ import { persistent } from './helpers'
 import { AppSettings, AppTheme } from './typings/app'
 
 /**
- * The application settings used throughout the application code, useful for
- * global settings beyond individual profile settings.
- */
-export const appSettings = persistent<AppSettings>('settings', {
-    deepLinking: false,
-    language: 'en',
-    theme: 'light',
-    darkMode: false,
-    notifications: true,
-    sendCrashReports: false,
-})
-
-/**
  * The initial application settings, useful for things that require
  * Firefly to restart\*:
  * - Sentry diagnostic reporting for errors and crashes - the Electron
@@ -70,3 +57,16 @@ export const lastAcceptedPrivacyPolicy = persistent<number>('lastAcceptedPrivacy
  * Note: The initial value must be set to 1 to support existing users and alert them
  */
 export const lastAcceptedTos = persistent<number>('lastAcceptedTos', 1)
+
+/**
+ * The application settings used throughout the application code, useful for
+ * global settings beyond individual profile settings.
+ */
+export const appSettings = persistent<AppSettings>('settings', {
+    deepLinking: false,
+    language: 'en',
+    theme: 'system',
+    darkMode: shouldBeDarkMode('system'),
+    notifications: true,
+    sendCrashReports: false,
+})


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

This PR sets the `appSettings.theme` to `system` the first time the user uses Firefly. 

⚠️ This change affects both **desktop** and **mobile**.

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Close #3653

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
