### PR TITLE
chore: center wallet action headers and adjust paddings

### DIFF
--- a/packages/shared/components/drawerContent/AccountSwitcher.svelte
+++ b/packages/shared/components/drawerContent/AccountSwitcher.svelte
@@ -135,7 +135,7 @@
     }
 </script>
 
-<div class="mb-4 flex w-full justify-center">
+<div class="mb-4 -mt-1 flex w-full justify-center">
     <Text type="h4">{localize('general.switchWallet')}</Text>
     <button class="fixed right-5 pr-5" on:click={() => (toggleEdit = !toggleEdit)}>
         <Text type="h5" overrideColor classes="text-blue-500 pt-1">

--- a/packages/shared/components/drawerContent/AddressHistory.svelte
+++ b/packages/shared/components/drawerContent/AddressHistory.svelte
@@ -26,8 +26,8 @@
     }
 </script>
 
-<div class="flex flex-col px-6 {$mobile ? 'safe-area pt-7 pb-3' : 'py-10'}">
-    <div class="mb-5">
+<div class="flex flex-col {$mobile ? 'safe-area p-5' : 'px-6 py-10'}">
+    <div class={$mobile ? 'flex flex-row justify-center mb-6' : 'mb-5'}>
         <Text type="h4">{localize('popups.addressHistory.title', { values: { name: account.alias } })}</Text>
     </div>
     <div class="history flex flex-row flex-wrap space-y-7 {$mobile ? 'overflow-y-auto' : 'scrollable-y'}">

--- a/packages/shared/components/drawerContent/AddressHistory.svelte
+++ b/packages/shared/components/drawerContent/AddressHistory.svelte
@@ -26,7 +26,7 @@
     }
 </script>
 
-<div class="flex flex-col {$mobile ? 'safe-area p-5' : 'px-6 py-10'}">
+<div class="flex flex-col {$mobile ? 'safe-area p-5 pt-6' : 'px-6 py-10'}">
     <div class={$mobile ? 'flex flex-row justify-center mb-6' : 'mb-5'}>
         <Text type="h4">{localize('popups.addressHistory.title', { values: { name: account.alias } })}</Text>
     </div>

--- a/packages/shared/components/drawerContent/ExportTransactionHistory.svelte
+++ b/packages/shared/components/drawerContent/ExportTransactionHistory.svelte
@@ -96,7 +96,7 @@
     }
 </script>
 
-<div class="safe-area flex flex-col p-5">
+<div class="safe-area flex flex-col p-5 pt-6">
     <div class="flex flex-row justify-center mb-6">
         <Text type="h4">{localize('popups.exportTransactionHistory.title')}</Text>
     </div>

--- a/packages/shared/components/drawerContent/ExportTransactionHistory.svelte
+++ b/packages/shared/components/drawerContent/ExportTransactionHistory.svelte
@@ -96,8 +96,10 @@
     }
 </script>
 
-<div class="flex flex-col px-6 py-10">
-    <Text type="h4" classes="mb-6">{localize('popups.exportTransactionHistory.title')}</Text>
+<div class="safe-area flex flex-col p-5">
+    <div class="flex flex-row justify-center mb-6">
+        <Text type="h4">{localize('popups.exportTransactionHistory.title')}</Text>
+    </div>
     <Text type="p" secondary classes="mb-5">{localize('popups.exportTransactionHistory.body')}</Text>
     <div class="flex w-full flex-row flex-wrap">
         <div class="flex w-full flex-row flex-wrap mb-1 justify-between">
@@ -141,3 +143,9 @@
         </div>
     </div>
 </div>
+
+<style>
+    .safe-area {
+        margin-bottom: calc(env(safe-area-inset-top) / 2);
+    }
+</style>

--- a/packages/shared/components/drawerContent/HideAccount.svelte
+++ b/packages/shared/components/drawerContent/HideAccount.svelte
@@ -123,7 +123,9 @@
         </div>
     {:else}
         <div class="mb-6 -mt-4">
-            <Text type="h4" classes="flex w-full justify-center">{localize('popups.hideAccount.errorTitle', { values: { name: account?.alias } })}</Text>
+            <Text type="h4" classes="flex w-full justify-center">
+                {localize('popups.hideAccount.errorTitle', { values: { name: account?.alias } })}
+            </Text>
         </div>
         <div class="flex w-full flex-row flex-wrap">
             <Text type="p" secondary classes="mb-3">{localize('popups.hideAccount.errorBody1')}</Text>

--- a/packages/shared/components/drawerContent/HideAccount.svelte
+++ b/packages/shared/components/drawerContent/HideAccount.svelte
@@ -75,7 +75,7 @@
 <div class="flex flex-col px-6 py-10">
     {#if canDelete}
         <div class="mb-5">
-            <Text type="h4">
+            <Text type="h4 w-full justify-center">
                 {localize(`popups.hideAccount.${hasMultipleAccounts ? 'title' : 'errorTitle'}`, {
                     values: { name: account?.alias },
                 })}
@@ -122,8 +122,8 @@
             </div>
         </div>
     {:else}
-        <div class="mb-5">
-            <Text type="h4">{localize('popups.hideAccount.errorTitle', { values: { name: account?.alias } })}</Text>
+        <div class="mb-6 -mt-4">
+            <Text type="h4" classes="flex w-full justify-center">{localize('popups.hideAccount.errorTitle', { values: { name: account?.alias } })}</Text>
         </div>
         <div class="flex w-full flex-row flex-wrap">
             <Text type="p" secondary classes="mb-3">{localize('popups.hideAccount.errorBody1')}</Text>

--- a/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
@@ -76,7 +76,7 @@
     $: hasColorChanged = getAccountColor(account.id) !== color
 </script>
 
-<div class="w-full h-full flex flex-col justify-between {$mobile ? 'safe-area p-5' : 'p-6'}">
+<div class="w-full h-full flex flex-col justify-between {$mobile ? 'safe-area p-5 pt-6' : 'p-6'}">
     <div>
         <div class="flex flex-row mb-6 {$mobile && 'justify-center'}">
             <Text type="h5">{localize('general.manageAccount')}</Text>

--- a/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
@@ -76,9 +76,9 @@
     $: hasColorChanged = getAccountColor(account.id) !== color
 </script>
 
-<div class="w-full h-full flex flex-col justify-between p-6">
+<div class="w-full h-full flex flex-col justify-between {$mobile ? 'safe-area p-5' : 'p-6'}">
     <div>
-        <div class="flex flex-row mb-6">
+        <div class="flex flex-row mb-6 {$mobile && 'justify-center'}">
             <Text type="h5">{localize('general.manageAccount')}</Text>
         </div>
         <div class="w-full flex flex-col justify-between">
@@ -113,3 +113,9 @@
         </div>
     {/if}
 </div>
+
+<style>
+    .safe-area {
+        margin-bottom: calc(env(safe-area-inset-top) / 2);
+    }
+</style>


### PR DESCRIPTION
## Summary

This PR centers the headers of all wallet actions and adjusts the padding.

## Changelog

```
- Wallet actions drawer headers centered
- Wallet actions drawer padding changed to 20px (except top: 24px)
```

## Relevant Issues

Closes #3749

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
