### PR TITLE
fix: send confirmation popup close

### DIFF
--- a/packages/shared/components/organisms/AccountActivity.svelte
+++ b/packages/shared/components/organisms/AccountActivity.svelte
@@ -91,16 +91,18 @@
             {#if $selectedAccount.isSyncing && shouldShowFirstSync()}
                 <Text secondary classes="text-center">{localize('general.firstSync')}</Text>
             {:else if $groupedActivities.length}
-                {#each $groupedActivities as group}
-                    <div class="space-y-2">
-                        <Text fontWeight={FontWeightText.semibold} color="gray-600">
-                            {group.date} • {group.activities.length}
-                        </Text>
-                        {#each group.activities as activity}
-                            <ActivityTile onClick={() => void handleTransactionClick(activity)} {activity} />
-                        {/each}
-                    </div>
-                {/each}
+                <div class="space-y-4">
+                    {#each $groupedActivities as group}
+                        <div class="space-y-2">
+                            <Text fontWeight={FontWeightText.semibold} color="gray-600">
+                                {group.date} • {group.activities.length}
+                            </Text>
+                            {#each group.activities as activity}
+                                <ActivityTile onClick={() => void handleTransactionClick(activity)} {activity} />
+                            {/each}
+                        </div>
+                    {/each}
+                </div>
             {:else}
                 <div class="h-full flex flex-col items-center justify-center text-center">
                     <Text secondary>{localize('general.noRecentHistory')}</Text>

--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -77,12 +77,17 @@
         storageDeposit = calculateStorageDepositFromOutput(preparedOutput, rawAmount)
     }
 
+    async function validateAndSendOutput(): Promise<void> {
+        validateSendConfirmation(outputOptions, preparedOutput)
+        await sendOutput(outputOptions, preparedOutput)
+        closePopup()
+    }
+
     async function onConfirm(): Promise<void> {
         error = null
         try {
             if ($isSoftwareProfile) {
-                validateSendConfirmation(outputOptions, preparedOutput)
-                await checkStronghold(() => sendOutput(outputOptions, preparedOutput), true)
+                await checkStronghold(validateAndSendOutput, true)
             }
         } catch (err) {
             if (!error) {
@@ -114,13 +119,6 @@
             if (!error) {
                 error = err.error ? new BaseError({ message: err.error, logError: true }) : err
             }
-        }
-        if ($isTransferring) {
-            isTransferring.subscribe((value) => {
-                if (!value) {
-                    closePopup()
-                }
-            })
         }
     })
 </script>

--- a/packages/shared/lib/stronghold.ts
+++ b/packages/shared/lib/stronghold.ts
@@ -27,6 +27,8 @@ export async function checkStronghold(callback: () => Promise<unknown>, reopenPo
             await isStrongholdUnlockedListener()
             if (reopenPopup) {
                 openPopup({ ...popup, props: { ...popup.props, _onMount: callback } })
+            } else {
+                return callback()
             }
         }
     } catch (err) {


### PR DESCRIPTION
## Summary
Closes send confirmation popup after sending output 

## Relevant Issues
closes #3753

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions
- Go through the send transaction flow with the stronghold locked
- Go through the send transaction flow with the stronghold unlocked

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
