### PR TITLE
chore: hide settings for mobile

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -17,6 +17,10 @@
         settingsRouter,
     } from '@core/router'
 
+    const { NetworkStatus, ...generalSettingsMobile } = GeneralSettings
+
+    const { CrashReporting, ...advancedSettingsMobile } = AdvancedSettings
+
     const securitySettings = Object.assign({}, SecuritySettings)
     const advancedSettings = Object.assign({}, AdvancedSettings)
 
@@ -69,7 +73,7 @@
             icon="settings"
             iconColor="bg-blue-500"
             icons={SettingsIcons}
-            settings={GeneralSettings}
+            settings={$mobile ? generalSettingsMobile : GeneralSettings}
             activeSettings={$loggedIn ? GeneralSettings : GeneralSettingsNoProfile}
             title={localize('views.settings.generalSettings.title')}
             description=""
@@ -89,7 +93,7 @@
             icon="tools"
             iconColor="bg-green-600"
             icons={SettingsIcons}
-            settings={advancedSettings}
+            settings={$mobile ? advancedSettingsMobile : advancedSettings}
             activeSettings={$loggedIn ? advancedSettings : AdvancedSettingsNoProfile}
             title={localize('views.settings.advancedSettings.title')}
             description=""

--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -18,9 +18,7 @@
     } from '@core/router'
 
     const { NetworkStatus, ...generalSettingsMobile } = GeneralSettings
-
-    const { CrashReporting, ...advancedSettingsMobile } = AdvancedSettings
-
+    const { CrashReporting, MigrateLedgerIndex, ...advancedSettingsMobile } = AdvancedSettings
     const securitySettings = Object.assign({}, SecuritySettings)
     const advancedSettings = Object.assign({}, AdvancedSettings)
 


### PR DESCRIPTION
## Summary

This PR should hide all settings not needed for the current mobile version.

## Changelog

```
- Hides NetworkStatus
- Hides CrashReport 
```

## Relevant Issues

Closes #3717

## Testing

### Platforms

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
