### PR TITLE
chore: disable csv export of transaction history

### DIFF
--- a/packages/shared/components/drawerContent/AccountSwitcher.svelte
+++ b/packages/shared/components/drawerContent/AccountSwitcher.svelte
@@ -44,11 +44,12 @@
             action: handleViewAddressHistoryClick,
             style: 'DEFAULT',
         },
-        {
-            title: localize('actions.exportTransactionHistory'),
-            action: handleExportTransactionHistoryClick,
-            style: 'DEFAULT',
-        },
+        // ToDo: Has to be enabled again, when the export works
+        // {
+        //     title: localize('actions.exportTransactionHistory'),
+        //     action: handleExportTransactionHistoryClick,
+        //     style: 'DEFAULT',
+        // },
         {
             title: localize(
                 canDelete ? 'actions.deleteAccount' : hidden ? 'actions.showAccount' : 'actions.hideAccount'


### PR DESCRIPTION
## Summary

This PR removes the action sheet button for exporting an account's transaction history. 

## Changelog

```
- Removed action sheet button for transaction history export
```

## Relevant Issues

Closes #3786

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
