### PR TITLE
style: change address input style to display the entire address

### DIFF
--- a/packages/shared/components/inputs/Address.svelte
+++ b/packages/shared/components/inputs/Address.svelte
@@ -26,22 +26,21 @@
         <textarea
             bind:this={textAreaElement}
             bind:value={address}
-            class="w-full text-12 border border-solid resize-none {!$mobile && 'leading-140'}
+            class="w-full text-12 border border-solid resize-none
                 {disabled
                 ? 'text-gray-400 dark:text-gray-700'
                 : 'text-gray-800 dark:text-white'} bg-white dark:bg-gray-800 
                 {error
                 ? 'border-red-300 hover:border-red-500 focus:border-red-500'
                 : 'border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-700 focus:border-blue-500 dark:focus:border-gray-600'} "
-            class:floating-active={address && label}
+            class:floating-active={address && label && $mobile === false}
             {placeholder}
             {disabled}
             spellcheck={false}
             maxlength={ADDRESS_LENGTH}
-            rows={$mobile ? 1 : 2}
             class:mobile={$mobile}
         />
-        {#if label}
+        {#if label && $mobile === false}
             <floating-label class:floating-active={address && label}>{label}</floating-label>
         {/if}
     </address-input>
@@ -58,7 +57,7 @@
         border-radius: 0.625rem; // TODO: add to tailwind
 
         &.mobile {
-            @apply leading-9;
+            @apply px-3;
             @apply py-1.5;
         }
 
@@ -77,10 +76,6 @@
         &.floating-active {
             @apply pt-6;
             @apply pb-2;
-            &.mobile {
-                @apply pt-3;
-                @apply pb-0;
-            }
         }
 
         + floating-label {

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -528,7 +528,7 @@
                                 bind:address
                                 label={localize('general.sendToAddress')}
                                 disabled={$isTransferring}
-                                placeholder={`${localize('general.sendToAddress')}: ${addressPrefix}...`}
+                                placeholder={`${localize('general.sendToAddress')} \n${addressPrefix}...`}
                                 classes="mb-6"
                                 autofocus={false}
                             />


### PR DESCRIPTION
## Summary

This PR changes the style of the address textarea to display the entire address.

I disabled the floating-label for mobile, so it doesn't change the textarea size, when focused. Let me know, If the floating-label should definitely be shown, then I will change it back.

@amadeu2 The one line solution was hard/not to implement with the textarea. I discussed that with Begoña and we came to the conclusion that it is better to do it more like in desktop. At least for the time being.

@begonaalvarezd I realised that the line break doesn't work on android (Don't know why) so I added a space before:
`placeholder={"${localize('general.sendToAddress')} \n${addressPrefix}..."}`

No focus:
<img width="298" alt="image" src="https://user-images.githubusercontent.com/6748220/177537057-380e8b7a-9c9e-4df7-8ed1-e9321f6e0455.png">

Focus:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/6748220/177536961-07752d32-a5f9-409e-91cc-50d8001b2db6.png">

## Changelog

```
- Changed mobile styling of the address component's textarea
- Disabled the floating-label for mobile
```

## Relevant Issues

Closes #3800

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
