### PR TITLE
chore: add touch padding to QR code button

### DIFF
--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -490,7 +490,7 @@
             <div class="w-full text-center">
                 <Text bold bigger>{localize('general.sendFunds')}</Text>
                 <div class="absolute right-10 top-6">
-                    <button on:click={onQRClick}>
+                    <button class="p-3" on:click={onQRClick}>
                         <Icon icon="qr" classes="text-blue-500" />
                     </button>
                 </div>

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -489,7 +489,7 @@
         <div>
             <div class="w-full text-center">
                 <Text bold bigger>{localize('general.sendFunds')}</Text>
-                <div class="absolute right-10 top-6">
+                <div class="absolute right-4 top-4">
                     <button class="p-3" on:click={onQRClick}>
                         <Icon icon="qr" classes="text-blue-500" />
                     </button>


### PR DESCRIPTION
## Summary

This PR adds a touch padding to the send flows QR code button

## Changelog

```
- Added touch padding of 12px to the send flows QR code button
```

## Relevant Issues

Closes #3825

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
