### PR TITLE
fix: action sheet crash

### DIFF
--- a/packages/shared/components/drawerContent/AccountSwitcher.svelte
+++ b/packages/shared/components/drawerContent/AccountSwitcher.svelte
@@ -33,6 +33,10 @@
 
     let toggleEdit = false
 
+    // TODO: find a better solution to avoid a crash when the action sheet is called again
+    // before the last call is finished.
+    let isActionSheetCalled = false
+
     const menuActions = [
         {
             title: localize('actions.customizeAcount'),
@@ -66,6 +70,12 @@
             return
         }
 
+        if (isActionSheetCalled) {
+            return
+        }
+
+        isActionSheetCalled = true
+
         const index = await Platform.showActionSheet({
             title: localize('general.walletActions'),
             options: [
@@ -77,6 +87,7 @@
             ],
         })
 
+        isActionSheetCalled = false
         menuActions[index].action()
     }
 

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -71,6 +71,10 @@
     let transactionTimeoutId = null
     let transactionNotificationId = null
 
+    // TODO: find a better solution to avoid a crash when the action sheet is called again
+    // before the last call is finished.
+    let isActionSheetCalled = false
+
     $: amount, (amountError = '')
     $: to, (toError = '')
     $: address, (addressError = '')
@@ -436,11 +440,19 @@
     const selectInternal = async (evt: Event): Promise<void> => {
         const node = evt.target as HTMLElement
         const accountItems = accountsDropdownItems.filter((item) => item.id !== $selectedAccountStore.id)
+
+        if (isActionSheetCalled) {
+            return
+        }
+
+        isActionSheetCalled = true
+
         const index = await Platform.showActionSheet({
             title: localize(`general.${SEND_TYPE.INTERNAL}`),
             options: [...accountItems.map((item) => ({ title: item.alias })), { title: 'Cancel', style: 'CANCEL' }],
         })
 
+        isActionSheetCalled = false
         if (index == accountItems.length) {
             node.blur()
             return
@@ -452,11 +464,18 @@
     }
 
     const showUnitActionSheet = async (units: Unit[], callback: (toUnit: Unit) => void): Promise<void> => {
+        if (isActionSheetCalled) {
+            return
+        }
+
+        isActionSheetCalled = true
+
         const index = await Platform.showActionSheet({
             title: localize('general.unit'),
             options: [...units.map((unit) => ({ title: unit as string })), { title: 'Cancel', style: 'CANCEL' }],
         })
 
+        isActionSheetCalled = false
         callback(units[index])
     }
 


### PR DESCRIPTION
## Summary

This PR should fix the crash when an action sheet is called again before the last call has finished.

## Changelog

```
- Added flag to check if the action sheet has been called
```

## Relevant Issues

Closes #3782

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
