### PR TITLE
fix: make sure remainder balance does not hide while a transfer is in progress

### DIFF
--- a/packages/shared/lib/core/wallet/actions/setAsyncStatusOfAccountActivities.ts
+++ b/packages/shared/lib/core/wallet/actions/setAsyncStatusOfAccountActivities.ts
@@ -6,7 +6,9 @@ export function setAsyncStatusOfAccountActivities(time: Date): void {
     allAccountActivities.update((state) => {
         state.forEach((accountActivities, accountId) => {
             for (const activity of accountActivities) {
-                const oldAsyncStatus = activity.asyncStatus
+                // Fallback to null because getAsyncStatus(time) returns null for non-async activities
+                // Otherwise, activity.asyncStatus results undefined and therefore oldAsyncStatus !== activity.asyncStatus check would fail
+                const oldAsyncStatus = activity.asyncStatus || null
                 activity.asyncStatus = activity.getAsyncStatus(time)
                 if (!balancesToUpdate.includes(accountId) && oldAsyncStatus !== activity.asyncStatus) {
                     balancesToUpdate.push(accountId)


### PR DESCRIPTION
## Summary

Balance used to set to 0 while a transfer was in progress. This PR fixes it. 


## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
