### PR TITLE
fix: changes from click to mousedown event listener in clickOutside

### DIFF
--- a/packages/shared/lib/actions.ts
+++ b/packages/shared/lib/actions.ts
@@ -16,7 +16,7 @@ export function clickOutside(node: any, options?: { includeScroll }): { destroy 
         node.dispatchEvent(new CustomEvent('clickOutside', node))
     }
 
-    document.addEventListener('click', handleClick, true)
+    document.addEventListener('mousedown', handleClick, true)
 
     if (options?.includeScroll) {
         document.addEventListener('scroll', handleScroll, true)


### PR DESCRIPTION
## Summary
This prevents the popup from closing when the user triggers the mousedown event inside the popup content and then triggers the mouseup outside it. Usually it happens when the user is trying to select a text.

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
