### PR TITLE
fix: set default expiration time if storage deposit is required

### DIFF
--- a/packages/shared/components/molecules/ExpirationTimePicker.svelte
+++ b/packages/shared/components/molecules/ExpirationTimePicker.svelte
@@ -6,8 +6,10 @@
     export let initialSelected: 'none' | '1hour' | '1day' | '1week' = 'none'
 
     let menu: ExpirationTimePickerMenu
-    let selected: 'none' | '1hour' | '1day' | '1week' = initialSelected
     let anchor: HTMLElement
+    let selected: 'none' | '1hour' | '1day' | '1week'
+
+    $: selected = initialSelected
 </script>
 
 <button class="flex items-center justify-center cursor-pointer" on:click={menu?.tryOpen} bind:this={anchor}>

--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -37,10 +37,6 @@
     export let tag: string
     export let _onMount: (..._: any[]) => Promise<void> = async () => {}
 
-    // If storage deposit is 0, then set expiration date to tomorrow
-    const defaultExpirationDate = new Date()
-    defaultExpirationDate.setDate(defaultExpirationDate.getDate() + 1)
-
     let expirationDate: Date
     let storageDeposit = 0
     let preparedOutput: OutputTypes


### PR DESCRIPTION
## Summary
set default expiration time if storage deposit is required

## Changelog

```
- fix race condition by adding a reactive statement to it
- remove unused part of the code
```

## Relevant Issues
Closes #3902 

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
