### PR TITLE
fix: SMR token amount formatting

### DIFF
--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -120,29 +120,23 @@ export function isAirdropAvailable(airdrop: StakingAirdrop): boolean {
  * @returns {string}
  */
 export const formatStakingAirdropReward = (airdrop: StakingAirdrop, amount: number, decimalPlaces: number): string => {
+    if (!amount) {
+        amount = 0
+    }
+
+    if (!decimalPlaces) {
+        decimalPlaces = 0
+    }
+
     const decimalSeparator = getDecimalSeparator(get(activeProfile)?.settings?.currency)
     const thousandthSeparator = decimalSeparator === '.' ? ',' : '.'
 
-    let reward: string
-    switch (airdrop) {
-        case StakingAirdrop.Assembly: {
-            decimalPlaces = clamp(decimalPlaces, 0, 6)
+    decimalPlaces = clamp(decimalPlaces, 0, 6)
 
-            const [integer, float] = (amount / 1_000_000).toFixed(decimalPlaces).split('.')
-            reward = `${delineateNumber(integer, thousandthSeparator)}${
-                Number(float) > 0 ? decimalSeparator + float : ''
-            }`
+    const [integer, float] = (amount / 1_000_000).toFixed(decimalPlaces).split('.')
+    let reward = `${delineateNumber(integer, thousandthSeparator)}${Number(float) > 0 ? decimalSeparator + float : ''}`
 
-            break
-        }
-        case StakingAirdrop.Shimmer: {
-            reward = delineateNumber(String(Math.floor(amount)), thousandthSeparator)
-            break
-        }
-        default:
-            reward = '0'
-            break
-    }
+    reward = reward ?? '0'
 
     return `${reward} ${STAKING_AIRDROP_TOKENS[airdrop]}`
 }

--- a/packages/shared/lib/participation/staking.ts
+++ b/packages/shared/lib/participation/staking.ts
@@ -134,11 +134,18 @@ export const formatStakingAirdropReward = (airdrop: StakingAirdrop, amount: numb
     decimalPlaces = clamp(decimalPlaces, 0, 6)
 
     const [integer, float] = (amount / 1_000_000).toFixed(decimalPlaces).split('.')
-    let reward = `${delineateNumber(integer, thousandthSeparator)}${Number(float) > 0 ? decimalSeparator + float : ''}`
 
-    reward = reward ?? '0'
-
-    return `${reward} ${STAKING_AIRDROP_TOKENS[airdrop]}`
+    let reward: string
+    const shouldModifyForGlowUnits = Number(integer) <= 0 && airdrop === StakingAirdrop.Shimmer
+    if (shouldModifyForGlowUnits) {
+        reward = `${delineateNumber(float, thousandthSeparator)}` ?? '0'
+        return `${reward} glow`
+    } else {
+        reward =
+            `${delineateNumber(integer, thousandthSeparator)}${Number(float) > 0 ? decimalSeparator + float : ''}` ??
+            '0'
+        return `${reward} ${STAKING_AIRDROP_TOKENS[airdrop]}`
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

The way of formatting and displaying Shimmer tokens has changed.

## Changelog

```
- Adjust logic of SMR token formatting
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Closes #3959 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Use a profile that has at least one account with Shimmer token rewards from the first staking period.

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
