### PR TITLE
Adds Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           upload_sources: true
           download_translations: true
-          localization_branch_name: 'l10n_develop'
+          localization_branch_name: 'l10n_stardust_develop'
           pull_request_title: 'New Stardust translations [ci skip]'
           crowdin_branch_name: 'stardust-develop'
           config: 'crowdin.yml'

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -20,8 +20,8 @@ jobs:
           upload_sources: true
           download_translations: true
           localization_branch_name: 'l10n_develop'
-          pull_request_title: 'New Crowdin translations [ci skip]'
-          crowdin_branch_name: 'develop'
+          pull_request_title: 'New Stardust translations [ci skip]'
+          crowdin_branch_name: 'stardust-develop'
           config: 'crowdin.yml'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a new branch to Crowdin for Stardust strings. Existing strings from `develop` will be carried over.

Note: Once stardust-develop is merged back into develop we need to revert the workflow changes.
...

## Changelog

```
- Updates crowdin workflow for Stardust
```

## Checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
