### PR TITLE
fix: Android exit app without crashing

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -52,7 +52,7 @@
     }
 
     backButtonStore.set(
-        new BackButtonHeap(() => {
+        new BackButtonHeap(async () => {
             await logout()
             App.exitApp()
         })

--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -5,7 +5,7 @@
     import { QRScanner, Route, ToastContainer, Popup } from 'shared/components'
     import { openPopup, popupState } from '@lib/popup'
     import {} from '@lib/popup'
-    import { mobile, stage } from '@lib/app'
+    import { logout, mobile, stage } from '@lib/app'
     import { appSettings } from '@lib/appSettings'
     import { goto } from '@lib/helpers'
     import { localeDirection, isLocaleLoaded, setupI18n, _ } from '@core/i18n'
@@ -52,13 +52,14 @@
     }
 
     let isDoubleBack = false
-    void App.addListener('backButton', () => {
+    void App.addListener('backButton', (): void => {
         if (isDoubleBack) {
             isDoubleBack = false
-            return handleContinueClick()
+            handleContinueClick()
+            return
         }
         isDoubleBack = true
-        openPopup({
+        void openPopup({
             type: 'confirmCloseApp',
             hideClose: true,
             props: {
@@ -68,8 +69,9 @@
         })
     })
 
-    function handleContinueClick() {
-        // void App.exitApp()
+    async function handleContinueClick() {
+        await logout()
+        void App.exitApp()
     }
 
     async function hideSplashScreen() {

--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -3,6 +3,7 @@
     import { App } from '@capacitor/app'
     import { onMount, tick } from 'svelte'
     import { QRScanner, Route, ToastContainer, Popup } from 'shared/components'
+    import { closeDrawers, closePreviousDrawer } from 'shared/components/Drawer.svelte'
     import { openPopup, popupState } from '@lib/popup'
     import {} from '@lib/popup'
     import { logout, mobile, stage } from '@lib/app'
@@ -53,20 +54,22 @@
 
     let isDoubleBack = false
     void App.addListener('backButton', (): void => {
-        if (isDoubleBack) {
-            isDoubleBack = false
-            handleContinueClick()
-            return
-        }
-        isDoubleBack = true
-        void openPopup({
-            type: 'confirmCloseApp',
-            hideClose: true,
-            props: {
-                handleContinueClick,
-                handleCancelClick: () => (isDoubleBack = false),
-            },
-        })
+        closeDrawers()
+        return
+        // if (isDoubleBack) {
+        //     isDoubleBack = false
+        //     handleContinueClick()
+        //     return
+        // }
+        // isDoubleBack = true
+        // void openPopup({
+        //     type: 'confirmCloseApp',
+        //     hideClose: true,
+        //     props: {
+        //         handleContinueClick,
+        //         handleCancelClick: () => (isDoubleBack = false),
+        //     },
+        // })
     })
 
     async function handleContinueClick() {

--- a/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
+++ b/packages/mobile/android/app/src/main/java/org/iota/firefly/mobile/alpha/WebViewSettingsPlugin.java
@@ -1,14 +1,10 @@
 package org.iota.firefly.mobile.alpha;
 
-import android.content.Context;
-import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.getcapacitor.Plugin;
 import com.getcapacitor.annotation.CapacitorPlugin;
-
-import java.io.File;
 
 @CapacitorPlugin(name = "WebViewSettings")
 public class WebViewSettingsPlugin extends Plugin {
@@ -38,5 +34,12 @@ public class WebViewSettingsPlugin extends Plugin {
         super.handleOnStop();
         WebView webView = getBridge().getWebView();
         webView.clearCache(true);
+    }
+
+    @Override
+    public void handleOnDestroy() {
+       super.handleOnDestroy();
+       WebView webView = getBridge().getWebView();
+       webView.clearCache(true);
     }
 }

--- a/packages/shared/components/Drawer.svelte
+++ b/packages/shared/components/Drawer.svelte
@@ -12,6 +12,20 @@
 	@function {() => Promise<viod>} open - Opens drawer.
 	@function {() => Promise<void>} close - Closes drawer.
 -->
+<script context="module" lang="typescript">
+    type Drawers = Set<{ close: () => Promise<void> }>
+	const drawers:Drawers = new Set()
+    
+    export function closePreviousDrawer(): void {
+		const last = [...drawers].pop()
+        last?.close()
+	}
+
+    export function closeDrawers(): void {
+        drawers.forEach(d => d.close())
+	}
+</script>
+
 <script lang="typescript">
     import { appSettings } from 'shared/lib/appSettings'
     import { createEventDispatcher, onMount } from 'svelte'

--- a/packages/shared/components/Drawer.svelte
+++ b/packages/shared/components/Drawer.svelte
@@ -19,10 +19,14 @@
     export function closePreviousDrawer(): void {
         const last = [...drawers].pop()
         last?.close()
+        drawers.delete(last)
     }
 
     export function closeDrawers(): void {
-        drawers.forEach((d) => void d.close())
+        drawers.forEach((d) => {
+            void d.close()
+            drawers.delete(d)
+        })
     }
 </script>
 

--- a/packages/shared/components/Drawer.svelte
+++ b/packages/shared/components/Drawer.svelte
@@ -14,16 +14,16 @@
 -->
 <script context="module" lang="typescript">
     type Drawers = Set<{ close: () => Promise<void> }>
-	const drawers:Drawers = new Set()
-    
+    const drawers: Drawers = new Set()
+
     export function closePreviousDrawer(): void {
-		const last = [...drawers].pop()
+        const last = [...drawers].pop()
         last?.close()
-	}
+    }
 
     export function closeDrawers(): void {
-        drawers.forEach(d => d.close())
-	}
+        drawers.forEach((d) => void d.close())
+    }
 </script>
 
 <script lang="typescript">
@@ -60,6 +60,8 @@
         if (opened) {
             await open()
         }
+        const currentDrawer = { close }
+        drawers.add(currentDrawer)
     })
 
     function slidable(node: HTMLElement, use: boolean = true) {


### PR DESCRIPTION
## Summary

This PR fixes the exit app issue on Android.

...

## Changelog

```
- Added logout() before call exitApp()
- Clean webview cache at exit app.
- Added drawer methods to implement in the future.
```

## Relevant Issues
Closes #3930 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [X] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
