### PR TITLE
fix: pincode android edge case

### DIFF
--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -156,7 +156,7 @@
                             class:active={!inputs[i] || inputs[i].length === 0}
                             class:glimpse
                             {disabled}
-                            on:input={(event) => (isAndroid ? changeHandlerHelper(event, i) : undefined)}
+                            on:input={(event) => changeHandlerHelper(event, i)}
                             on:keydown={(event) => changeHandler(event, i)}
                             on:contextmenu|preventDefault
                         />

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -152,6 +152,7 @@
                             maxLength="1"
                             id={`input-${i}`}
                             type="tel"
+                            inputmode="numeric"
                             bind:this={inputElements[i]}
                             class:active={!inputs[i] || inputs[i].length === 0}
                             class:glimpse

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -151,7 +151,7 @@
                             bind:value={inputs[i]}
                             maxLength="1"
                             id={`input-${i}`}
-                            type="tel"
+                            type="password"
                             inputmode="numeric"
                             bind:this={inputElements[i]}
                             class:active={!inputs[i] || inputs[i].length === 0}

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -153,6 +153,7 @@
                             id={`input-${i}`}
                             type="password"
                             inputmode="numeric"
+                            autocomplete="off"
                             bind:this={inputElements[i]}
                             class:active={!inputs[i] || inputs[i].length === 0}
                             class:glimpse


### PR DESCRIPTION
## Summary
This PR aims to fix the Android edge case at Pin component.

## Changelog

```
- Removed isAndroid check, since the behavior described here https://trello.com/c/6WHc9HqN/96-button-doesnt-become-active-after-entering-the-pin
is like it's not applied, I reviewed the Capacitor code but just in case, since this change does not affect iOS.
- Added inputmode="numeric", this change allow us to change input type from `tel` to `password`,
- Added the attribute autocomplete=off the auto-suggest feature or other event might follow the keydown event and invalidate it. More details here: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values
```

## Relevant Issues

Closes #4010 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
