### PR TITLE
fix: verification badge on new assets only

### DIFF
--- a/packages/shared/components/molecules/VerificationBadge.svelte
+++ b/packages/shared/components/molecules/VerificationBadge.svelte
@@ -7,7 +7,7 @@
     export let large = false
 </script>
 
-{#if verificationStatus === VerificationStatus.New || verificationStatus === VerificationStatus.NotVerified}
+{#if verificationStatus === VerificationStatus.New}
     <Icon
         width={large ? 20 : 14}
         height={large ? 20 : 14}


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

We decided to only show the grey unverified badge when the asset is new. Now if the user skips we remove the badge all together.

## Changelog

```
- Remove verification badge on skipped verified assets.
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
