### PR TITLE
fix: text hint colours and styles

### DIFF
--- a/packages/shared/components/TextHint.svelte
+++ b/packages/shared/components/TextHint.svelte
@@ -14,7 +14,7 @@
     export let text: string = ''
     export let textClasses: string = ''
     export let textColor = 'gray-700'
-    export let textDarkColor = 'gray-700'
+    export let textDarkColor = 'gray-400'
 
     let _classes
     let _icon
@@ -26,21 +26,21 @@
         } else if (secondary) {
             _classes = 'bg-gray-50 dark:bg-gray-800'
         } else if (success) {
-            _classes = 'bg-green-50 dark:bg-green-50 border-green-500'
+            _classes = 'bg-green-50 dark:bg-green-500'
             _icon = 'checkmark'
-            _iconClasses = 'text-green-500 dark:text-green-500'
+            _iconClasses = 'text-green-700 dark:text-green-700'
         } else if (danger) {
-            _classes = 'bg-red-50 dark:bg-red-50 border-red-500'
+            _classes = 'bg-red-50 dark:bg-red-500'
             _icon = 'success-error'
             _iconClasses = 'text-red-500 dark:text-red-500'
         } else if (warning) {
-            _classes = 'bg-yellow-50 dark:bg-yellow-50 border-yellow-500'
+            _classes = 'bg-yellow-50 dark:bg-yellow-500'
             _icon = 'exclamation'
-            _iconClasses = 'text-yellow-500 dark:text-yellow-500'
+            _iconClasses = 'text-yellow-700 dark:text-yellow-700'
         } else if (info) {
-            _classes = 'bg-blue-50 dark:bg-blue-50 border-blue-500'
+            _classes = 'bg-blue-50 dark:bg-blue-500'
             _icon = 'info'
-            _iconClasses = 'text-blue-500 dark:text-blue-500'
+            _iconClasses = 'text-blue-600 dark:text-blue-600'
         }
     }
 
@@ -48,7 +48,7 @@
 </script>
 
 {#if text}
-    <div class="flex flex-row items-center p-4 rounded-lg border border-solid {_classes} {classes}">
+    <div class="flex flex-row items-center p-4 rounded-lg dark:bg-opacity-10 {_classes} {classes}">
         {#if icon}
             <Icon
                 icon={_icon}

--- a/packages/shared/components/popups/ConfirmationPopup.svelte
+++ b/packages/shared/components/popups/ConfirmationPopup.svelte
@@ -7,7 +7,10 @@
     export let title: string
     export let description: string
     export let hint: string
+    export let info: boolean
+    export let success: boolean
     export let warning: boolean
+    export let danger: boolean
     export let confirmText: string
     export let onConfirm: () => void = undefined
     export let onCancel: () => void = undefined
@@ -38,12 +41,12 @@
             <Text fontSize="14" classes="text-left">{description}</Text>
         {/if}
         {#if hint}
-            <TextHint info text={hint} />
+            <TextHint {info} {success} {warning} {danger} text={hint} />
         {/if}
     </div>
     <popup-buttons class="flex flex-row flex-nowrap w-full space-x-4">
         <Button classes="w-full" secondary onClick={cancelClick}>{localize('actions.cancel')}</Button>
-        <Button classes="w-full" {warning} onClick={confirmClick}
+        <Button classes="w-full" warning={warning || danger} onClick={confirmClick}
             >{confirmText ? confirmText : localize('actions.confirm')}</Button
         >
     </popup-buttons>


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

This is to standardise and align the textHint across the app

## Changelog

```
- Remove border of text hint
- Update colours
- Add opacity to darkmode
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
