### PR TITLE
fix: use asset icon in dropdown

### DIFF
--- a/packages/shared/components/inputs/AssetDropdown.svelte
+++ b/packages/shared/components/inputs/AssetDropdown.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { NetworkProtocol } from '@core/network'
     import { selectedAccountAssets } from '@core/wallet'
-    import { AssetTile, Icon, Text } from 'shared/components'
+    import { AssetTile, Icon, Text, AssetIcon } from 'shared/components'
     import { FontWeightText } from 'shared/components/Text.svelte'
     import { clickOutside } from 'shared/lib/actions'
 
@@ -43,15 +43,7 @@
             class:cursor-pointer={hasMultipleAssets}
             on:click={handleDropdownClick}
         >
-            <div
-                class="
-                    icon h-6 w-6 flex-shrink-0 rounded-full flex items-center justify-center p-0.5
-                    {asset?.metadata?.primaryColor ? 'icon-bg' : 'bg-blue-500'}
-                "
-                style={asset?.metadata?.primaryColor ? `--icon-bg-color: ${asset?.metadata?.primaryColor}` : ''}
-            >
-                <Icon classes="text-white" {icon} height="80%" width="80%" />
-            </div>
+            <AssetIcon {asset} />
             <div class="w-full relative" style="max-width: 75px;">
                 <Text
                     color="gray-600"
@@ -79,7 +71,7 @@
                             onClick={() => handleAssetClick($selectedAccountAssets?.baseCoin)}
                             asset={$selectedAccountAssets?.baseCoin}
                             overrideColor
-                            classes="bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700"
+                            classes="bg-white hover:bg-gray-50 dark:bg-transparent"
                         />
                     </li>
                     {#each $selectedAccountAssets?.nativeTokens as nativeToken}
@@ -88,7 +80,7 @@
                                 onClick={() => handleAssetClick(nativeToken)}
                                 asset={nativeToken}
                                 overrideColor
-                                classes="bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700"
+                                classes="bg-white hover:bg-gray-50 dark:bg-transparent"
                             />
                         </li>
                     {/each}

--- a/packages/shared/components/molecules/AssetIcon.svelte
+++ b/packages/shared/components/molecules/AssetIcon.svelte
@@ -4,7 +4,6 @@
     import { VerificationStatus } from '@core/wallet/enums/verification-status.enum'
     import { isBright } from '@lib/helpers'
     import { Animation, Icon, VerificationBadge } from 'shared/components'
-    import { onMount } from 'svelte'
 
     export let asset: IAsset
     export let large = false
@@ -17,8 +16,8 @@
     let assetIconWrapperWidth: number
 
     $: isAnimation = asset?.id === SPECIAL_TOKEN_ID
-
-    onMount(() => {
+    $: {
+        icon = ''
         assetIconBackgroundColor = asset?.metadata?.primaryColor
         assetIconColor = isBright(assetIconBackgroundColor) ? 'gray-800' : 'white'
         if (
@@ -29,7 +28,7 @@
         } else {
             assetInitials = getAssetInitials(asset)
         }
-    })
+    }
 </script>
 
 <div


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.
We need to display the accurate asset icon in the drop down of the send form.

## Changelog

```
- Make asset icon component reactive to asset
- Add AssetIcon to dropdown
- Make asset tile bg transparent in darkmode for the asset dropdown
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
