### PR TITLE
fix: german decimal comma on send

### DIFF
--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -3,7 +3,7 @@
     import UnitInput from './UnitInput.svelte'
     import { parseCurrency } from '@lib/currency'
     import { localize } from '@core/i18n'
-    import { formatTokenAmountBestMatch, generateRawAmount, IAsset, parseRawAmount } from '@core/wallet'
+    import { formatTokenAmountBestMatch, generateRawAmount, IAsset, formatTokenAmountDefault } from '@core/wallet'
     import { UNIT_MAP } from '@lib/units'
 
     export let inputElement: HTMLInputElement
@@ -23,7 +23,7 @@
         amount = null
         unit = null
     }
-    $: rawAmount = generateRawAmount(amount, unit, asset?.metadata)
+    $: rawAmount = generateRawAmount(parseCurrency(amount).toString(), unit, asset?.metadata)
 
     let allowedDecimals = 0
     $: if (!asset?.metadata?.useMetricPrefix) {
@@ -39,9 +39,9 @@
     function onClickAvailableBalance(): void {
         const isRawAmount = asset?.metadata?.decimals && asset?.metadata?.unit
         if (isRawAmount) {
-            const parsedAmount = parseRawAmount(asset?.balance.available ?? 0, asset?.metadata)
-            amount = parsedAmount.amount
-            unit = parsedAmount.unit
+            const parsedAmount = formatTokenAmountDefault(asset?.balance?.available, asset?.metadata)
+            amount = parsedAmount
+            unit = asset?.metadata?.unit
             return
         }
         amount = asset?.balance.available.toString() ?? '0'
@@ -73,8 +73,6 @@
         if (error) {
             return Promise.reject(error)
         }
-
-        amount = amountAsFloat.toString()
     }
 </script>
 

--- a/packages/shared/components/popups/SendFormPopup.svelte
+++ b/packages/shared/components/popups/SendFormPopup.svelte
@@ -5,6 +5,7 @@
     import { FontWeightText } from 'shared/components/Text.svelte'
     import { IAsset, Subject } from '@core/wallet'
     import { onMount } from 'svelte'
+    import { parseCurrency } from '@lib/currency'
 
     export let asset: IAsset
     export let amount: string
@@ -23,7 +24,7 @@
                 type: 'sendConfirmation',
                 props: {
                     asset,
-                    amount,
+                    amount: String(parseCurrency(amount)),
                     unit,
                     recipient,
                     internal: false,


### PR DESCRIPTION
## Summary
On "available balance" click, in german a decimal dot was used

## Changelog

```
- On "available balance" click, use decimal comma in german
```

## Relevant Issues
Closes #4095 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
