### PR TITLE
fix: update desktop `package.json` file 

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "start": "npm-run-all -p start:dev start:electron",
         "start:dev": "cross-env NODE_ENV=development PLATFORM=desktop webpack serve --content-base public",
-        "start:electron": "cross-env NODE_ENV=development PLATFORM=desktop electron public/build/main.js",
+        "start:electron": "cross-env NODE_ENV=development PLATFORM=desktop electron --no-sandbox public/build/main.js",
         "start:electron-prod": "cross-env NODE_ENV=production PLATFORM=desktop electron public/build/main.js",
         "build": "yarn build:alpha",
         "build:dev": "cross-env NODE_ENV=development PLATFORM=desktop webpack",


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

With a recent update for `Ubuntu 22.04`, the Electron development environment does **NOT** work anymore unless run with the `--no-sandbox` flag. 

This PR makes changes that allow the developer instance to run on Linux, and **only affects development; NOT production environments**.

See more on this [issue](https://github.com/ebkr/r2modmanPlus/issues/735).

## Changelog

```
- Add "--no-sandbox" flag to "start:electron" NPM script
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

_N/a_

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [x] Linux
  - [x] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Run `yarn build && yarn start` and do at least one action that requires using the `Platform` API (e.g. exporting a Stronghold).

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation