### PR TITLE
fix: close recipient input on outside click

### DIFF
--- a/packages/shared/components/inputs/RecipientInput.svelte
+++ b/packages/shared/components/inputs/RecipientInput.svelte
@@ -32,8 +32,11 @@
     }
 
     $: hasFocus && (error = '')
-    $: hasFocus && modal?.open()
     $: value && modal?.open()
+
+    $: if (hasFocus) {
+        setTimeout(() => modal.open(), 101)
+    }
 
     $: {
         if (inputElement && selectedAccount) {
@@ -83,5 +86,10 @@
             {...$$restProps}
         />
     </InputContainer>
-    <RecipientAccountSelector bind:modal bind:selected={selectedAccount} searchValue={value} />
+    <RecipientAccountSelector
+        bind:modal
+        bind:selected={selectedAccount}
+        searchValue={value}
+        onClose={() => inputElement.blur()}
+    />
 </recipient-input>

--- a/packages/shared/components/inputs/RecipientInput.svelte
+++ b/packages/shared/components/inputs/RecipientInput.svelte
@@ -18,7 +18,6 @@
     let value: string
     let error: string
     let hasFocus: boolean
-    let keepRecipientAccountSelectorOpen: boolean
     let previousValue: string
 
     if (!selectedAccount && recipient?.type === 'account') {
@@ -35,7 +34,6 @@
     $: hasFocus && (error = '')
     $: hasFocus && modal?.open()
     $: value && modal?.open()
-    $: keepRecipientAccountSelectorOpen = hasFocus
 
     $: {
         if (inputElement && selectedAccount) {
@@ -85,10 +83,5 @@
             {...$$restProps}
         />
     </InputContainer>
-    <RecipientAccountSelector
-        bind:modal
-        bind:selected={selectedAccount}
-        searchValue={value}
-        disableOnClickOutside={keepRecipientAccountSelectorOpen}
-    />
+    <RecipientAccountSelector bind:modal bind:selected={selectedAccount} searchValue={value} />
 </recipient-input>

--- a/packages/shared/components/modals/RecipientAccountSelector.svelte
+++ b/packages/shared/components/modals/RecipientAccountSelector.svelte
@@ -9,7 +9,6 @@
     export let modal: Modal
     export let searchValue: string
     export let selected: IAccountState
-    export let disableOnClickOutside: boolean = false
 
     $: otherAccounts = $visibleActiveAccounts?.filter((account) => account.id !== $selectedAccount.id)
     $: filteredAccounts = otherAccounts?.filter(
@@ -25,7 +24,7 @@
 </script>
 
 {#if filteredAccounts?.length > 0}
-    <Modal {disableOnClickOutside} bind:this={modal} position={{ left: '0', top: '100%' }} classes="w-full p-4">
+    <Modal bind:this={modal} position={{ left: '0', top: '100%' }} classes="w-full p-4">
         <recipient-account-picker-modal
             class="max-h-64 flex flex-col space-y-1 scrollable-y"
             in:fade={{ duration: 100 }}

--- a/packages/shared/components/modals/RecipientAccountSelector.svelte
+++ b/packages/shared/components/modals/RecipientAccountSelector.svelte
@@ -9,6 +9,7 @@
     export let modal: Modal
     export let searchValue: string
     export let selected: IAccountState
+    export let onClose: () => void
 
     $: otherAccounts = $visibleActiveAccounts?.filter((account) => account.id !== $selectedAccount.id)
     $: filteredAccounts = otherAccounts?.filter(
@@ -24,7 +25,7 @@
 </script>
 
 {#if filteredAccounts?.length > 0}
-    <Modal bind:this={modal} position={{ left: '0', top: '100%' }} classes="w-full p-4">
+    <Modal bind:this={modal} position={{ left: '0', top: '100%' }} classes="w-full p-4" on:close={onClose}>
         <recipient-account-picker-modal
             class="max-h-64 flex flex-col space-y-1 scrollable-y"
             in:fade={{ duration: 100 }}


### PR DESCRIPTION
## Summary
This PR solves the problem that the recipient selection modal doesn't get closed after outside clicking once. This PR also solves the problem, that if the outside click is on the textinput itself, the modal gets closed, by re-opening it 


## Changelog

```
- Remove lock for closing the popup on outside click
- Re-open modal if click on TextInput
```

## Relevant Issues
Closes #4135 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
