### PR TITLE
fix: fix tokeninfo after hiding token

### DIFF
--- a/packages/shared/components/modals/AssetActionsMenu.svelte
+++ b/packages/shared/components/modals/AssetActionsMenu.svelte
@@ -1,19 +1,10 @@
 <script lang="typescript">
     import { localize } from '@core/i18n'
-    import {
-        hideAsset,
-        IAsset,
-        selectedAccountAssets,
-        unhideAsset,
-        unverifyAsset,
-        VerificationStatus,
-        verifyAsset,
-    } from '@core/wallet'
+    import { hideAsset, IAsset, unhideAsset, unverifyAsset, VerificationStatus, verifyAsset } from '@core/wallet'
     import { hideActivitiesForHiddenAssets } from '@core/wallet/actions/hideActivitiesForHiddenAssets'
     import { Icon } from '@lib/auxiliary/icon'
     import { updatePopupProps } from '@lib/popup'
     import { HR, MenuItem, Modal } from 'shared/components'
-    import { get } from 'svelte/store'
 
     export let modal: Modal
     export let asset: IAsset
@@ -21,7 +12,7 @@
     const handleUnverify = () => {
         unverifyAsset(asset.id)
         updatePopupProps({
-            asset: get(selectedAccountAssets)?.nativeTokens?.find((nativeToken) => nativeToken.id === asset.id),
+            asset: { ...asset, verification: VerificationStatus.NotVerified },
         })
         modal.close()
     }
@@ -29,7 +20,7 @@
     function handleVerify() {
         verifyAsset(asset.id)
         updatePopupProps({
-            asset: get(selectedAccountAssets)?.nativeTokens?.find((nativeToken) => nativeToken.id === asset.id),
+            asset: { ...asset, verification: VerificationStatus.Verified },
         })
         modal.close()
     }
@@ -38,7 +29,7 @@
         unhideAsset(asset.id)
         hideActivitiesForHiddenAssets()
         updatePopupProps({
-            asset: get(selectedAccountAssets)?.nativeTokens?.find((nativeToken) => nativeToken.id === asset.id),
+            asset: { ...asset, hidden: false },
         })
         modal.close()
     }
@@ -47,7 +38,7 @@
         hideAsset(asset.id)
         hideActivitiesForHiddenAssets()
         updatePopupProps({
-            asset: get(selectedAccountAssets)?.nativeTokens?.find((nativeToken) => nativeToken.id === asset.id),
+            asset: { ...asset, hidden: true },
         })
         modal.close()
     }


### PR DESCRIPTION
## Summary
This PR fixes the issue, that after hiding a token in `TokenInformationPopup`, all values become `undefined`

## Changelog

```
- Locally update asset instead of getting it from the store
```

## Relevant Issues
Closes #4146 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
