### PR TITLE
feat: implement export Stronghold with Android Sharesheet

### DIFF
--- a/packages/mobile/capacitor/plugins/secure-filesystem-access/android/src/main/java/org/iota/plugins/securefilesystemaccess/SecureFilesystemAccessPlugin.java
+++ b/packages/mobile/capacitor/plugins/secure-filesystem-access/android/src/main/java/org/iota/plugins/securefilesystemaccess/SecureFilesystemAccessPlugin.java
@@ -14,6 +14,8 @@ import android.util.Log;
 
 import androidx.activity.result.ActivityResult;
 import androidx.annotation.RequiresApi;
+import androidx.core.content.ContextCompat;
+import androidx.core.content.FileProvider;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;

--- a/packages/mobile/capacitor/plugins/secure-filesystem-access/android/src/main/java/org/iota/plugins/securefilesystemaccess/SecureFilesystemAccessPlugin.java
+++ b/packages/mobile/capacitor/plugins/secure-filesystem-access/android/src/main/java/org/iota/plugins/securefilesystemaccess/SecureFilesystemAccessPlugin.java
@@ -89,18 +89,36 @@ public class SecureFilesystemAccessPlugin extends Plugin {
                 return;
             }
 
-            if (Build.VERSION.SDK_INT == 29 && resourceType.equals("folder")) {
+            if (Build.VERSION.SDK_INT <= 32 && resourceType.equals("folder")) {
+                selectedPath = getContext().getCacheDir().getPath() + File.separator + fileName;
+                String authority = getContext().getPackageName() + ".fileprovider";
+                File file = new File(Uri.parse(selectedPath).getPath());
+                Uri fileUrl = FileProvider.getUriForFile(getActivity(), authority, file);
+                Intent shareIntent = new Intent();
+                shareIntent.setAction(Intent.ACTION_SEND);
+                shareIntent.putExtra(Intent.EXTRA_STREAM, fileUrl);
+                shareIntent.setData(fileUrl);
+                shareIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                getContext().startActivity(Intent.createChooser(shareIntent, null));
+
+                JSObject response = new JSObject();
+                response.put("selected", selectedPath);
+                call.resolve(response);
+                return;
+            }
+
+//            if (Build.VERSION.SDK_INT == 29 && resourceType.equals("folder")) {
                 // Temporary hotfix for Android 10, it's uses new storage later deprecated on API 30,
                 // We don't show the picker to export, as Stronghold can only copy on cache, then we copy
                 // on Downloads folder calling finishBackup() to give to the user an accessible location
                 // API level 29 use media collections such as MediaStore.Downloads
                 // without requesting any storage-related permissions.
-                JSObject response = new JSObject();
-                selectedPath = getContext().getCacheDir().getPath() + File.separator + fileName;
-                response.put("selected", selectedPath);
-                call.resolve(response);
-                return;
-            }
+//                JSObject response = new JSObject();
+//                selectedPath = getContext().getCacheDir().getPath() + File.separator + fileName;
+//                response.put("selected", selectedPath);
+//                call.resolve(response);
+//                return;
+//            }
 
             Intent intent = new Intent(resourceType.equals("file")
                     ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_OPEN_DOCUMENT_TREE);


### PR DESCRIPTION
## Summary

This PR modifies only on Android the current filesystem export action by using Sharesheet with the aim to simplify the Stronghold backup flow. Allowing to use quick share classic actions, nearby device share with bluetooth, wifi, usb cable, or uploading to Google Drive app or any app desired to transfer the file to an external device.
The same Sharesheet could be used to export transaction history or any file desired. Still we've to implement it, but it's way simpler.

Tested with Android 7, 8, 9, 10, 11, 12.

## Changelog

Closes #2473 

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
