### PR TITLE
fix: if toast has action do not show generic dismiss button

### DIFF
--- a/packages/shared/components/Toast.svelte
+++ b/packages/shared/components/Toast.svelte
@@ -82,16 +82,19 @@
                         ? 'bg-white'
                         : ''} text-{action.isPrimary ? 'black' : TOAST_STYLE[type].buttonSecondary}"
                     style={'min-width:90px;min-height:32px'}
-                    on:click={() => action.onClick()}
+                    on:click={action.onClick}
                 >
                     {action.label}
                 </button>
             {/each}
         </div>
-    {/if}
-    {#if $mobile}
-        <button on:click={onDismissClick}>
-            <Text type="p" color="white" darkColor="white">{localize('actions.dismiss')}</Text>
+    {:else if $mobile}
+        <button
+            class="cursor-pointer text-center rounded-lg font-bold text-11 text-{TOAST_STYLE[type].buttonSecondary}"
+            style={'min-width:90px;min-height:32px'}
+            on:click={onDismissClick}
+        >
+            {localize('actions.dismiss')}
         </button>
     {/if}
 </div>


### PR DESCRIPTION
## Summary
Removes dismiss button duplication in mobile, so the generic dismiss button will only appear when there are no actions.

## Changelog

```
- Fixes conditions for displaying the generic dismiss button
- Fixes the styling of generic dismiss button
```

## Relevant Issues
closes #4185

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android

### Instructions
- Test different types of toast ('info', 'warning', 'error') and with and without actions (like the toast after the migration flow)

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
