### PR TITLE
fix: adjusts styling of ProfileActions as figma

### DIFF
--- a/packages/shared/components/ProfileActions.svelte
+++ b/packages/shared/components/ProfileActions.svelte
@@ -97,7 +97,7 @@
     {#if !isUpToDate}
         <button
             on:click={handleVersionUpdateClick}
-            class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
+            class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid"
         >
             <Icon icon="warning" classes="row-span-3 text-blue-500" />
             <Text type="h5" unwrapped classes="text-left col-span-6" fontWeight="font-600">
@@ -118,7 +118,7 @@
     {/if}
     <button
         on:click={handleBackupClick}
-        class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-1 ring-{backupWarningColor}-300 dark:ring-opacity-30"
+        class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid ring-1 ring-{backupWarningColor}-300 dark:ring-opacity-30"
     >
         <Icon icon="warning-filled" classes="row-span-3 text-{backupWarningColor}-500" />
         <Text type="h5" unwrapped classes="text-left col-span-3" fontWeight="font-600">

--- a/packages/shared/components/ProfileActions.svelte
+++ b/packages/shared/components/ProfileActions.svelte
@@ -100,10 +100,10 @@
             class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
         >
             <Icon icon="warning" classes="row-span-3 text-blue-500" />
-            <Text type="p" unwrapped classes="col-span-6">
+            <Text type="h5" unwrapped classes="col-span-6" fontWeight="font-600">
                 {localize('views.dashboard.profileModal.version.title')}
             </Text>
-            <Text type="p" overrideColor classes="text-gray-500 -mt-0.5">
+            <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
                 {localize('views.dashboard.profileModal.version.updateVersion', {
                     values: { version: $versionDetails.newVersion },
                 })}
@@ -112,19 +112,19 @@
                 width={18}
                 height={18}
                 icon="chevron-right"
-                classes="row-span-3 justify-self-end text-gray-500 dark:text-white"
+                classes="row-span-3 justify-self-end text-gray-600 dark:text-white"
             />
         </button>
     {/if}
     <button
         on:click={handleBackupClick}
-        class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
+        class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-{backupWarningColor}-300 dark:ring-opacity-30"
     >
-        <Icon icon="warning" classes="row-span-3 text-{backupWarningColor}-500" />
-        <Text type="p" unwrapped classes="col-span-3">
+        <Icon icon="warning-filled" classes="row-span-3 text-{backupWarningColor}-500" />
+        <Text type="h5" unwrapped classes="col-span-3" fontWeight="font-600">
             {localize('views.dashboard.profileModal.backup.title')}
         </Text>
-        <Text type="p" overrideColor classes="text-gray-500 -mt-0.5">
+        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {$activeProfile?.lastStrongholdBackupTime
                 ? localize('views.dashboard.profileModal.backup.lastBackup', {
                       values: {
@@ -139,56 +139,56 @@
             width={18}
             height={18}
             icon="chevron-right"
-            classes="row-span-3 justify-self-end text-gray-500 dark:text-white"
+            classes="row-span-3 justify-self-end text-gray-600 dark:text-white"
         />
     </button>
     <button
         on:click={handleNetworkStatusClick}
-        class="main-button bg-{healthStatusColor}-50 dark:bg-{healthStatusColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
+        class="main-button bg-{healthStatusColor}-50 dark:bg-{healthStatusColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-{healthStatusColor}-300 dark:ring-opacity-30"
     >
         <Icon icon="network" classes="row-span-3 text-{healthStatusColor}-500" />
-        <Text type="p" unwrapped classes="col-span-6">
+        <Text type="h5" unwrapped classes="col-span-6" fontWeight="font-600">
             {localize('views.dashboard.network.status')}
         </Text>
-        <Text type="p" overrideColor classes="text-gray-500 -mt-0.5">
+        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {localize(`views.dashboard.network.${healthStatusText}`)}
         </Text>
         <Icon
             width={18}
             height={18}
             icon="chevron-right"
-            classes="row-span-3 justify-self-end text-gray-500 dark:text-white"
+            classes="row-span-3 justify-self-end text-gray-600 dark:text-white"
         />
     </button>
     <button
         on:click={handleStrongholdToggleClick}
-        class="main-button bg-blue-50 dark:bg-blue-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
+        class="main-button bg-gray-50 dark:bg-gray-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-gray-300  dark:ring-opacity-30"
     >
         <Icon icon={$isStrongholdLocked ? 'lock' : 'unlock'} classes="row-span-3 text-blue-500" />
-        <Text type="p" unwrapped classes="col-span-6">
+        <Text type="h5" unwrapped classes="col-span-6" fontWeight="font-600">
             {localize('views.dashboard.profileModal.stronghold.title')}
         </Text>
-        <Text type="p" overrideColor classes="text-gray-500 -mt-0.5">
+        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {localize(`views.dashboard.profileModal.stronghold.${$isStrongholdLocked ? 'locked' : 'unlocked'}`)}
         </Text>
         <Toggle active={!$isStrongholdLocked} classes="row-span-3 justify-self-end" />
     </button>
     <button
         on:click={handleSettingsClick}
-        class="main-button bg-blue-50 dark:bg-blue-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
+        class="main-button bg-white dark:bg-gray-400 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-gray-200  dark:ring-opacity-30"
     >
         <Icon icon="settings" classes="row-span-3 text-blue-500" />
-        <Text type="p" unwrapped classes="col-span-4">
+        <Text type="h5" unwrapped classes="col-span-4" fontWeight="font-600">
             {localize('views.dashboard.profileModal.allSettings.title')}
         </Text>
-        <Text type="p" overrideColor classes="text-gray-500 -mt-0.5">
+        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {localize('views.dashboard.profileModal.allSettings.description')}
         </Text>
         <Icon
             width={18}
             height={18}
             icon="chevron-right"
-            classes="row-span-3 justify-self-end text-gray-500 dark:text-white"
+            classes="row-span-3 justify-self-end text-gray-600 dark:text-white"
         />
     </button>
 </div>

--- a/packages/shared/components/ProfileActions.svelte
+++ b/packages/shared/components/ProfileActions.svelte
@@ -100,10 +100,10 @@
             class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white"
         >
             <Icon icon="warning" classes="row-span-3 text-blue-500" />
-            <Text type="h5" unwrapped classes="col-span-6" fontWeight="font-600">
+            <Text type="h5" unwrapped classes="text-left col-span-6" fontWeight="font-600">
                 {localize('views.dashboard.profileModal.version.title')}
             </Text>
-            <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
+            <Text type="h5" classes="text-left" color="gray-600" darkColor="gray-500" fontWeight="font-400">
                 {localize('views.dashboard.profileModal.version.updateVersion', {
                     values: { version: $versionDetails.newVersion },
                 })}
@@ -118,13 +118,13 @@
     {/if}
     <button
         on:click={handleBackupClick}
-        class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-{backupWarningColor}-300 dark:ring-opacity-30"
+        class="main-button bg-{backupWarningColor}-50 dark:bg-{backupWarningColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-1 ring-{backupWarningColor}-300 dark:ring-opacity-30"
     >
         <Icon icon="warning-filled" classes="row-span-3 text-{backupWarningColor}-500" />
-        <Text type="h5" unwrapped classes="col-span-3" fontWeight="font-600">
+        <Text type="h5" unwrapped classes="text-left col-span-3" fontWeight="font-600">
             {localize('views.dashboard.profileModal.backup.title')}
         </Text>
-        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
+        <Text type="h5" classes="text-left" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {$activeProfile?.lastStrongholdBackupTime
                 ? localize('views.dashboard.profileModal.backup.lastBackup', {
                       values: {
@@ -144,13 +144,13 @@
     </button>
     <button
         on:click={handleNetworkStatusClick}
-        class="main-button bg-{healthStatusColor}-50 dark:bg-{healthStatusColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-{healthStatusColor}-300 dark:ring-opacity-30"
+        class="main-button bg-{healthStatusColor}-50 dark:bg-{healthStatusColor}-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-1 ring-{healthStatusColor}-300 dark:ring-opacity-30"
     >
         <Icon icon="network" classes="row-span-3 text-{healthStatusColor}-500" />
-        <Text type="h5" unwrapped classes="col-span-6" fontWeight="font-600">
+        <Text type="h5" unwrapped classes="text-left col-span-6" fontWeight="font-600">
             {localize('views.dashboard.network.status')}
         </Text>
-        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
+        <Text type="h5" classes="text-left" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {localize(`views.dashboard.network.${healthStatusText}`)}
         </Text>
         <Icon
@@ -162,26 +162,26 @@
     </button>
     <button
         on:click={handleStrongholdToggleClick}
-        class="main-button bg-gray-50 dark:bg-gray-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-gray-300  dark:ring-opacity-30"
+        class="main-button bg-gray-50 dark:bg-gray-500 dark:bg-opacity-10 rounded-xl border-solid border-white ring-1 ring-gray-300 dark:ring-opacity-30"
     >
         <Icon icon={$isStrongholdLocked ? 'lock' : 'unlock'} classes="row-span-3 text-blue-500" />
-        <Text type="h5" unwrapped classes="col-span-6" fontWeight="font-600">
+        <Text type="h5" unwrapped classes="text-left col-span-6" fontWeight="font-600">
             {localize('views.dashboard.profileModal.stronghold.title')}
         </Text>
-        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
+        <Text type="h5" classes="text-left" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {localize(`views.dashboard.profileModal.stronghold.${$isStrongholdLocked ? 'locked' : 'unlocked'}`)}
         </Text>
         <Toggle active={!$isStrongholdLocked} classes="row-span-3 justify-self-end" />
     </button>
     <button
         on:click={handleSettingsClick}
-        class="main-button bg-white dark:bg-gray-400 dark:bg-opacity-10 rounded-xl border-solid border-white ring-2 ring-gray-200  dark:ring-opacity-30"
+        class="main-button bg-white dark:bg-gray-400 dark:bg-opacity-10 rounded-xl border-solid border-white ring-1 ring-gray-200 dark:ring-opacity-30"
     >
         <Icon icon="settings" classes="row-span-3 text-blue-500" />
-        <Text type="h5" unwrapped classes="col-span-4" fontWeight="font-600">
+        <Text type="h5" unwrapped classes="text-left col-span-4" fontWeight="font-600">
             {localize('views.dashboard.profileModal.allSettings.title')}
         </Text>
-        <Text type="h5" color="gray-600" darkColor="gray-500" fontWeight="font-400">
+        <Text type="h5" classes="text-left" color="gray-600" darkColor="gray-500" fontWeight="font-400">
             {localize('views.dashboard.profileModal.allSettings.description')}
         </Text>
         <Icon

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -278,6 +278,7 @@ module.exports = {
         backgroundOpacity: ['dark'],
         opacity: ['responsive', 'group-hover', 'focus-within', 'hover', 'focus', 'disabled'],
         cursor: ['responsive', 'disabled'],
+        ringOpacity: ['dark'],
     },
     plugins: [
         // Add individual border colors


### PR DESCRIPTION
## Relevant Issues
closes #3700 

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android

### Instructions
- Open the Profile Menu on mobile
- Switch between dark and light themes

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
