### PR TITLE
feat: disable auto backup

### DIFF
--- a/packages/backend/bindings/capacitor/ios/Plugin/Plugin.swift
+++ b/packages/backend/bindings/capacitor/ios/Plugin/Plugin.swift
@@ -20,6 +20,7 @@ public class WalletPlugin: CAPPlugin {
             if !fm.fileExists(atPath: path) {
                 try fm.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
             }
+            try path.setResourceValue(true, forKey: NSURLIsExcludedFromBackupKey)
             call.keepAlive = true
             // TODO: it's possible to make this better? investigate for implications
             // based on: https://vmanot.com/context-capturing-c-function-pointers-in-swift

--- a/packages/backend/bindings/capacitor/ios/Plugin/Plugin.swift
+++ b/packages/backend/bindings/capacitor/ios/Plugin/Plugin.swift
@@ -20,7 +20,11 @@ public class WalletPlugin: CAPPlugin {
             if !fm.fileExists(atPath: path) {
                 try fm.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
             }
-            try path.setResourceValue(true, forKey: NSURLIsExcludedFromBackupKey)
+            // Exclude folder from auto-backup
+            var urlPath = URL(fileURLWithPath: path, isDirectory: true)
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try urlPath.setResourceValues(values)
             call.keepAlive = true
             // TODO: it's possible to make this better? investigate for implications
             // based on: https://vmanot.com/context-capturing-c-function-pointers-in-swift

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
## Summary
Auto backup of sensitive data is not good for the app security so this PR should address this issue

## Changelog
```
- Sets allowBackup flag from AndroidManifest application to `false`
- Sets resource value as `true` for excluding storagePath from backup for iOS Capacitor plugin
```

## Relevant Issues
closes #4147 

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
