### PR TITLE
fix: amount input with decimal point in iOS

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -166,7 +166,8 @@
 <svelte:window on:click={onOutsideClick} />
 <amount-input class:disabled class="relative block {classes}" on:keydown={handleKey}>
     <Input
-        type={$mobile ? 'tel' : 'text'}
+        type={$mobile ? 'number' : 'text'}
+        inputmode="decimal"
         {error}
         label={amountForLabel || localize('general.amount')}
         placeholder={placeholder || localize('general.amount')}


### PR DESCRIPTION
## Summary
The keyboard for amount input in iOS doesn't have a decimal point in it, so I've changed the `Input` prop `type` from `tel` to `number` in mobile and added the `inputmode` prop with the value `decimal` and now the iOS keyboard shows the decimal point

...

## Changelog
```
- Changed the `Input` prop `type` from `tel` to `number` in mobile
- Added the `inputmode` prop with the value `decimal` in it
```

## Relevant Issues
closes #4021

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
