### PR TITLE
fix: back button issue with swipe actions

### DIFF
--- a/packages/shared/components/AccountNavigation.svelte
+++ b/packages/shared/components/AccountNavigation.svelte
@@ -51,6 +51,7 @@
     function onDrawerClose(): void {
         setDrawerRoute(null) // needed to remount the child components and reset its internal variables (eg: edit/cancel state)
         isDrawerOpened = false
+        $backButtonStore?.reset()
     }
 </script>
 

--- a/packages/shared/components/Drawer.svelte
+++ b/packages/shared/components/Drawer.svelte
@@ -103,10 +103,6 @@
         }
     }
 
-    export function isDrawerOpen(): boolean {
-        return isOpen
-    }
-
     export async function open(): Promise<void> {
         isOpen = true
         await coords.set({ x: 0, y: 0 }, { duration: 650, easing: quintOut })

--- a/packages/shared/components/MainMenu.svelte
+++ b/packages/shared/components/MainMenu.svelte
@@ -50,7 +50,7 @@
 >
     <span class="text-14 font-600 text-center text-white uppercase">{profileInitial || 'A'}</span>
 </button>
-<Drawer bind:this={drawer} fromLeft classes="flex">
+<Drawer bind:this={drawer} fromLeft classes="flex" on:close={$backButtonStore?.reset()}>
     <section class="flex flex-col w-full">
         <header
             class="w-full mt-3 py-3 px-9 mb-3 flex items-centers justify-center bg-white dark:bg-gray-800"

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -177,6 +177,11 @@
         e.preventDefault()
     }
 
+    const handleDrawerClose = () => {
+        closePopup($popupState?.preventClose)
+        $backButtonStore?.pop()
+    }
+
     onMount(async () => {
         $backButtonStore?.add(closePopup as () => Promise<void>)
         const elems = focusableElements()
@@ -189,7 +194,7 @@
 
 <svelte:window on:keydown={onKey} />
 {#if $mobile && !fullScreen}
-    <Drawer opened zIndex="z-40" preventClose={hideClose} on:close={() => closePopup($popupState?.preventClose)}>
+    <Drawer opened zIndex="z-40" preventClose={hideClose} on:close={handleDrawerClose}>
         <div bind:this={popupContent} class="py-10 px-5">
             <svelte:component this={types[type]} {...props} {locale} />
         </div>

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -401,9 +401,6 @@
 
     $: if (mobile && drawer && $accountRoute === AccountRoute.Init) {
         drawer.close()
-        if (drawer.isDrawerOpen() === false) {
-            $backButtonStore?.reset()
-        }
     }
 
     onMount(() => {
@@ -468,8 +465,14 @@
         })
     }
 
+    function handleDrawerClose(): void {
+        accountRoute.set(AccountRoute.Init)
+        $backButtonStore?.reset()
+    }
+
     function handleActivityDrawerBackClick(): void {
         selectedMessage.set(null)
+        $backButtonStore?.pop()
     }
 
     $: if ($selectedMessage && activityDrawer) {
@@ -493,7 +496,7 @@
                     <Drawer
                         opened={$accountRoute !== AccountRoute.Init}
                         bind:this={drawer}
-                        on:close={() => accountRoute.set(AccountRoute.Init)}
+                        on:close={handleDrawerClose}
                         backgroundBlur={$accountRoute === AccountRoute.Receive}
                     >
                         {#if $accountRoute === AccountRoute.Send}


### PR DESCRIPTION
## Summary

This PR fixes issues with the back button when drawers are closed through swiping.

## Changelog

```
- Resets the back button store when the settings or account switcher are closed via swipe
- Removes corresponding close functions from the back button store when popups or the activity drawer are closed via swipe
- Removes the isDrawerOpen function from the drawer (was previously implemented for the back button and isn't necessary anymore)
```

## Relevant Issues

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
