### PR TITLE
fix: updates deprecated version of ubuntu for github hosted runners

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -46,7 +46,7 @@ jobs:
         needs: [setup]
         strategy:
             matrix:
-                os: [ubuntu-18.04, macos-11, windows-2019]
+                os: [ubuntu-20.04, macos-11, windows-2019]
             fail-fast: false
         env:
             VERSION: ${{ needs.setup.outputs.version }}
@@ -92,7 +92,7 @@ jobs:
                   sudo apt install -y gcc-multilib g++-multilib build-essential libssl-dev rpm libsecret-1-dev \
                     software-properties-common apt-transport-https libudev-dev libusb-1.0-0-dev \
                     llvm-dev libclang-dev clang
-              if: matrix.os == 'ubuntu-18.04'
+              if: matrix.os == 'ubuntu-20.04'
 
             - name: Enable verbose output for electron-builder (macOS/Linux)
               run: echo "DEBUG=electron-builder" >> $GITHUB_ENV
@@ -146,7 +146,7 @@ jobs:
             - name: Build Electron app (Linux)
               run: yarn compile:${STAGE}:linux
               working-directory: packages/desktop
-              if: matrix.os == 'ubuntu-18.04'
+              if: matrix.os == 'ubuntu-20.04'
 
             - name: Import GPG key (Linux)
               run: |
@@ -155,19 +155,19 @@ jobs:
               env:
                   GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
                   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-              if: matrix.os == 'ubuntu-18.04'
+              if: matrix.os == 'ubuntu-20.04'
 
             - name: Sign AppImage (Linux)
               run: echo $GPG_PASSPHRASE | gpg --pinentry-mode loopback --batch --passphrase-fd 0 --armor --detach-sign --default-key contact@iota.org firefly-desktop*.AppImage
               working-directory: packages/desktop/out
               env:
                   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-              if: matrix.os == 'ubuntu-18.04'
+              if: matrix.os == 'ubuntu-20.04'
 
             - name: Compute checksums (Linux)
               run: for i in `ls | grep 'firefly-desktop*'` ; do sha256sum $i | awk {'print $1'} > $i.sha256 ; done
               working-directory: packages/desktop/out
-              if: matrix.os == 'ubuntu-18.04'
+              if: matrix.os == 'ubuntu-20.04'
 
             - name: Compute checksums (macOS)
               run: for i in `ls | grep 'firefly-desktop*'` ; do shasum -a 256 $i | awk {'print $1'} > $i.sha256 ; done
@@ -217,7 +217,7 @@ jobs:
             - name: Downloading artifacts
               uses: actions/download-artifact@v2
               with:
-                  name: firefly-desktop-ubuntu-18.04
+                  name: firefly-desktop-ubuntu-20.04
                   path: assets
 
             - name: Preparing release body

--- a/.github/workflows/ci.lint.yml
+++ b/.github/workflows/ci.lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   rust:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -21,7 +21,7 @@ jobs:
           components: rustfmt
 
   js:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.snyk.yml
+++ b/.github/workflows/ci.snyk.yml
@@ -11,7 +11,7 @@ jobs:
     # Only run on push events or PRs from iotaledger/firefly, skip on PRs from forks
     # Secret variables cannot be exposed to PRs from forks
     if: github.event_name == 'push'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   shared:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/handbook.yml
+++ b/.github/workflows/handbook.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
GitHub actions with hosted runners are not working because `ubuntu-18.04` has been removed from them, so we need to update to `ubuntu-20.04` or `ubuntu-22.04`, in this PR I've updated to `ubuntu-20.04`

https://github.com/actions/runner-images/issues/6002