### PR TITLE
fix: remove prevent close flag from password popup call

### DIFF
--- a/packages/shared/components/popups/Backup.svelte
+++ b/packages/shared/components/popups/Backup.svelte
@@ -92,7 +92,6 @@
         openPopup({
             type: 'password',
             hideClose: true,
-            preventClose: true,
             overflow: true,
             props: {
                 onSuccess: (_password) => {


### PR DESCRIPTION
## Summary

This PR fixes an issue that prevents the password popup of the profile backup from being canceled/closed

...

## Changelog

```
- Removed preventClose flag from password popup call 
```

## Relevant Issues

Closes #4275

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
