### PR TITLE
fix: disable notification settings

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -127,6 +127,9 @@
         await pollMarketData()
         await pollNetworkStatus()
     })
+
+    // TODO: Has to be enabled again when system notifications are implemented
+    $appSettings.notifications = false
 </script>
 
 {#if $isLocaleLoaded && !showSplash}

--- a/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
+++ b/packages/shared/routes/dashboard/settings/views/SettingsHome.svelte
@@ -17,7 +17,8 @@
         settingsRouter,
     } from '@core/router'
 
-    const { NetworkStatus, ...generalSettingsMobile } = GeneralSettings
+    // TODO: Notification settings have to be enabled again when system notifications are implemented for mobile
+    const { NetworkStatus, Notifications, ...generalSettingsMobile } = GeneralSettings
     const { CrashReporting, MigrateLedgerIndex, DeepLinks, ...advancedSettingsMobile } = AdvancedSettings
     const securitySettings = Object.assign({}, SecuritySettings)
     const advancedSettings = Object.assign({}, AdvancedSettings)


### PR DESCRIPTION
## Summary

This PR removes the notification settings from the settings list for the upcoming production release as system notifications for mobile are not implemented yet.

## Changelog

```
- Removed notification item from the settings list
- Disabled notifications as default
```

## Relevant Issues

Closes #4304
Closes #4311

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
