### PR TITLE
fix: mnemonic was already stored error

### DIFF
--- a/packages/shared/routes/setup/backup/views/VerifyRecoveryPhrase.svelte
+++ b/packages/shared/routes/setup/backup/views/VerifyRecoveryPhrase.svelte
@@ -39,6 +39,7 @@
     }
 
     function handleChoice(word: string): void {
+        if (verified) return
         if ($mobile) {
             const wordElement = document.getElementById(`recovery-word-${verifyIndex}`)
             wordElement?.scrollIntoView({ behavior: 'smooth', block: 'center' })


### PR DESCRIPTION
## Summary

Fixes error when recovery phrase verification is completed too quickly
...

## Changelog

```
- Stop additional verification choices once mnemonic has been verified
```

## Relevant Issues

Fixes #4195

...

## Testing

### Platforms

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [ ] Android

### Instructions

Try verify a mnemonic by pressing lots of random words on device
...

## Checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
