### PR TITLE
improvement: polish keyboard open and close animations

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -5,9 +5,8 @@
     import { StatusBar, Style } from '@capacitor/status-bar'
     import { onMount, tick } from 'svelte'
     import { QRScanner, Route, ToastContainer, Popup } from 'shared/components'
-    import { closeDrawers, closePreviousDrawer } from 'shared/components/Drawer.svelte'
-    import { openPopup, popupState } from '@lib/popup'
-    import { logout, keyboardHeight, isKeyboardOpened, mobile, stage } from '@lib/app'
+    import { popupState } from '@lib/popup'
+    import { logout, keyboardHeight, isKeyboardOpened, mobile, stage, isAndroid } from '@lib/app'
     import { appSettings } from '@lib/appSettings'
     import { goto } from '@lib/helpers'
     import { localeDirection, isLocaleLoaded, setupI18n, _ } from '@core/i18n'
@@ -41,12 +40,6 @@
     stage.set(Stage[process.env.STAGE?.toUpperCase()] ?? Stage.ALPHA)
 
     let showSplash = true
-
-    /**
-     * We use !== 'ios' since Android sometimes is not detected
-     * so as default we define Android.
-     */
-    const isAndroid = Platform.getOS() !== 'ios'
 
     $: if ($appSettings.darkMode) {
         document.body.classList.add('scheme-dark')
@@ -105,7 +98,7 @@
         $keyboardHeight = info.keyboardHeight
         $isKeyboardOpened = true
     })
-    void Keyboard.addListener('keyboardDidHide', () => {
+    void Keyboard.addListener('keyboardWillHide', () => {
         // Listen for when the keyboard is about to be hidden.
         $isKeyboardOpened = false
     })
@@ -118,6 +111,7 @@
     void setupI18n({ fallbackLocale: 'en', initialLocale: $appSettings.language })
 
     onMount(async () => {
+        isAndroid.set((await Platform.getOS()) !== 'ios')
         // Display splash screen at least for 3 seconds
         setTimeout(() => {
             showSplash = false
@@ -135,7 +129,7 @@
 {#if $isLocaleLoaded && !showSplash}
     <!-- empty div to avoid auto-purge removing dark classes -->
     <div class="scheme-dark" />
-    <div class="scanner-hide" style="--transition-scroll: {isAndroid ? 'cubic-bezier(0, 0.3, 0, 1)' : 'ease-out'}">
+    <div class="scanner-hide" style="--transition-scroll: cubic-bezier(0, 0.3, 0, 1)">
         {#if $popupState.active}
             <Popup
                 type={$popupState.type}

--- a/packages/shared/components/popups/AddNode.svelte
+++ b/packages/shared/components/popups/AddNode.svelte
@@ -13,7 +13,7 @@
     import { Locale } from '@core/i18n'
     import { Node, NodeAuth, NodeInfo } from 'shared/lib/typings/node'
     import { Network } from 'shared/lib/typings/network'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
 
     export let locale: Locale
 
@@ -190,7 +190,7 @@
         class="flex flex-row justify-between space-x-4 w-full md:px-8 "
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight - 20
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Button secondary classes="w-1/2" onClick={() => closePopup()} disabled={isBusy}>
             {locale('actions.cancel')}

--- a/packages/shared/components/popups/AddNode.svelte
+++ b/packages/shared/components/popups/AddNode.svelte
@@ -190,7 +190,7 @@
         class="flex flex-row justify-between space-x-4 w-full md:px-8 "
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight - 20
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button secondary classes="w-1/2" onClick={() => closePopup()} disabled={isBusy}>
             {locale('actions.cancel')}

--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -14,7 +14,7 @@
         isSyncing,
         wallet,
     } from '@lib/wallet'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
 
     export let locale: Locale
 
@@ -132,7 +132,7 @@
     class="flex flex-row flex-nowrap w-full space-x-4"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight - 20
-        : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
 >
     <Button classes="w-full" secondary onClick={handleCancelClick} disabled={isBusy}>
         {locale('actions.done')}

--- a/packages/shared/components/popups/BalanceFinder.svelte
+++ b/packages/shared/components/popups/BalanceFinder.svelte
@@ -132,7 +132,7 @@
     class="flex flex-row flex-nowrap w-full space-x-4"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight - 20
-        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
 >
     <Button classes="w-full" secondary onClick={handleCancelClick} disabled={isBusy}>
         {locale('actions.done')}

--- a/packages/shared/components/popups/CreateAccount.svelte
+++ b/packages/shared/components/popups/CreateAccount.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { localize } from '@core/i18n'
-    import { mobile, isKeyboardOpened, keyboardHeight } from '@lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from '@lib/app'
     import { getTrimmedLength } from '@lib/helpers'
     import { displayNotificationForLedgerProfile, promptUserToConnectLedger } from '@lib/ledger'
     import { showAppNotification } from '@lib/notifications'
@@ -94,7 +94,7 @@
     class="flex flex-col h-full justify-between"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight
-        : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
 >
     <div>
         <div class="flex flex-row mb-6 {$mobile && 'w-full justify-center -mt-1'}">

--- a/packages/shared/components/popups/CreateAccount.svelte
+++ b/packages/shared/components/popups/CreateAccount.svelte
@@ -94,7 +94,7 @@
     class="flex flex-col h-full justify-between"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight
-        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
 >
     <div>
         <div class="flex flex-row mb-6 {$mobile && 'w-full justify-center -mt-1'}">

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
     import { get } from 'svelte/store'
     import { Button, Password, Text } from 'shared/components'
-    import { logout, mobile, keyboardHeight, isKeyboardOpened } from '@lib/app'
+    import { logout, mobile, keyboardHeight, isKeyboardOpened, getKeyboardTransitionSpeed } from '@lib/app'
     import { showAppNotification } from 'shared/lib/notifications'
     import { closePopup } from 'shared/lib/popup'
     import { activeProfile, isSoftwareProfile, profiles, removeProfile, removeProfileFolder } from 'shared/lib/profile'
@@ -116,7 +116,7 @@
     class="flex flex-row justify-between space-x-4 w-full md:px-8"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight - 20
-        : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
 >
     <Button secondary classes="w-1/2" onClick={() => closePopup()} disabled={isBusy}>{locale('actions.no')}</Button>
     <Button

--- a/packages/shared/components/popups/DeleteProfile.svelte
+++ b/packages/shared/components/popups/DeleteProfile.svelte
@@ -116,7 +116,7 @@
     class="flex flex-row justify-between space-x-4 w-full md:px-8"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight - 20
-        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
 >
     <Button secondary classes="w-1/2" onClick={() => closePopup()} disabled={isBusy}>{locale('actions.no')}</Button>
     <Button

--- a/packages/shared/components/popups/HideAccount.svelte
+++ b/packages/shared/components/popups/HideAccount.svelte
@@ -69,7 +69,7 @@
     class="flex flex-col {$mobile ? 'safe-area px-2 pt-0 -mb-2 items-center' : 'px-6 py-10'}"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight
-        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
 >
     {#if canDelete}
         <div class={$mobile ? 'mb-6 -mt-4' : 'mb-5'}>

--- a/packages/shared/components/popups/HideAccount.svelte
+++ b/packages/shared/components/popups/HideAccount.svelte
@@ -3,7 +3,7 @@
     import { accountRouter } from '@core/router'
     import { AccountRoute } from '@core/router/enums'
     import { Unit } from '@iota/unit-converter'
-    import { mobile, isKeyboardOpened, keyboardHeight } from '@lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from '@lib/app'
     import { formatUnitPrecision } from '@lib/units'
     import { Button, Password, Text } from 'shared/components'
     import { sendParams } from 'shared/lib/app'
@@ -69,7 +69,7 @@
     class="flex flex-col {$mobile ? 'safe-area px-2 pt-0 -mb-2 items-center' : 'px-6 py-10'}"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight
-        : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
 >
     {#if canDelete}
         <div class={$mobile ? 'mb-6 -mt-4' : 'mb-5'}>

--- a/packages/shared/components/popups/Password.svelte
+++ b/packages/shared/components/popups/Password.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Button, Password, Text } from 'shared/components'
-    import { keyboardHeight, isKeyboardOpened, mobile } from 'shared/lib/app'
+    import { keyboardHeight, isKeyboardOpened, mobile, getKeyboardTransitionSpeed } from 'shared/lib/app'
     import { closePopup } from 'shared/lib/popup'
     import { api } from 'shared/lib/wallet'
     import { Locale } from '@core/i18n'
@@ -67,7 +67,7 @@
         class="flex flex-row justify-between w-full space-x-4 md:px-8 {$mobile && $isKeyboardOpened && '-mb-6'}"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Button secondary classes="w-1/2" onClick={handleCancelClick}>{locale('actions.cancel')}</Button>
         <Button classes="w-1/2" type="submit" form="password-popup-form" disabled={!password || password.length === 0}>

--- a/packages/shared/components/popups/Password.svelte
+++ b/packages/shared/components/popups/Password.svelte
@@ -67,7 +67,7 @@
         class="flex flex-row justify-between w-full space-x-4 md:px-8 {$mobile && $isKeyboardOpened && '-mb-6'}"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button secondary classes="w-1/2" onClick={handleCancelClick}>{locale('actions.cancel')}</Button>
         <Button classes="w-1/2" type="submit" form="password-popup-form" disabled={!password || password.length === 0}>

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -165,3 +165,8 @@ export const TOS_VERSION = 2
 
 export const needsToAcceptLatestPrivacyPolicy = (): boolean => get(lastAcceptedPrivacyPolicy) < PRIVACY_POLICY_VERSION
 export const needsToAcceptLatestTos = (): boolean => get(lastAcceptedTos) < TOS_VERSION
+
+export const isAndroid = writable<boolean>(false)
+
+export const getKeyboardTransitionSpeed = (isKeyboardOpened: boolean): string =>
+    isKeyboardOpened ? (get(isAndroid) ? '0.2s' : '0.4s') : '0.25s'

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
@@ -2,7 +2,7 @@
     import { Button, Pin, Spinner, Text } from 'shared/components'
     import { localize } from '@core/i18n'
     import { Platform } from 'shared/lib/platform'
-    import { mobile, isKeyboardOpened } from '@lib/app'
+    import { mobile, isKeyboardOpened, getKeyboardTransitionSpeed } from '@lib/app'
     import { activeProfile } from 'shared/lib/profile'
     import { PIN_LENGTH } from 'shared/lib/utils'
     import { api } from 'shared/lib/wallet'
@@ -93,7 +93,7 @@
     id="pincode-change-form"
     style="margin-top: {$mobile && $isKeyboardOpened
         ? '-20%'
-        : '0px'}; transition: margin-top 0.2s var(--transition-scroll)"
+        : '0px'}; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)}  (--transition-scroll)"
 >
     <Text type="h4" classes="mb-3">{localize('views.settings.changePincode.title')}</Text>
     <Text type="p" secondary classes="mb-5">{localize('views.settings.changePincode.description')}</Text>

--- a/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/ManageAccount.svelte
@@ -2,7 +2,7 @@
     import { localize } from '@core/i18n'
     import { AccountRoute, accountRouter } from '@core/router'
     import { Button, ColorPicker, Input, Text } from 'shared/components'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
     import { getTrimmedLength } from 'shared/lib/helpers'
     import { activeProfile, getAccountColor, setProfileAccount } from 'shared/lib/profile'
     import { WalletAccount } from 'shared/lib/typings/wallet'
@@ -80,7 +80,7 @@
     class="w-full h-full flex flex-col justify-between {$mobile ? 'safe-area px-5 pt-6' : 'p-6'}"
     style="padding-bottom: {$mobile && $isKeyboardOpened
         ? $keyboardHeight
-        : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+        : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)}  (--transition-scroll)"
 >
     <div>
         <div class="flex flex-row mb-6 {$mobile && 'justify-center'}">

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -3,7 +3,14 @@
     import { accountRouter } from '@core/router'
     import { Unit } from '@iota/unit-converter'
     import { Address, Amount, Button, Dropdown, Icon, Illustration, Input, ProgressBar, Text } from 'shared/components'
-    import { clearSendParams, keyboardHeight, isKeyboardOpened, mobile, sendParams } from 'shared/lib/app'
+    import {
+        clearSendParams,
+        keyboardHeight,
+        isKeyboardOpened,
+        mobile,
+        sendParams,
+        getKeyboardTransitionSpeed,
+    } from 'shared/lib/app'
     import {
         convertFromFiat,
         convertToFiat,
@@ -517,7 +524,11 @@
             <div
                 style="margin-top: {$isKeyboardOpened ? '-230px' : '0px'}; opacity: {$isKeyboardOpened
                     ? 0
-                    : 1}; transition: opacity 0.2s var(--transition-scroll); transition: margin-top 0.2s var(--transition-scroll)"
+                    : 1}; transition: opacity {getKeyboardTransitionSpeed(
+                    $isKeyboardOpened
+                )} (--transition-scroll); transition: margin-top {getKeyboardTransitionSpeed(
+                    $isKeyboardOpened
+                )} (--transition-scroll)"
             >
                 <Illustration height={230} background illustration="send-mobile" />
             </div>
@@ -576,7 +587,9 @@
                 class="mt-8 flex flex-row justify-between px-2"
                 style="margin-bottom: {$isKeyboardOpened
                     ? $keyboardHeight
-                    : 0}px; transition: margin-bottom 0.2s var(--transition-scroll)"
+                    : 0}px; transition: margin-bottom {getKeyboardTransitionSpeed(
+                    $isKeyboardOpened
+                )} (--transition-scroll)"
             >
                 <Button secondary classes="-mx-2 w-1/2" onClick={() => handleBackClick()}>
                     {localize('actions.cancel')}

--- a/packages/shared/routes/login/views/EnterPin.svelte
+++ b/packages/shared/routes/login/views/EnterPin.svelte
@@ -17,6 +17,7 @@
         keyboardHeight,
         needsToAcceptLatestPrivacyPolicy,
         needsToAcceptLatestTos,
+        getKeyboardTransitionSpeed,
     } from '@lib/app'
 
     export let locale: Locale
@@ -178,7 +179,7 @@
             class="flex flex-col items-center {$mobile ? 'w-full' : 'w-96 flex-wrap mb-20'}"
             style="padding-bottom: {$mobile
                 ? $keyboardHeight + 15
-                : 0}px; ; transition: padding 0.2s var(--transition-scroll)"
+                : 0}px; ; transition: padding {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
         >
             <Profile name={$activeProfile?.name} bgColor="blue" />
             <Pin

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -1,6 +1,12 @@
 <script lang="typescript">
     import { Animation, Button, OnboardingLayout, Password, Text } from 'shared/components'
-    import { mobile, isKeyboardOpened, keyboardHeight, strongholdPassword } from 'shared/lib/app'
+    import {
+        mobile,
+        isKeyboardOpened,
+        keyboardHeight,
+        strongholdPassword,
+        getKeyboardTransitionSpeed,
+    } from 'shared/lib/app'
     import { showAppNotification } from 'shared/lib/notifications'
     import passwordInfo from 'shared/lib/password'
     import { asyncChangeStrongholdPassword, asyncSetStrongholdPassword, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
@@ -82,7 +88,7 @@
         slot="leftpane__content"
         style="margin-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: margin-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)}  var(--transition-scroll)"
     >
         <form on:submit|preventDefault={handleContinueClick} id="password-form">
             <Text type="p" classes="mb-4" secondary>{locale('views.password.body1')}</Text>
@@ -114,7 +120,9 @@
         slot="leftpane__action"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed(
+            $isKeyboardOpened
+        )}  var(--transition-scroll)"
     >
         <Button type="submit" form="password-form" classes="w-full" disabled={!password || !confirmedPassword || busy}>
             {locale('actions.savePassword')}
@@ -125,7 +133,7 @@
         class="w-full h-full flex justify-center {$mobile ? 'overflow-hidden' : 'bg-pastel-yellow dark:bg-gray-900'}"
         style="margin-top: {$mobile && $isKeyboardOpened
             ? -$keyboardHeight
-            : 0}px; transition: margin-top 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)}  var(--transition-scroll)"
     >
         <Animation classes="setup-anim-aspect-ratio {$mobile ? 'transform ' : ''}" animation="password-desktop" />
     </div>

--- a/packages/shared/routes/setup/Profile.svelte
+++ b/packages/shared/routes/setup/Profile.svelte
@@ -1,7 +1,14 @@
 <script lang="typescript">
     import { get } from 'svelte/store'
     import { initAppSettings } from 'shared/lib/appSettings'
-    import { cleanupSignup, mobile, isKeyboardOpened, keyboardHeight, stage } from 'shared/lib/app'
+    import {
+        cleanupSignup,
+        mobile,
+        isKeyboardOpened,
+        keyboardHeight,
+        stage,
+        getKeyboardTransitionSpeed,
+    } from 'shared/lib/app'
     import {
         Animation,
         Button,
@@ -108,7 +115,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.profile.body1')}</Text>
         <Text type="p" secondary classes={$mobile ? 'mb-4' : 'mb-10'}>
@@ -143,7 +150,7 @@
         class="flex flex-col"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button classes="w-full" disabled={!isProfileNameValid || busy} onClick={handleContinueClick}>
             {locale('actions.continue')}
@@ -154,7 +161,7 @@
         class="w-full h-full flex justify-center {$mobile ? 'overflow-hidden ' : 'bg-pastel-green dark:bg-gray-900'}"
         style="margin-top: {$mobile && $isKeyboardOpened
             ? -$keyboardHeight
-            : 0}px; transition: margin-top 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Animation
             animation={$mobile ? 'password-desktop' : 'profile-desktop'}

--- a/packages/shared/routes/setup/import/views/BackupPassword.svelte
+++ b/packages/shared/routes/setup/import/views/BackupPassword.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Animation, Button, OnboardingLayout, Password, Spinner, Text } from 'shared/components'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
     import { Locale } from '@core/i18n'
     import { createEventDispatcher, getContext } from 'svelte'
     import { ImportRouter } from '@core/router'
@@ -42,7 +42,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.importBackupPassword.body1')}</Text>
         <Text type="p" secondary classes="mb-8">{locale('views.importBackupPassword.body2')}</Text>
@@ -62,7 +62,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Button
             classes="flex-1"
@@ -83,7 +83,7 @@
         class="w-full h-full flex justify-center {$mobile ? 'overflow-hidden ' : 'bg-pastel-orange dark:bg-gray-900'}"
         style="margin-top: {$mobile && $isKeyboardOpened
             ? -$keyboardHeight
-            : 0}px; transition: margin-top 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Animation
             classes="setup-anim-aspect-ratio {$mobile ? 'transform scale-120' : ''}"

--- a/packages/shared/routes/setup/import/views/BackupPassword.svelte
+++ b/packages/shared/routes/setup/import/views/BackupPassword.svelte
@@ -42,7 +42,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.importBackupPassword.body1')}</Text>
         <Text type="p" secondary classes="mb-8">{locale('views.importBackupPassword.body2')}</Text>
@@ -62,7 +62,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button
             classes="flex-1"

--- a/packages/shared/routes/setup/import/views/TextImport.svelte
+++ b/packages/shared/routes/setup/import/views/TextImport.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Animation, Button, ImportTextfield, OnboardingLayout, Spinner, Text } from 'shared/components'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
     import { createEventDispatcher, getContext } from 'svelte'
     import { Locale } from '@core/i18n'
     import { ImportRouter } from '@core/router'
@@ -31,7 +31,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-8">{locale(`views.importFromText.${$importType}.body`)}</Text>
         <Text type="h5" classes="mb-3">{locale(`views.importFromText.${$importType}.enter`)}</Text>
@@ -42,7 +42,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Button
             classes="flex-1"
@@ -63,7 +63,7 @@
         class="w-full h-full flex justify-center {$mobile ? 'overflow-hidden ' : 'bg-pastel-blue dark:bg-gray-900'}"
         style="margin-top: {$mobile && $isKeyboardOpened
             ? -$keyboardHeight
-            : 0}px; transition: margin-top 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Animation
             classes="setup-anim-aspect-ratio {$mobile ? 'transform scale-120' : ''}"

--- a/packages/shared/routes/setup/import/views/TextImport.svelte
+++ b/packages/shared/routes/setup/import/views/TextImport.svelte
@@ -31,7 +31,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-8">{locale(`views.importFromText.${$importType}.body`)}</Text>
         <Text type="h5" classes="mb-3">{locale(`views.importFromText.${$importType}.enter`)}</Text>
@@ -42,7 +42,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button
             classes="flex-1"

--- a/packages/shared/routes/setup/protect/views/Pin.svelte
+++ b/packages/shared/routes/setup/protect/views/Pin.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Animation, Button, OnboardingLayout, Pin, Text } from 'shared/components'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
     import { validatePinFormat } from 'shared/lib/utils'
     import { createEventDispatcher } from 'svelte'
     import { Locale } from '@core/i18n'
@@ -35,7 +35,7 @@
         class={$mobile && 'overflow-hidden'}
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.pin.body1')}</Text>
         <Text type="p" secondary highlighted classes="mb-8 font-bold">{locale('views.pin.body2')}</Text>
@@ -54,7 +54,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Button classes="flex-1" disabled={!validatePinFormat(pinInput) || busy} onClick={() => onSubmit()}>
             {locale('actions.setPin')}
@@ -65,7 +65,7 @@
         class="w-full h-full flex justify-center {$mobile ? 'overflow-hidden ' : 'bg-pastel-pink dark:bg-gray-900'}"
         style="margin-top: {$mobile && $isKeyboardOpened
             ? -$keyboardHeight
-            : 0}px; transition: margin-top 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Animation classes="setup-anim-aspect-ratio {$mobile ? 'transform scale-120' : ''}" animation="pin-desktop" />
     </div>

--- a/packages/shared/routes/setup/protect/views/Pin.svelte
+++ b/packages/shared/routes/setup/protect/views/Pin.svelte
@@ -35,7 +35,7 @@
         class={$mobile && 'overflow-hidden'}
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.pin.body1')}</Text>
         <Text type="p" secondary highlighted classes="mb-8 font-bold">{locale('views.pin.body2')}</Text>
@@ -54,7 +54,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button classes="flex-1" disabled={!validatePinFormat(pinInput) || busy} onClick={() => onSubmit()}>
             {locale('actions.setPin')}

--- a/packages/shared/routes/setup/protect/views/RepeatPin.svelte
+++ b/packages/shared/routes/setup/protect/views/RepeatPin.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { Animation, Button, OnboardingLayout, Pin, Text } from 'shared/components'
-    import { mobile, isKeyboardOpened, keyboardHeight } from 'shared/lib/app'
+    import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
     import { Locale } from '@core/i18n'
     import { validatePinFormat } from 'shared/lib/utils'
     import { createEventDispatcher, onMount } from 'svelte'
@@ -45,7 +45,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.confirmPin.body1')}</Text>
         <Text type="p" secondary classes="mb-8">{locale('views.confirmPin.body2')}</Text>
@@ -65,7 +65,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom 0.2s var(--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Button classes="flex-1" disabled={!validatePinFormat(pinInput) || busy} onClick={() => onSubmit()}>
             {locale('actions.confirmPin')}
@@ -76,7 +76,7 @@
         class="w-full h-full flex justify-center {$mobile ? 'overflow-hidden ' : 'bg-pastel-pink dark:bg-gray-900'}"
         style="margin-top: {$mobile && $isKeyboardOpened
             ? -$keyboardHeight
-            : 0}px; transition: margin-top 0.2s var(--transition-scroll)"
+            : 0}px; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
     >
         <Animation
             classes="setup-anim-aspect-ratio {$mobile ? 'transform scale-120' : ''}"

--- a/packages/shared/routes/setup/protect/views/RepeatPin.svelte
+++ b/packages/shared/routes/setup/protect/views/RepeatPin.svelte
@@ -45,7 +45,7 @@
         slot="leftpane__content"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Text type="p" secondary classes="mb-4">{locale('views.confirmPin.body1')}</Text>
         <Text type="p" secondary classes="mb-8">{locale('views.confirmPin.body2')}</Text>
@@ -65,7 +65,7 @@
         class="flex flex-row flex-wrap justify-between items-center space-x-4"
         style="padding-bottom: {$mobile && $isKeyboardOpened
             ? $keyboardHeight
-            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} (--transition-scroll)"
+            : 0}px; transition: padding-bottom {getKeyboardTransitionSpeed($isKeyboardOpened)} var(--transition-scroll)"
     >
         <Button classes="flex-1" disabled={!validatePinFormat(pinInput) || busy} onClick={() => onSubmit()}>
             {locale('actions.confirmPin')}


### PR DESCRIPTION
## Summary

Ensures clean keyboard open and close animations on iOS and Android 
...

## Changelog

```
- Updates keyboard close/open animation transition speeds
```

## Testing

### Platforms

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

## Checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
