### PR TITLE
fix: adds prevent default to change pin and password

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
@@ -105,7 +105,7 @@
 </script>
 
 <!-- TODO: improve UX for mobile, 3 step screen -->
-<form id="form-change-password" on:submit={changePassword}>
+<form id="form-change-password" on:submit|preventDefault={changePassword}>
     <Text type="h4" classes="mb-3">{localize('views.settings.changePassword.title')}</Text>
     <Text type="p" secondary classes="mb-5">{localize('views.settings.changePassword.description')}</Text>
     <Password

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
@@ -89,7 +89,7 @@
 
 <!-- TODO: improve UX for mobile, 3 step screen -->
 <form
-    on:submit={changePincode}
+    on:submit|preventDefault={changePincode}
     id="pincode-change-form"
     style="margin-top: {$mobile && $isKeyboardOpened
         ? '-20%'


### PR DESCRIPTION
## Summary
Adds prevent default to ChangePin's and ChangePassword's submit event to prevent the app to reload after changing one of them.

## Changelog
- Add preventDefault event modifier to on:submit in ChangePin.svelte form
- Add preventDefault event modifier to on:submit in ChangePassword.svelte form

## Relevant Issues
closes #4351 

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android

### Instructions
- Change password
- If the app does not reload so the fix is working
- Change pin
- If the app does not reload so the fix is working

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
