### PR TITLE
fix: adds bottom padding to recovery phrase setup title

### DIFF
--- a/packages/shared/routes/setup/backup/views/RecoveryPhrase.svelte
+++ b/packages/shared/routes/setup/backup/views/RecoveryPhrase.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <OnboardingLayout onBackClick={handleBackClick} {busy} reverseContent={$mobile}>
-    <div slot="title">
+    <div slot="title" class:pb-2={$mobile}>
         <Text type="h2">{locale('views.recoveryPhrase.title')}</Text>
     </div>
     <div slot="leftpane__content">


### PR DESCRIPTION
## Relevant Issues
closes #4358 

## Testing

### Platforms
- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [x] Android
  
## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
