### PR TITLE
fix: disable horizontal scroll on main div

### DIFF
--- a/packages/shared/components/MainMenu.svelte
+++ b/packages/shared/components/MainMenu.svelte
@@ -67,7 +67,7 @@
                 )}
             </Text>
         </header>
-        <main class="h-full overflow-y-auto px-5 mb-10">
+        <main class="h-full overflow-y-auto overflow-x-hidden px-5 mb-10">
             {#if $profileRoute === ProfileRoute.ProfileActions}
                 <ProfileActions {profileColor} {profileInitial} {handleSettingsClick} />
             {:else if $profileRoute === ProfileRoute.Settings}


### PR DESCRIPTION
## Summary

This PR removes the horizontal scroll showed only on Android at sub menu transitions, as we forced to show scroll as workaround to show scrolls on inner divs.

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
