### PR TITLE
fix: hide title at show keyboard for mobile

### DIFF
--- a/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Button, Checkbox, Password, Spinner, Text } from 'shared/components'
+    import { mobile, isKeyboardOpened, getKeyboardTransitionSpeed } from '@lib/app'
     import { localize } from '@core/i18n'
     import passwordInfo from 'shared/lib/password'
     import { api, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
@@ -105,7 +106,14 @@
 </script>
 
 <!-- TODO: improve UX for mobile, 3 step screen -->
-<form id="form-change-password" on:submit|preventDefault={changePassword}>
+<form 
+    id="form-change-password" 
+    on:submit|preventDefault={changePassword}
+    style="margin-top: {$mobile && $isKeyboardOpened
+        ? '-25%'
+        : '0px'}; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened) +
+        'ms'} var(--transition-scroll)"
+>
     <Text type="h4" classes="mb-3">{localize('views.settings.changePassword.title')}</Text>
     <Text type="p" secondary classes="mb-5">{localize('views.settings.changePassword.description')}</Text>
     <Password

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
@@ -106,8 +106,8 @@
 </script>
 
 <!-- TODO: improve UX for mobile, 3 step screen -->
-<form 
-    id="form-change-password" 
+<form
+    id="form-change-password"
     on:submit|preventDefault={changePassword}
     style="margin-top: {$mobile && $isKeyboardOpened
         ? '-25%'


### PR DESCRIPTION
## Summary

For smaller screens is needed to hide the title and text to allow the user tap the button to confirm action.

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
