### PR TITLE
fix: correct subject if expired output

### DIFF
--- a/packages/shared/lib/core/wallet/utils/transactions/getSenderFromInputs.ts
+++ b/packages/shared/lib/core/wallet/utils/transactions/getSenderFromInputs.ts
@@ -1,21 +1,42 @@
 import { Subject } from '../../types'
-import { ADDRESS_TYPE_ED25519, OUTPUT_TYPE_TREASURY, UNLOCK_CONDITION_ADDRESS } from '../../constants'
+import { OUTPUT_TYPE_TREASURY, UNLOCK_CONDITION_ADDRESS, UNLOCK_CONDITION_EXPIRATION } from '../../constants'
 import { convertEd25519ToBech32 } from '../convertEd25519ToBech32'
 import { getSubjectFromAddress } from '../getSubjectFromAddress'
-import { IOutputResponse } from '@iota/types'
+import {
+    AddressTypes,
+    IOutputResponse,
+    IExpirationUnlockCondition,
+    IEd25519Address,
+    IAddressUnlockCondition,
+} from '@iota/types'
 
 export function getSenderFromInputs(inputs: IOutputResponse[]): Subject {
-    for (const input of inputs) {
-        if (input.output.type !== OUTPUT_TYPE_TREASURY) {
-            for (const unlockCondition of input.output.unlockConditions) {
-                if (
-                    unlockCondition.type === UNLOCK_CONDITION_ADDRESS &&
-                    unlockCondition.address.type === ADDRESS_TYPE_ED25519
-                ) {
-                    return getSubjectFromAddress(convertEd25519ToBech32(unlockCondition.address.pubKeyHash))
-                }
+    for (const { output } of inputs) {
+        // TODO: currently getSubjectFromEd25519 only handles basic outputs
+        // We need to add a wrapper function to handle alias, NFT and Foundry outputs
+        if (output.type !== OUTPUT_TYPE_TREASURY) {
+            const { unlockConditions } = output
+
+            const expirationUnlockCondition = unlockConditions.find(
+                ({ type }) => type === UNLOCK_CONDITION_EXPIRATION
+            ) as IExpirationUnlockCondition
+            if (expirationUnlockCondition) {
+                return getSubjectFromEd25519(expirationUnlockCondition.returnAddress)
+            }
+
+            const addressUnlockCondition = unlockConditions.find(
+                ({ type }) => type === UNLOCK_CONDITION_ADDRESS
+            ) as IAddressUnlockCondition
+            if (addressUnlockCondition) {
+                return getSubjectFromEd25519(addressUnlockCondition.address)
             }
         }
     }
     return undefined
+}
+
+function getSubjectFromEd25519(address: AddressTypes): Subject {
+    const ed25519Address = address as IEd25519Address
+    const bech32Address = convertEd25519ToBech32(ed25519Address.pubKeyHash)
+    return getSubjectFromAddress(bech32Address)
 }

--- a/packages/shared/lib/core/wallet/utils/transactions/getSenderFromInputs.ts
+++ b/packages/shared/lib/core/wallet/utils/transactions/getSenderFromInputs.ts
@@ -17,6 +17,7 @@ export function getSenderFromInputs(inputs: IOutputResponse[]): Subject {
         if (output.type !== OUTPUT_TYPE_TREASURY) {
             const { unlockConditions } = output
 
+            // A transaction with an expiration unlock condition is included if the transaction expired
             const expirationUnlockCondition = unlockConditions.find(
                 ({ type }) => type === UNLOCK_CONDITION_EXPIRATION
             ) as IExpirationUnlockCondition


### PR DESCRIPTION
## Summary

Correctly get subject if expired output is contained

...

## Changelog

```
- Add extra condition for fetching address from expired unlock condition
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/4365

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
