### PR TITLE
chore: add address click to copy for activity details

### DIFF
--- a/packages/shared/components/ActivityDetail.svelte
+++ b/packages/shared/components/ActivityDetail.svelte
@@ -11,6 +11,7 @@
     import { Payload } from 'shared/lib/typings/message'
     import { WalletAccount } from 'shared/lib/typings/wallet'
     import { formatUnitBestMatch } from 'shared/lib/units'
+    import { setClipboard } from 'shared/lib/utils'
     import {
         findAccountWithAddress,
         findAccountWithAnyAddress,
@@ -189,8 +190,11 @@
                 <div class="mb-5">
                     <Text secondary>{localize('general.inputAddress')}</Text>
                     <div class="flex flex-row justify-between items-center">
-                        <Text type="pre">{senderAddress}</Text>
-                        <CopyButton itemToCopy={senderAddress} />
+                        <div on:click={() => setClipboard(senderAddress)}>
+                            <Text type="pre" overrideColor classes="text-blue-500">
+                                {senderAddress}
+                            </Text>
+                        </div>
                     </div>
                     <Text type="pre">
                         {#if senderAccount}({senderAccount.alias}){/if}
@@ -202,8 +206,11 @@
                     <Text secondary>{localize('general.receiveAddress')}</Text>
                     {#each receiverAddresses as receiver, idx}
                         <div class="flex flex-row justify-between items-center">
-                            <Text type="pre">{receiver}</Text>
-                            <CopyButton itemToCopy={receiver} />
+                            <div on:click={() => setClipboard(receiver)}>
+                                <Text type="pre" overrideColor classes="text-blue-500">
+                                    {receiver}
+                                </Text>
+                            </div>
                         </div>
                         <Text type="pre" classes="mb-2 mt-0">
                             {#if receiverAddressesYou[idx]}({receiverAddressesYou[idx].alias}){/if}


### PR DESCRIPTION
## Summary

This PR removes the copy buttons in the activity details and adds copy via address click instead.

## Changelog

```
- Removes address copy button
- Adds set to clipboard function to address text
```

## Relevant Issues

Closes #4387

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
