### PR TITLE
fix: reset profile state upon changing setup type

### DIFF
--- a/packages/shared/lib/contexts/onboarding/actions/cleanupOnboardingProfileManager.ts
+++ b/packages/shared/lib/contexts/onboarding/actions/cleanupOnboardingProfileManager.ts
@@ -3,10 +3,8 @@ import { get } from 'svelte/store'
 import { deleteAccountsAndDatabase, destroyProfileManager, profileManager } from '@core/profile-manager'
 
 export async function cleanupOnboardingProfileManager(): Promise<void> {
-    if (!get(profileManager)) {
-        return
+    if (get(profileManager)) {
+        await deleteAccountsAndDatabase()
+        destroyProfileManager()
     }
-
-    await deleteAccountsAndDatabase()
-    destroyProfileManager()
 }

--- a/packages/shared/lib/contexts/onboarding/actions/createShimmerClaimingProfileManager.ts
+++ b/packages/shared/lib/contexts/onboarding/actions/createShimmerClaimingProfileManager.ts
@@ -2,7 +2,6 @@ import { get } from 'svelte/store'
 
 import { COIN_TYPE, NetworkProtocol } from '@core/network'
 import { initialiseProfileManager } from '@core/profile-manager'
-import { generateRandomId } from '@lib/utils'
 
 import { getShimmerClaimingProfileManagerStorageDirectory } from '../helpers'
 import { shimmerClaimingProfileManager, onboardingProfile } from '../stores'
@@ -20,6 +19,6 @@ export async function createShimmerClaimingProfileManager(): Promise<void> {
         Stronghold: { snapshotPath: `${storagePath}/wallet.stronghold` },
     }
 
-    const manager = initialiseProfileManager(storagePath, coinType, clientOptions, secretManager, generateRandomId())
+    const manager = initialiseProfileManager(storagePath, coinType, clientOptions, secretManager)
     shimmerClaimingProfileManager.set(manager)
 }

--- a/packages/shared/lib/contexts/onboarding/actions/initialiseProfileManagerFromOnboardingProfile.ts
+++ b/packages/shared/lib/contexts/onboarding/actions/initialiseProfileManagerFromOnboardingProfile.ts
@@ -2,27 +2,21 @@ import { get } from 'svelte/store'
 
 import {
     buildProfileManagerOptionsFromProfileData,
-    deleteAccountsAndDatabase,
     initialiseProfileManager,
     profileManager,
 } from '@core/profile-manager'
 
 import { onboardingProfile, updateOnboardingProfile } from '../stores'
+import { cleanupOnboardingProfileManager } from '@contexts/onboarding/actions/cleanupOnboardingProfileManager'
 
-export async function initialiseProfileManagerFromOnboardingProfile(checkForExistingManager?: boolean): Promise<void> {
-    if (get(profileManager)) {
-        if (!checkForExistingManager) {
-            await deleteAccountsAndDatabase()
-            await get(profileManager)?.destroy()
-        } else {
-            return
-        }
-    }
+export async function initialiseProfileManagerFromOnboardingProfile(): Promise<void> {
+    // Always start with a clean profile manager
+    await cleanupOnboardingProfileManager()
 
     const profileManagerOptions = await buildProfileManagerOptionsFromProfileData(get(onboardingProfile))
     const { storagePath, coinType, clientOptions, secretManager } = profileManagerOptions
-    const { id } = get(onboardingProfile)
-    const manager = initialiseProfileManager(storagePath, coinType, clientOptions, secretManager, id)
+    const manager = initialiseProfileManager(storagePath, coinType, clientOptions, secretManager)
     profileManager.set(manager)
+
     updateOnboardingProfile({ hasInitialisedProfileManager: true })
 }

--- a/packages/shared/lib/contexts/onboarding/actions/resetOnboardingProfileWithProfileManager.ts
+++ b/packages/shared/lib/contexts/onboarding/actions/resetOnboardingProfileWithProfileManager.ts
@@ -5,9 +5,7 @@ import { onboardingProfile, updateOnboardingProfile } from '../stores'
 import { resetOnboardingProfile } from './resetOnboardingProfile'
 
 export async function resetOnboardingProfileWithProfileManager(): Promise<void> {
-    if (!get(onboardingProfile)?.hasInitialisedProfileManager) {
-        return
-    } else {
+    if (get(onboardingProfile)?.hasInitialisedProfileManager) {
         await resetOnboardingProfile()
         updateOnboardingProfile({
             type: null,

--- a/packages/shared/lib/core/profile-manager/actions/destroyProfileManager.ts
+++ b/packages/shared/lib/core/profile-manager/actions/destroyProfileManager.ts
@@ -1,14 +1,13 @@
-import { get, Writable } from 'svelte/store'
+import { get } from 'svelte/store'
 
 import { api } from '../api'
-import { IProfileManager } from '../interfaces'
 import { profileManager } from '../stores'
 
-export function destroyProfileManager(_profileManager: Writable<IProfileManager> = profileManager): void {
+export function destroyProfileManager(_profileManager = profileManager): void {
     const manager = get(_profileManager)
-    if (!manager) return
-
-    _profileManager.set(null)
-    api.deleteAccountManager(manager?.id)
-    manager.destroy()
+    if (manager) {
+        _profileManager.set(null)
+        api.deleteAccountManager(manager?.id)
+        manager.destroy()
+    }
 }

--- a/packages/shared/lib/core/router/subrouters/onboarding/profile-recovery-router.ts
+++ b/packages/shared/lib/core/router/subrouters/onboarding/profile-recovery-router.ts
@@ -13,15 +13,11 @@ export class ProfileRecoveryRouter extends Subrouter<ProfileRecoveryRoute> {
     public importFile: Buffer
 
     constructor() {
-        super(
-            getInitialRoute() ?? ProfileRecoveryRoute.ImportMnemonicPhrase,
-            profileRecoveryRoute,
-            get(onboardingRouter)
-        )
+        super(getInitialRoute(), profileRecoveryRoute, get(onboardingRouter))
     }
 
     resetRoute(): void {
-        profileRecoveryRoute.set(getInitialRoute() ?? ProfileRecoveryRoute.ImportMnemonicPhrase)
+        profileRecoveryRoute.set(getInitialRoute())
     }
 
     next(): void {
@@ -60,11 +56,12 @@ export class ProfileRecoveryRouter extends Subrouter<ProfileRecoveryRoute> {
 
 function getInitialRoute(): ProfileRecoveryRoute {
     switch (get(onboardingProfile)?.recoveryType) {
-        case ProfileRecoveryType.Mnemonic:
-            return ProfileRecoveryRoute.ImportMnemonicPhrase
         case ProfileRecoveryType.Stronghold:
             return ProfileRecoveryRoute.ImportStrongholdBackup
         case ProfileRecoveryType.Ledger:
             return ProfileRecoveryRoute.LedgerImport
+        case ProfileRecoveryType.Mnemonic:
+        default:
+            return ProfileRecoveryRoute.ImportMnemonicPhrase
     }
 }

--- a/packages/shared/routes/onboarding/views/network-setup/views/ChooseNetworkView.svelte
+++ b/packages/shared/routes/onboarding/views/network-setup/views/ChooseNetworkView.svelte
@@ -18,11 +18,12 @@
     }
 
     function onNetworkSelectionClick(networkType: NetworkType): void {
-        if (networkType !== NetworkType.PrivateNet) {
+        if (networkType === NetworkType.PrivateNet) {
+            updateOnboardingProfile({ networkType })
+        } else {
             const clientOptions = getDefaultClientOptions($onboardingProfile?.networkProtocol, networkType)
-            updateOnboardingProfile({ clientOptions })
+            updateOnboardingProfile({ clientOptions, networkType })
         }
-        updateOnboardingProfile({ networkType })
         $networkSetupRouter.next()
     }
 

--- a/packages/shared/routes/onboarding/views/network-setup/views/SetupPrivateNetworkConnectionView.svelte
+++ b/packages/shared/routes/onboarding/views/network-setup/views/SetupPrivateNetworkConnectionView.svelte
@@ -35,7 +35,7 @@
             updateOnboardingProfile({ clientOptions: { nodes: [node] } })
             await initialiseProfileManagerFromOnboardingProfile(true)
             await getNodeInfo(node.url)
-            await destroyProfileManager()
+            destroyProfileManager()
             $networkSetupRouter.next()
         } catch (err) {
             console.error(err)

--- a/packages/shared/routes/onboarding/views/network-setup/views/SetupPrivateNetworkConnectionView.svelte
+++ b/packages/shared/routes/onboarding/views/network-setup/views/SetupPrivateNetworkConnectionView.svelte
@@ -33,7 +33,7 @@
                 validateClientOptions: false,
             })
             updateOnboardingProfile({ clientOptions: { nodes: [node] } })
-            await initialiseProfileManagerFromOnboardingProfile(true)
+            await initialiseProfileManagerFromOnboardingProfile()
             await getNodeInfo(node.url)
             destroyProfileManager()
             $networkSetupRouter.next()

--- a/packages/shared/routes/onboarding/views/profile-recovery/views/BackupPasswordView.svelte
+++ b/packages/shared/routes/onboarding/views/profile-recovery/views/BackupPasswordView.svelte
@@ -7,7 +7,6 @@
     import {
         CannotRestoreWithMismatchedCoinTypeError,
         createShimmerClaimingProfileManager,
-        destroyShimmerClaimingProfileManager,
         initialiseProfileManagerFromOnboardingProfile,
         onboardingProfile,
         ProfileSetupType,
@@ -35,10 +34,9 @@
                 $profileRecoveryRouter.next()
             } catch (err) {
                 if (err instanceof CannotRestoreWithMismatchedCoinTypeError) {
-                    await initialiseProfileManagerFromOnboardingProfile(false)
+                    await initialiseProfileManagerFromOnboardingProfile()
 
                     if ($onboardingProfile?.setupType === ProfileSetupType.Claimed) {
-                        await destroyShimmerClaimingProfileManager()
                         await createShimmerClaimingProfileManager()
                     }
                 } else if (err?.error.match(/`invalid stronghold password`/)) {

--- a/packages/shared/routes/onboarding/views/profile-setup/views/SetupClaimedView.svelte
+++ b/packages/shared/routes/onboarding/views/profile-setup/views/SetupClaimedView.svelte
@@ -26,7 +26,7 @@
         isBusy = { ...isBusy, [recoveryType]: true }
         const type = getProfileTypeFromProfileRecoveryType(recoveryType)
         updateOnboardingProfile({ type, recoveryType, shimmerClaimingAccounts: [] })
-        await initialiseProfileManagerFromOnboardingProfile(true)
+        await initialiseProfileManagerFromOnboardingProfile()
         await createShimmerClaimingProfileManager()
         $profileSetupRouter.next()
     }

--- a/packages/shared/routes/onboarding/views/profile-setup/views/SetupNewView.svelte
+++ b/packages/shared/routes/onboarding/views/profile-setup/views/SetupNewView.svelte
@@ -5,7 +5,6 @@
     import { mobile } from '@core/app'
     import { localize } from '@core/i18n'
     import { ProfileType } from '@core/profile'
-    import { destroyProfileManager } from '@core/profile-manager'
     import {
         initialiseProfileManagerFromOnboardingProfile,
         onboardingProfile,
@@ -24,8 +23,7 @@
     }
 
     onMount(() => {
-        destroyProfileManager()
-        updateOnboardingProfile({ type: null, hasInitialisedProfileManager: false })
+        updateOnboardingProfile({ type: null })
     })
 </script>
 

--- a/packages/shared/routes/onboarding/views/profile-setup/views/SetupRecoveredView.svelte
+++ b/packages/shared/routes/onboarding/views/profile-setup/views/SetupRecoveredView.svelte
@@ -25,7 +25,7 @@
         isBusy = { ...isBusy, [recoveryType]: true }
         const type = getProfileTypeFromProfileRecoveryType(recoveryType)
         updateOnboardingProfile({ type, recoveryType })
-        await initialiseProfileManagerFromOnboardingProfile(true)
+        await initialiseProfileManagerFromOnboardingProfile()
         $profileSetupRouter.next()
     }
     function onBackClick() {


### PR DESCRIPTION
## Summary

Correctly resets the profile manager upon going back in the setup flows.

...

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

closes: #4212 

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
