### PR TITLE
fix: force the right decimal sign for the amount calculation

### DIFF
--- a/packages/shared/components/inputs/Amount.svelte
+++ b/packages/shared/components/inputs/Amount.svelte
@@ -166,7 +166,7 @@
 <svelte:window on:click={onOutsideClick} />
 <amount-input class:disabled class="relative block {classes}" on:keydown={handleKey}>
     <Input
-        type={$mobile ? 'number' : 'text'}
+        type={'text'}
         inputmode="decimal"
         {error}
         label={amountForLabel || localize('general.amount')}

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -46,10 +46,12 @@
             }
             if ((float || integer) && !isEnter) {
                 // if the input is float, we accept one dot or comma depending on localization
-                if (float && e.key === decimalSeparator) {
-                    if (value.indexOf(decimalSeparator) >= 0) {
-                        e.preventDefault()
+                if (float && allDecimalSeparators.find((sep) => sep === e.key)) {
+                    if (allDecimalSeparators.some((sep) => value.indexOf(sep) >= 0)) {
+                        return e.preventDefault()
                     }
+                    value += decimalSeparator
+                    e.preventDefault()
                 } else if ('0123456789'.indexOf(e.key) < 0) {
                     // if float or interger we accept numbers
                     e.preventDefault()


### PR DESCRIPTION
## Summary

This PR changes the input component to select the right decimal sign no matter if a comma or dot is pressed via keyboard.

...

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

Closes #4379
Closes #4393 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
