### PR TITLE
fix: content scroll overflow

### DIFF
--- a/packages/shared/components/BottomNavigation.svelte
+++ b/packages/shared/components/BottomNavigation.svelte
@@ -5,7 +5,7 @@
 
     export let locale: Locale
 
-    let navigation: HTMLElement
+    let height = 0
 
     const tabs: BottomNavigationType[] = [
         {
@@ -30,11 +30,11 @@
     }
 
     export function getHeight(): number {
-        return navigation.getBoundingClientRect().height
+        return height
     }
 </script>
 
-<div class="w-full bottom-0 z-10" bind:this={navigation}>
+<div class="w-full bottom-0 z-10" bind:clientHeight={height}>
     <div class="nav-wrapper flex flex-row justify-center pt-4 space-x-24 bg-white dark:bg-gray-900 shadow-elevation-4">
         {#each tabs as tab}
             <BottomNavigationTab {tab} />

--- a/packages/shared/routes/dashboard/wallet/Wallet.svelte
+++ b/packages/shared/routes/dashboard/wallet/Wallet.svelte
@@ -82,6 +82,7 @@
     }
 
     const unsubscribeHeaderScale = headerScale.subscribe((curr) => mobileHeaderAnimation.set(curr))
+    const [safeArea] = getComputedStyle(document.documentElement).getPropertyValue('--sat').split('px')
 
     let unsubscribeLiftDasboard = () => {}
     let unsubscribeScrollDetection = () => {}
@@ -89,6 +90,7 @@
     const viewableAccounts = getContext<Readable<WalletAccount[]>>('viewableAccounts')
 
     let modal: Modal
+    let bottomOffset = '0px'
 
     $: {
         if ($isDeepLinkRequestActive && $sendParams && $sendParams.address) {
@@ -96,6 +98,9 @@
             isDeepLinkRequestActive.set(false)
         }
     }
+
+    $: bottomNavigation?.getHeight(),
+        (bottomOffset = `${headerHeight * 0.6 - (bottomNavigation?.getHeight() - parseInt(safeArea) / 2)}px`)
 
     let isGeneratingAddress = false
 
@@ -440,7 +445,6 @@
     }
 
     function liftDashboard(node: HTMLElement): void {
-        const [safeArea] = getComputedStyle(document.documentElement).getPropertyValue('--sat').split('px')
         node.style.zIndex = '0'
         unsubscribeLiftDasboard = headerScale.subscribe((curr) => {
             const topOffset = parseInt(safeArea) * (1 - curr)
@@ -519,11 +523,7 @@
                         {#if $walletRoute === WalletRoute.Assets}
                             <div class="h-full" in:fade|local={{ duration: 200 }} out:fade|local={{ duration: 200 }}>
                                 {#key $haveStakingResultsCached}
-                                    <AccountAssets
-                                        {scroll}
-                                        {scrollDetection}
-                                        bottomOffset="{bottomNavigation?.getHeight()}px"
-                                    />
+                                    <AccountAssets {scroll} {scrollDetection} {bottomOffset} />
                                 {/key}
                             </div>
                         {:else if $walletRoute === WalletRoute.AccountHistory}
@@ -532,7 +532,7 @@
                                     {scroll}
                                     {scrollDetection}
                                     transactions={getAccountMessages($selectedAccountStore)}
-                                    bottomOffset="{bottomNavigation?.getHeight() * 0.8}px"
+                                    {bottomOffset}
                                 />
                             </div>
                         {/if}

--- a/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
@@ -18,13 +18,13 @@
     style="--bottom-offset: {bottomOffset}"
 >
     <div class="flex relative">
-        <Text classes="text-left mr-2 mt-1 mb-3" type="h5">{localize('general.myAssets')}</Text>
+        <Text classes="text-left mr-2 {$mobile && 'mt-1 mb-3'}" type="h5">{localize('general.myAssets')}</Text>
         {#if isSelectedAccountSyncing && $mobile}
             <Spinner busy={true} classes="absolute right-0" />
         {/if}
     </div>
     <div
-        class="account-assets flex flex-auto flex-col h-0 -mr-2 pr-2 py-4 {scroll
+        class="flex flex-auto flex-col h-0 -mr-2 pr-2 {$mobile && 'account-assets py-4'} {scroll
             ? 'overflow-y-auto scroll-secondary'
             : ''}"
         use:scrollDetection

--- a/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountAssets.svelte
@@ -14,19 +14,19 @@
 </script>
 
 <div
-    class="account-assets w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0 {$mobile
-        ? 'p-5'
-        : 'p-6'} {classes}"
+    class="w-full h-full flex flex-auto flex-col flex-shrink-0 {$mobile ? 'p-5' : 'p-6'} {classes}"
     style="--bottom-offset: {bottomOffset}"
 >
     <div class="flex relative">
-        <Text classes="text-left mr-2" type="h5">{localize('general.myAssets')}</Text>
+        <Text classes="text-left mr-2 mt-1 mb-3" type="h5">{localize('general.myAssets')}</Text>
         {#if isSelectedAccountSyncing && $mobile}
             <Spinner busy={true} classes="absolute right-0" />
         {/if}
     </div>
     <div
-        class="flex flex-auto flex-col h-0 -mr-2 pr-2 {scroll ? 'overflow-y-auto scroll-secondary' : ''}"
+        class="account-assets flex flex-auto flex-col h-0 -mr-2 pr-2 py-4 {scroll
+            ? 'overflow-y-auto scroll-secondary'
+            : ''}"
         use:scrollDetection
     >
         {#each $assets as asset}
@@ -39,6 +39,6 @@
 
 <style>
     .account-assets {
-        padding-bottom: var(--bottom-offset);
+        margin-bottom: var(--bottom-offset);
     }
 </style>

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -261,7 +261,7 @@
         <ActivityDetail onBackClick={handleBackClick} {...$selectedMessage} />
     {:else}
         <div
-            class="activity-wrapper flex-auto h-1 space-y-2.5 -mr-2 pr-2 pb-4 {scroll
+            class="flex-auto h-1 space-y-2.5 -mr-2 pr-2 {$mobile && 'activity-wrapper pb-4'} {scroll
                 ? 'overflow-y-auto scroll-secondary'
                 : ''}"
             style="--bottom-offset: {bottomOffset}"

--- a/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/AccountHistory.svelte
@@ -261,7 +261,7 @@
         <ActivityDetail onBackClick={handleBackClick} {...$selectedMessage} />
     {:else}
         <div
-            class="activity-wrapper flex-auto h-1 space-y-2.5 -mr-2 pr-2 {scroll
+            class="activity-wrapper flex-auto h-1 space-y-2.5 -mr-2 pr-2 pb-4 {scroll
                 ? 'overflow-y-auto scroll-secondary'
                 : ''}"
             style="--bottom-offset: {bottomOffset}"
@@ -288,6 +288,6 @@
 
 <style>
     .activity-wrapper {
-        padding-bottom: var(--bottom-offset);
+        margin-bottom: var(--bottom-offset);
     }
 </style>


### PR DESCRIPTION
## Summary

This PR fixes the issue that items of the asset list or transaction history are cut off through the bottom navigation.

## Changelog

- Adds a bottom offset calculation for the main views content area

## Relevant Issues

Closes #4207

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
