### PR TITLE
chore:  adds tab change between input fields for iOS

### DIFF
--- a/packages/shared/lib/keyboard.ts
+++ b/packages/shared/lib/keyboard.ts
@@ -1,0 +1,14 @@
+/**
+ * Tabs through form inputs via enter key
+ */
+export function tabFormWithEnterKey(event: KeyboardEvent, document: Document, formName: string): void {
+    if (event.key == 'Enter') {
+        const inputs = document.forms[formName].getElementsByTagName('input')
+        const active = document.activeElement
+        for (let index = 0; index < inputs.length; index++) {
+            if (active === inputs[index] && index < inputs.length) {
+                inputs[index + 1].focus()
+            }
+        }
+    }
+}

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePassword.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { Button, Checkbox, Password, Spinner, Text } from 'shared/components'
     import { mobile, isKeyboardOpened, getKeyboardTransitionSpeed } from '@lib/app'
+    import { tabFormWithEnterKey } from '@lib/keyboard'
     import { localize } from '@core/i18n'
     import passwordInfo from 'shared/lib/password'
     import { api, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
@@ -97,6 +98,10 @@
         }
     }
 
+    function onKeyPress(e) {
+        tabFormWithEnterKey(e, document, 'change-password')
+    }
+
     function reset() {
         currentPasswordError = ''
         newPasswordError = ''
@@ -108,7 +113,9 @@
 <!-- TODO: improve UX for mobile, 3 step screen -->
 <form
     id="form-change-password"
+    name="change-password"
     on:submit|preventDefault={changePassword}
+    on:keypress={onKeyPress}
     style="margin-top: {$mobile && $isKeyboardOpened
         ? '-25%'
         : '0px'}; transition: margin-top {getKeyboardTransitionSpeed($isKeyboardOpened) +

--- a/packages/shared/routes/setup/Password.svelte
+++ b/packages/shared/routes/setup/Password.svelte
@@ -8,6 +8,7 @@
         getKeyboardTransitionSpeed,
     } from 'shared/lib/app'
     import { showAppNotification } from 'shared/lib/notifications'
+    import { tabFormWithEnterKey } from '@lib/keyboard'
     import passwordInfo from 'shared/lib/password'
     import { asyncChangeStrongholdPassword, asyncSetStrongholdPassword, MAX_PASSWORD_LENGTH } from 'shared/lib/wallet'
     import zxcvbn from 'zxcvbn'
@@ -84,6 +85,10 @@
             return zxcvbn(limitedPassword)
         }
     } // zxcvbn lib recommends to not validate long passwords because of performance issues https://github.com/dropbox/zxcvbn#user-content-performance
+
+    function onKeyPress(e) {
+        tabFormWithEnterKey(e, document, 'set-password')
+    }
 </script>
 
 <OnboardingLayout onBackClick={handleBackClick} {busy}>
@@ -98,7 +103,12 @@
             'ms'} var(--transition-scroll)"
         bind:this={passwordContainer}
     >
-        <form on:submit|preventDefault={handleContinueClick} id="password-form">
+        <form
+            on:submit|preventDefault={handleContinueClick}
+            on:keypress={onKeyPress}
+            id="password-form"
+            name="set-password"
+        >
             <Text type="p" classes="mb-4" secondary>{locale('views.password.body1')}</Text>
             <Text type="p" classes="mb-10" secondary>{locale('views.password.body2')}</Text>
             <Password


### PR DESCRIPTION
## Summary

This PR adds the possibility for iOS to tab through the input fields of the password create and change forms via pressing enter.

## Changelog

```
- Adds a function to enable tabbing for form input fields via enter key
- Adds tab change with enter key for password creation form
- Adds tab change with enter key for password change form
```

## Relevant Issues

Closes #4472

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
