### PR TITLE
fix: qr scanner back button closes app

### DIFF
--- a/packages/shared/components/QRScanner.svelte
+++ b/packages/shared/components/QRScanner.svelte
@@ -1,9 +1,15 @@
 <script lang="typescript">
     import { Icon, Text } from 'shared/components'
     import { Locale } from '@core/i18n'
+    import { backButtonStore } from '@core/router'
     import { showCameraScanner, stopQRScanner } from 'shared/lib/device'
 
     export let locale: Locale
+
+    function onCloseButton() {
+        $backButtonStore?.pop()
+        stopQRScanner()
+    }
 </script>
 
 {#if $showCameraScanner}
@@ -17,7 +23,7 @@
             </div>
         </div>
         <button
-            on:click={stopQRScanner}
+            on:click={onCloseButton}
             class="flex justify-center items-center close absolute top-6 right-8 text-white bg-white rounded-full w-10 h-10"
             style="--tw-bg-opacity: 0.2"
         >

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
     import { localize } from '@core/i18n'
-    import { accountRouter } from '@core/router'
+    import { accountRouter, backButtonStore } from '@core/router'
     import { Unit } from '@iota/unit-converter'
     import { Address, Amount, Button, Dropdown, Icon, Illustration, Input, ProgressBar, Text } from 'shared/components'
     import {
@@ -20,7 +20,7 @@
         isFiatCurrency,
         parseCurrency,
     } from 'shared/lib/currency'
-    import { startQRScanner } from 'shared/lib/device'
+    import { startQRScanner, stopQRScanner } from 'shared/lib/device'
     import {
         displayNotificationForLedgerProfile,
         ledgerDeviceState,
@@ -431,16 +431,19 @@
 
     const onQRClick = (): void => {
         const onSuccess = (result: string) => {
+            $backButtonStore?.pop()
             selectedSendType = SEND_TYPE.EXTERNAL
             to = null
             address = result
         }
         const onError = (): void => {
+            $backButtonStore?.pop()
             showAppNotification({
                 type: 'error',
                 message: localize('error.global.generic'),
             })
         }
+        $backButtonStore?.add(stopQRScanner as () => Promise<void>)
         void startQRScanner(onSuccess, onError)
     }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue that causes the app to close when the back button is pressed while the QR scanner is open

## Changelog

```
- Added back button logic for QR scanner
```

## Relevant Issues

Closes #4490

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
