### PR TITLE
fix: pin code change issues on iOS

### DIFF
--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -14,6 +14,7 @@
     export let glimpse = false
     export let smaller = false
     export let error
+    export let onSubmit: () => void
 
     let inputs = new Array(PIN_LENGTH)
     $: {
@@ -91,7 +92,6 @@
      */
     function changeHandlerMobile(event: Event & InputEventInit, i: number): void {
         if (!event.isTrusted || !/^[0-9]$/.test(event.data)) {
-            inputs[i] = ''
             inputElements[i].focus()
             return
         }
@@ -132,6 +132,10 @@
         if (e.target === root) {
             selectFirstEmpty()
         }
+    }
+
+    export function blur(): void {
+        inputElements.forEach((input) => input.blur())
     }
 
     export function focus(): void {

--- a/packages/shared/components/inputs/Pin.svelte
+++ b/packages/shared/components/inputs/Pin.svelte
@@ -14,7 +14,6 @@
     export let glimpse = false
     export let smaller = false
     export let error
-    export let onSubmit: () => void
 
     let inputs = new Array(PIN_LENGTH)
     $: {

--- a/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
+++ b/packages/shared/routes/dashboard/settings/views/security/ChangePincode.svelte
@@ -17,6 +17,10 @@
     let pinCodeBusy = false
     let pinCodeMessage = ''
 
+    let currentPinInput: Pin
+    let newPinInput: Pin
+    let confirmedPinInput: Pin
+
     function changePincode() {
         if (currentPincode && newPincode && confirmedPincode) {
             reset()
@@ -34,6 +38,9 @@
                 pinCodeMessage = localize('general.pinCodeUpdating')
 
                 const _clear = (err?) => {
+                    currentPinInput.blur()
+                    newPinInput.blur()
+                    confirmedPinInput.blur()
                     setTimeout(() => {
                         pinCodeMessage = ''
                     }, 2000)
@@ -103,6 +110,7 @@
         smaller
         error={currentPincodeError}
         classes="mb-4"
+        bind:this={currentPinInput}
         bind:value={currentPincode}
         disabled={pinCodeBusy}
         on:submit={changePincode}
@@ -112,6 +120,7 @@
         smaller
         error={newPincodeError}
         classes="mb-4"
+        bind:this={newPinInput}
         bind:value={newPincode}
         disabled={pinCodeBusy}
         on:submit={changePincode}
@@ -121,6 +130,7 @@
         smaller
         error={confirmationPincodeError}
         classes="mb-4"
+        bind:this={confirmedPinInput}
         bind:value={confirmedPincode}
         disabled={pinCodeBusy}
         on:submit={changePincode}


### PR DESCRIPTION
## Summary

This PR removes the focus from all pin code fields after the pin has been changed to prevent further entry. This prevents strange input behaviour on iOS.

## Changelog

```
- Adds blur function to pin component
- Blurs pin code inputs after the pin code has been changed
```

## Relevant Issues

Closes #4473

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
