### PR TITLE
fix: QR background colour in dark theme

### DIFF
--- a/packages/shared/components/QR.svelte
+++ b/packages/shared/components/QR.svelte
@@ -9,7 +9,6 @@
     let qr
     let cells
 
-    $: darkModeEnabled = $appSettings.darkMode
     $: data, create()
 
     function create() {
@@ -32,7 +31,7 @@
                     <rect
                         height={1}
                         key={cellIndex}
-                        style="fill: {cell ? (darkModeEnabled ? '#ffffff' : '#000000') : 'none'};"
+                        style="fill: {cell ? '#000000' : 'none'};"
                         width={1}
                         x={cellIndex}
                         y={rowIndex}

--- a/packages/shared/routes/dashboard/wallet/views/Receive.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Receive.svelte
@@ -57,7 +57,9 @@
         </div>
     {:else}
         <div class="flex flex-auto items-center justify-center mb-4">
-            <QR size={qrSize} data={$selectedAccountStore.depositAddress} />
+            <div class="rounded-xl bg-white p-2">
+                <QR size={qrSize} data={$selectedAccountStore.depositAddress} />
+            </div>
         </div>
         <div class="mb-6">
             <Text secondary smaller classes="mb-1">


### PR DESCRIPTION
## Summary

It is not possible to scan the QR code with an Android device when the desktop app is in dark mode. This PR adds a white background.

## Changelog

```
- Adjust QR presentation in dark mode
```

## Testing

### Platforms

Tested on Mac OS, scanning with both iOS and Android.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

Scan the receive address QR code.

## Checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
