### PR TITLE
fix: set system language as initial language

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -121,7 +121,8 @@
         await pollMarketData()
         await pollNetworkStatus()
 
-        const initialLocale = $appRoute === AppRoute.Welcome ? null : $appSettings.language
+        const systemLanguage = await Platform.getLanguageCode()
+        const initialLocale = $appRoute === AppRoute.Welcome ? systemLanguage : $appSettings.language
         void setupI18n({ fallbackLocale: 'en', initialLocale })
     })
 

--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -122,7 +122,9 @@
         await pollNetworkStatus()
 
         const systemLanguage = await Platform.getLanguageCode()
-        const initialLocale = $appRoute === AppRoute.Welcome ? systemLanguage : $appSettings.language
+        let initialLocale = $appRoute === AppRoute.Welcome ? systemLanguage : $appSettings.language
+        // handle 'es' & 'pt' cases when we can't get the region code
+        initialLocale = initialLocale === 'es' ? 'es-ES' : initialLocale === 'pt' ? 'pt-PT' : initialLocale
         void setupI18n({ fallbackLocale: 'en', initialLocale })
     })
 

--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -109,8 +109,6 @@
         nativeSplash.hide()
     }
 
-    void setupI18n({ fallbackLocale: 'en', initialLocale: $appSettings.language })
-
     onMount(async () => {
         isAndroid.set((await Platform.getOS()) !== 'ios')
         // Display splash screen at least for 3 seconds
@@ -122,6 +120,9 @@
         await getVersionDetails()
         await pollMarketData()
         await pollNetworkStatus()
+
+        const initialLocale = $appRoute === AppRoute.Welcome ? null : $appSettings.language
+        void setupI18n({ fallbackLocale: 'en', initialLocale })
     })
 
     // TODO: Has to be enabled again when system notifications are implemented

--- a/packages/mobile/capacitor/capacitorApi.ts
+++ b/packages/mobile/capacitor/capacitorApi.ts
@@ -414,6 +414,11 @@ export const CapacitorApi: IPlatform = {
     hideKeyboard: async () => {
         await Keyboard.hide()
     },
+
+    getLanguageCode: async () => {
+        const { value } = await Device.getLanguageCode()
+        return value
+    },
 }
 
 window['__CAPACITOR__'] = CapacitorApi

--- a/packages/shared/lib/tests/mocks/platform.ts
+++ b/packages/shared/lib/tests/mocks/platform.ts
@@ -117,6 +117,9 @@ const Platform: IPlatform = {
     loadJsonFile(filepath: string): Promise<unknown> {
         return Promise.resolve({ filepath })
     },
+    getLanguageCode(): Promise<string> {
+        return Promise.resolve('')
+    },
 }
 
 window['__CAPACITOR__'] = Platform

--- a/packages/shared/lib/typings/platform.ts
+++ b/packages/shared/lib/typings/platform.ts
@@ -71,4 +71,5 @@ export interface IPlatform {
     setKeyboardStyle(style: KeyboardStyle): Promise<void>
     showKeyboard(): Promise<void>
     hideKeyboard(): Promise<void>
+    getLanguageCode(): Promise<string>
 }


### PR DESCRIPTION
## Summary

The App still uses english as initial language. This RP changes the initial selection to the system language. 

## Changelog

```
- Selects the navigator language when the app is started for the first time
```

## Relevant Issues

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
