### PR TITLE
enhancement: enables screen capturing for all views except the mnemonics

### DIFF
--- a/packages/mobile/capacitor.config.ts
+++ b/packages/mobile/capacitor.config.ts
@@ -15,7 +15,7 @@ const config: CapacitorConfig = {
     bundledWebRuntime: false,
     plugins: {
         PrivacyScreen: {
-            enable: true,
+            enable: false,
         },
         SplashScreen: {
             launchAutoHide: false,

--- a/packages/mobile/capacitor/capacitorApi.ts
+++ b/packages/mobile/capacitor/capacitorApi.ts
@@ -6,6 +6,7 @@ import { ActionSheet, ShowActionsOptions } from '@capacitor/action-sheet'
 import { Keyboard } from '@capacitor/keyboard'
 import { SplashScreen } from '@capacitor/splash-screen'
 import { Share } from '@capacitor/share'
+import { PrivacyScreen } from '@capacitor-community/privacy-screen'
 import { BarcodeManager } from './lib/barcodeManager'
 import { SecureFilesystemAccess } from 'capacitor-secure-filesystem-access'
 import { DeepLinkManager } from '../../mobile/capacitor/lib/deepLinkManager'
@@ -413,6 +414,14 @@ export const CapacitorApi: IPlatform = {
 
     hideKeyboard: async () => {
         await Keyboard.hide()
+    },
+
+    enablePrivacy: async () => {
+        await PrivacyScreen.enable()
+    },
+
+    disablePrivacy: async () => {
+        await PrivacyScreen.disable()
     },
 }
 

--- a/packages/shared/lib/tests/mocks/platform.ts
+++ b/packages/shared/lib/tests/mocks/platform.ts
@@ -117,6 +117,12 @@ const Platform: IPlatform = {
     loadJsonFile(filepath: string): Promise<unknown> {
         return Promise.resolve({ filepath })
     },
+    enablePrivacy(): Promise<void> {
+        return Promise.resolve(undefined)
+    },
+    disablePrivacy(): Promise<void> {
+        return Promise.resolve(undefined)
+    },
 }
 
 window['__CAPACITOR__'] = Platform

--- a/packages/shared/lib/typings/platform.ts
+++ b/packages/shared/lib/typings/platform.ts
@@ -71,4 +71,6 @@ export interface IPlatform {
     setKeyboardStyle(style: KeyboardStyle): Promise<void>
     showKeyboard(): Promise<void>
     hideKeyboard(): Promise<void>
+    enablePrivacy(): Promise<void>
+    disablePrivacy(): Promise<void>
 }

--- a/packages/shared/routes/setup/backup/views/RecoveryPhrase.svelte
+++ b/packages/shared/routes/setup/backup/views/RecoveryPhrase.svelte
@@ -1,8 +1,9 @@
 <script lang="typescript">
     import { Button, Icon, OnboardingLayout, RecoveryPhrase, Text } from 'shared/components'
     import { mobile } from 'shared/lib/app'
+    import { Platform } from 'shared/lib/platform'
     import { downloadRecoveryKit } from 'shared/lib/utils'
-    import { createEventDispatcher } from 'svelte'
+    import { createEventDispatcher, onDestroy, onMount } from 'svelte'
     import { Locale } from '@core/i18n'
 
     export let locale: Locale
@@ -26,6 +27,14 @@
     function handleDownloadClick() {
         downloadRecoveryKit()
     }
+
+    onMount(() => {
+        Platform.enablePrivacy()
+    })
+
+    onDestroy(() => {
+        Platform.disablePrivacy()
+    })
 </script>
 
 <OnboardingLayout onBackClick={handleBackClick} {busy} reverseContent={$mobile}>

--- a/packages/shared/routes/setup/backup/views/VerifyRecoveryPhrase.svelte
+++ b/packages/shared/routes/setup/backup/views/VerifyRecoveryPhrase.svelte
@@ -1,7 +1,8 @@
 <script lang="typescript">
-    import { createEventDispatcher, onMount } from 'svelte'
+    import { createEventDispatcher, onMount, onDestroy } from 'svelte'
     import { Button, Icon, OnboardingLayout, RecoveryPhrase, Text, Spinner } from 'shared/components'
     import { mobile } from 'shared/lib/app'
+    import { Platform } from 'shared/lib/platform'
     import { english } from 'shared/lib/wordlists/english'
     import { Locale } from '@core/i18n'
 
@@ -67,7 +68,12 @@
     }
 
     onMount(() => {
+        Platform.enablePrivacy()
         fillChoices()
+    })
+
+    onDestroy(() => {
+        Platform.disablePrivacy()
     })
 </script>
 

--- a/packages/shared/routes/setup/import/views/TextImport.svelte
+++ b/packages/shared/routes/setup/import/views/TextImport.svelte
@@ -1,7 +1,8 @@
 <script lang="typescript">
     import { Animation, Button, ImportTextfield, OnboardingLayout, Spinner, Text } from 'shared/components'
     import { mobile, isKeyboardOpened, keyboardHeight, getKeyboardTransitionSpeed } from 'shared/lib/app'
-    import { createEventDispatcher, getContext } from 'svelte'
+    import { Platform } from 'shared/lib/platform'
+    import { createEventDispatcher, getContext, onMount, onDestroy } from 'svelte'
     import { Locale } from '@core/i18n'
     import { ImportRouter } from '@core/router'
 
@@ -31,6 +32,14 @@
             dispatch('previous')
         }
     }
+
+    onMount(() => {
+        Platform.enablePrivacy()
+    })
+
+    onDestroy(() => {
+        Platform.disablePrivacy()
+    })
 </script>
 
 <OnboardingLayout onBackClick={handleBackClick}>


### PR DESCRIPTION
## Summary

This PR disables the screen capturing just for views which display a recovery phrase or a seed.

## Changelog

```
- Adds privacy enbale/disable function to capacitorAPI
- Enables the privacy for RecoveryPhrase, VerifyRecoveryPhrase and TextImport (onboarding)
```

## Relevant Issues

Closes #4491

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [x] iOS
  - [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
