### PR TITLE
Fixed wrong links for FAQ and documentation sites

### DIFF
--- a/packages/shared/lib/core/router/enums/routes.ts
+++ b/packages/shared/lib/core/router/enums/routes.ts
@@ -114,9 +114,9 @@ export enum HelpAndInfo {
 }
 
 export enum ExternalRoute {
-    Documentation = 'https://wiki.iota.org/learn/wallets/firefly/general',
+    Documentation = 'https://wiki.iota.org/wallets/firefly/general',
     Discord = 'https://discord.iota.org',
-    FAQ = 'https://wiki.iota.org/learn/wallets/firefly/faq-and-troubleshooting',
+    FAQ = 'https://wiki.iota.org/wallets/firefly/faq-and-troubleshooting',
     IssueReport = 'https://github.com/iotaledger/firefly/issues/new/choose',
 }
 


### PR DESCRIPTION
## Summary

> Adapted the link to FAQ and documentation 
...

## Changelog

Changed the links from 
https://wiki.iota.org/learn/wallets/firefly/faq-and-troubleshooting --> 
https://wiki.iota.org/wallets/firefly/faq-and-troubleshooting

## Relevant Issues

> Please list any related issues using [development keywords]().
fixes #4561 
[FAQ - Link is broken](https://github.com/iotaledger/firefly/compare/develop...hadze:firefly:hadze-patch-wronglink?expand=1#top)

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
