### PR TITLE
feat: parse deep link

### DIFF
--- a/packages/shared/lib/address.ts
+++ b/packages/shared/lib/address.ts
@@ -1,2 +1,2 @@
 export const isValidAddressAndPrefix = (address: string, expectedAddressPrefix: string): boolean =>
-    !new RegExp(`^${expectedAddressPrefix}1[02-9ac-hj-np-z]{59}$`).test(address)
+    new RegExp(`^${expectedAddressPrefix}1[02-9ac-hj-np-z]{59}$`).test(address)

--- a/packages/shared/lib/app.ts
+++ b/packages/shared/lib/app.ts
@@ -52,6 +52,8 @@ export const sendParams = writable<SendParams>({
     address: '',
     message: '',
     isInternal: false,
+    receiverAddress: '',
+    chainId: '',
 })
 export const clearSendParams = (isInternal = false): void =>
     sendParams.set({

--- a/packages/shared/lib/common/deep-links/enums/wallet-context.enum.ts
+++ b/packages/shared/lib/common/deep-links/enums/wallet-context.enum.ts
@@ -3,6 +3,7 @@
  */
 export enum WalletOperation {
     Send = 'send',
+    SwapOut = 'swapOut',
 }
 
 /**
@@ -11,4 +12,12 @@ export enum WalletOperation {
 export enum SendOperationParameter {
     Amount = 'amount',
     Unit = 'unit',
+}
+
+/**
+ * The query parameters available exclusively for a bridge operation
+ */
+export enum SwapOperationParameter {
+    ChainId = 'chainId',
+    ReceiverAddress = 'receiverAddress',
 }

--- a/packages/shared/lib/common/deep-links/types/deep-link-request.type.ts
+++ b/packages/shared/lib/common/deep-links/types/deep-link-request.type.ts
@@ -1,6 +1,11 @@
 import type { NotificationData } from '../../../typings/notification'
 
-import type { DeepLinkContext, SendOperationParameters, WalletOperation } from '@common/deep-links'
+import type {
+    DeepLinkContext,
+    SendOperationParameters,
+    SwapOutOperationParameters,
+    WalletOperation,
+} from '@common/deep-links'
 
 /**
  * A union type of all deep link contexts' operations.
@@ -10,7 +15,7 @@ export type DeepLinkOperation = WalletOperation
 /**
  * A union type of all deep link operations' parameters.
  */
-export type DeepLinkParameters = void | SendOperationParameters
+export type DeepLinkParameters = void | SendOperationParameters | SwapOutOperationParameters
 
 /**
  * The content of a deep link request.

--- a/packages/shared/lib/common/deep-links/types/wallet-context.type.ts
+++ b/packages/shared/lib/common/deep-links/types/wallet-context.type.ts
@@ -9,3 +9,11 @@ export type SendOperationParameters = {
     unit: Unit
     message: string
 }
+
+/**
+ * The parameters of a bridge operation.
+ */
+export type SwapOutOperationParameters = SendOperationParameters & {
+    chainId: string
+    receiverAddress: string
+}

--- a/packages/shared/lib/common/deep-links/wallet-context-handler.ts
+++ b/packages/shared/lib/common/deep-links/wallet-context-handler.ts
@@ -41,7 +41,7 @@ export const parseWalletDeepLinkRequest = (url: URL, expectedAddressPrefix: stri
     }
 
     const address = pathnameParts[1] ?? ''
-    if (isValidAddress(address, expectedAddressPrefix)) {
+    if (!isValidAddress(address, expectedAddressPrefix)) {
         return addError({
             time: Date.now(),
             type: 'deepLink',
@@ -174,11 +174,9 @@ const parseSwapOutOperation = (
 }
 
 const isValidAddress = (address: string, expectedAddressPrefix: string): boolean => {
-    if (!address) {
-        return false
-    } else if (isValidAddressAndPrefix(address, expectedAddressPrefix)) {
-        return false
-    } else {
+    if (address && isValidAddressAndPrefix(address, expectedAddressPrefix)) {
         return true
+    } else {
+        return false
     }
 }

--- a/packages/shared/lib/common/deep-links/wallet-context-handler.ts
+++ b/packages/shared/lib/common/deep-links/wallet-context-handler.ts
@@ -5,8 +5,18 @@ import { localize } from '@core/i18n'
 import { isValidAddressAndPrefix } from '../../address'
 import { addError } from '../../errors'
 
-import { DeepLinkContext, SendOperationParameter, WalletOperation } from '@common/deep-links/enums'
-import { DeepLinkRequest, SendOperationParameters } from '@common/deep-links/types'
+import {
+    DeepLinkContext,
+    SendOperationParameter,
+    SwapOperationParameter,
+    WalletOperation,
+} from '@common/deep-links/enums'
+import {
+    DeepLinkParameters,
+    DeepLinkRequest,
+    SendOperationParameters,
+    SwapOutOperationParameters,
+} from '@common/deep-links/types'
 import { formatNumber } from '@lib/currency'
 import { getNumberOfDecimalPlaces } from '@lib/utils'
 
@@ -21,7 +31,7 @@ import { getNumberOfDecimalPlaces } from '@lib/utils'
  * @return {void | DeepLinkRequest} The formatted content of a deep link request within the wallet context.
  */
 export const parseWalletDeepLinkRequest = (url: URL, expectedAddressPrefix: string): void | DeepLinkRequest => {
-    let parameters
+    let parameters: DeepLinkParameters
 
     // Remove any leading and trailing slashes
     const pathnameParts = url.pathname.replace(/^\/+|\/+$/g, '').split('/')
@@ -30,9 +40,21 @@ export const parseWalletDeepLinkRequest = (url: URL, expectedAddressPrefix: stri
         return addError({ time: Date.now(), type: 'deepLink', message: 'No operation specified in the url' })
     }
 
+    const address = pathnameParts[1] ?? ''
+    if (isValidAddress(address, expectedAddressPrefix)) {
+        return addError({
+            time: Date.now(),
+            type: 'deepLink',
+            message: `Address or prefix is not valid for ${address}`,
+        })
+    }
+
     switch (pathnameParts[0]) {
         case WalletOperation.Send:
-            parameters = parseSendOperation(pathnameParts[1] ?? '', url.searchParams, expectedAddressPrefix)
+            parameters = parseSendOperation(address, url.searchParams)
+            break
+        case WalletOperation.SwapOut:
+            parameters = parseSwapOutOperation(address, url.searchParams)
             break
         default:
             return addError({
@@ -64,26 +86,10 @@ export const parseWalletDeepLinkRequest = (url: URL, expectedAddressPrefix: stri
  *
  * @return {void | SendOperationParameters} The formatted parameters for the send operation.
  */
-const parseSendOperation = (
-    address: string,
-    searchParams: URLSearchParams,
-    expectedAddressPrefix: string
-): void | SendOperationParameters => {
+const parseSendOperation = (address: string, searchParams: URLSearchParams): void | SendOperationParameters => {
     let numDecimalPlaces = 0
     let parsedAmount: number | undefined
     let parsedUnit: Unit | undefined
-
-    // Check address exists and is valid this is not optional.
-    if (!address) {
-        return addError({ time: Date.now(), type: 'deepLink', message: 'No address specified in the url path' })
-    }
-    if (isValidAddressAndPrefix(address, expectedAddressPrefix)) {
-        return addError({
-            time: Date.now(),
-            type: 'deepLink',
-            message: `Address or prefix is not valid for ${address}`,
-        })
-    }
 
     // Optional parameter: amount
     // Check if exists and is valid or does not exist
@@ -125,5 +131,54 @@ const parseSendOperation = (
         amount: formatNumber(Math.abs(parsedAmount), numDecimalPlaces, numDecimalPlaces),
         unit: parsedUnit,
         message: '',
+    }
+}
+
+const parseSwapOutOperation = (
+    waspAddress: string,
+    searchParams: URLSearchParams
+): void | SwapOutOperationParameters => {
+    const sendParams = parseSendOperation(waspAddress, searchParams)
+    if (!sendParams) {
+        // Error handling is done in parseSendOperation already
+        return
+    }
+
+    const chainId = searchParams.get(SwapOperationParameter.ChainId)
+    if (!chainId) {
+        return addError({
+            time: Date.now(),
+            type: 'deepLink',
+            message: 'The chain ID is missing',
+        })
+    } else {
+        // TODO: validation logic
+    }
+
+    const receiverAddress = searchParams.get(SwapOperationParameter.ReceiverAddress)
+    if (!receiverAddress) {
+        return addError({
+            time: Date.now(),
+            type: 'deepLink',
+            message: 'The receiver address is missing',
+        })
+    } else {
+        // TODO: validation logic
+    }
+
+    return {
+        ...sendParams,
+        chainId,
+        receiverAddress,
+    }
+}
+
+const isValidAddress = (address: string, expectedAddressPrefix: string): boolean => {
+    if (!address) {
+        return false
+    } else if (isValidAddressAndPrefix(address, expectedAddressPrefix)) {
+        return false
+    } else {
+        return true
     }
 }

--- a/packages/shared/lib/typings/sendParams.ts
+++ b/packages/shared/lib/typings/sendParams.ts
@@ -1,3 +1,4 @@
+import { SwapOutOperationParameters } from '@common/deep-links'
 import { Unit } from '@iota/unit-converter'
 import { LabeledWalletAccount } from './wallet'
 
@@ -8,4 +9,6 @@ export interface SendParams {
     message: string
     isInternal: boolean
     toWalletAccount?: LabeledWalletAccount
+    receiverAddress?: string
+    chainId?: string
 }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1208,7 +1208,6 @@
         "total": "Total: {balance}",
         "openExplorer": "View in Explorer",
         "activityDetails": "Transaction details",
-        "index": "Index",
         "chainId": "Chain ID",
         "bridgeToAddress": "Bridge to address"
     },

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -262,12 +262,7 @@
             if ($accounts && $accounts.length > 0) {
                 const addressPrefix = $accounts[0].depositAddress.split('1')[0]
                 const parsedDeepLink = parseDeepLinkRequest(addressPrefix, data)
-                if (
-                    parsedDeepLink &&
-                    parsedDeepLink.context === DeepLinkContext.Wallet &&
-                    parsedDeepLink.operation === WalletOperation.Send &&
-                    parsedDeepLink.parameters
-                ) {
+                if (parsedDeepLink && parsedDeepLink.context === DeepLinkContext.Wallet && parsedDeepLink.parameters) {
                     _redirect(DashboardRoute.Wallet)
                     sendParams.set({
                         ...parsedDeepLink.parameters,

--- a/packages/shared/routes/dashboard/Dashboard.svelte
+++ b/packages/shared/routes/dashboard/Dashboard.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { DeepLinkContext, isDeepLinkRequestActive, parseDeepLinkRequest, WalletOperation } from '@common/deep-links'
+    import { DeepLinkContext, isDeepLinkRequestActive, parseDeepLinkRequest } from '@common/deep-links'
     import { Locale } from '@core/i18n'
     import {
         AccountRoute,

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -558,7 +558,6 @@
                         classes="mb-6"
                     />
                     {#if showBridgeFields}
-                        <KeyValueBox value={'swapOut'} key={localize('general.index')} />
                         <KeyValueBox bind:value={$sendParams.chainId} key={localize('general.chainId')} />
                         <KeyValueBox
                             bind:value={$sendParams.receiverAddress}

--- a/packages/shared/routes/dashboard/wallet/views/Send.svelte
+++ b/packages/shared/routes/dashboard/wallet/views/Send.svelte
@@ -2,8 +2,26 @@
     import { getContext, onDestroy, onMount } from 'svelte'
     import { get, Readable } from 'svelte/store'
     import { Unit } from '@iota/unit-converter'
-    import { Address, Amount, Button, Dropdown, Icon, KeyValueBox, ProgressBar, Text } from 'shared/components'
-    import { clearSendParams, mobile, sendParams } from 'shared/lib/app'
+    import {
+        Address,
+        Amount,
+        Button,
+        Dropdown,
+        Icon,
+        Illustration,
+        Input,
+        KeyValueBox,
+        ProgressBar,
+        Text,
+    } from 'shared/components'
+    import {
+        clearSendParams,
+        keyboardHeight,
+        isKeyboardOpened,
+        mobile,
+        sendParams,
+        getKeyboardTransitionSpeed,
+    } from 'shared/lib/app'
     import {
         convertFromFiat,
         convertToFiat,
@@ -76,6 +94,7 @@
     $: amount, (amountError = '')
     $: to, (toError = '')
     $: address, (addressError = '')
+    $: showBridgeFields = Boolean($sendParams.receiverAddress && $sendParams.chainId)
 
     const transferSteps: {
         [key in TransferProgressEventType]: {
@@ -538,9 +557,14 @@
                         autofocus={selectedSendType === SEND_TYPE.INTERNAL && $liveAccounts.length === 2}
                         classes="mb-6"
                     />
-                    <KeyValueBox value={'swapOut'} key={localize('general.index')} />
-                    <KeyValueBox bind:value={chainId} key={localize('general.chainId')} />
-                    <KeyValueBox bind:value={bridgeAddress} key={localize('general.bridgeToAddress')} />
+                    {#if showBridgeFields}
+                        <KeyValueBox value={'swapOut'} key={localize('general.index')} />
+                        <KeyValueBox bind:value={$sendParams.chainId} key={localize('general.chainId')} />
+                        <KeyValueBox
+                            bind:value={$sendParams.receiverAddress}
+                            key={localize('general.bridgeToAddress')}
+                        />
+                    {/if}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Implemented deep linking parsing for `swapOut`.
...

## Changelog

```
- Added swapOut operation parser
- Disable index, receiverAddress and chainId field when regular tx
```

## Relevant Issues

closes: #4540
closes: #4542
...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

Use the following deep link:

iota://wallet/swapOut/atoi1qz0mvjzjfwt5wcy8j8daw6avh67z77kquwkwzr5fvuu6pfzpjqgz7cptqex/?amount=1000&chainId=4002&receiverAddress=0xF65e3cCbe04D4784EDa9CC4a33F84A6162aC9EB6
...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
