### PR TITLE
fix: fix default expiration time

### DIFF
--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -77,7 +77,7 @@
     function getInitialExpirationDate(): ExpirationTime {
         if (expirationDate) {
             return ExpirationTime.Custom
-        } else if (storageDeposit) {
+        } else if (storageDeposit && !giftStorageDeposit) {
             return ExpirationTime.OneDay
         } else {
             return ExpirationTime.None

--- a/packages/shared/components/popups/SendConfirmationPopup.svelte
+++ b/packages/shared/components/popups/SendConfirmationPopup.svelte
@@ -45,7 +45,7 @@
     let error: BaseError
 
     const rawAmount = generateRawAmount(amount, unit, asset.metadata)
-    const initialExpirationDate = getInitialExpirationDate()
+    let initialExpirationDate
 
     $: recipientAddress = recipient.type === 'account' ? recipient.account.depositAddress : recipient.address
     $: isInternal = recipient.type === 'account'
@@ -99,6 +99,9 @@
             getStorageDepositFromOutput(preparedOutput)
         storageDeposit = _storageDeposit
         giftedStorageDeposit = _giftedStorageDeposit
+        if (!initialExpirationDate) {
+            initialExpirationDate = getInitialExpirationDate()
+        }
     }
 
     async function validateAndSendOutput(): Promise<void> {
@@ -166,7 +169,7 @@
                 />
             </KeyValueBox>
         {/if}
-        {#if storageDeposit !== undefined}
+        {#if initialExpirationDate !== undefined}
             <KeyValueBox keyText={localize('general.expirationTime')}>
                 <ExpirationTimePicker
                     slot="value"


### PR DESCRIPTION
## Summary

Fixes the issue that on a transaction with required storage deposit the default expiration time isnt used

## Changelog

```
- fix default expiration time
```

## Relevant Issues
Closes #4595 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
