### PR TITLE
fix: initiate Ledger Nano polling earlier in the onboarding flow

### DIFF
--- a/packages/shared/routes/onboarding/views/ledger-setup/views/ConnectLedgerView.svelte
+++ b/packages/shared/routes/onboarding/views/ledger-setup/views/ConnectLedgerView.svelte
@@ -1,15 +1,8 @@
 <script lang="typescript">
-    import { onMount } from 'svelte'
     import { LedgerAnimation, Button, Icon, Link, OnboardingLayout, Spinner, Text } from 'shared/components'
     import { localize } from '@core/i18n'
     import { ledgerSetupRouter } from '@core/router'
-    import {
-        LedgerConnectionState,
-        ledgerConnectionState,
-        stopPollingLedgerNanoStatus,
-        pollLedgerNanoStatus,
-        displayNotificationForLedgerProfile,
-    } from '@core/ledger'
+    import { LedgerConnectionState, ledgerConnectionState, displayNotificationForLedgerProfile } from '@core/ledger'
     import { openPopup } from '@lib/popup'
     import { initialiseFirstShimmerClaimingAccount, onboardingProfile, ProfileSetupType } from '@contexts/onboarding'
 
@@ -59,13 +52,8 @@
     }
 
     function onBackClick(): void {
-        stopPollingLedgerNanoStatus()
         $ledgerSetupRouter.previous()
     }
-
-    onMount(() => {
-        pollLedgerNanoStatus()
-    })
 </script>
 
 <OnboardingLayout {onBackClick}>

--- a/packages/shared/routes/onboarding/views/storage-protection-setup/views/SetupPinProtectionView.svelte
+++ b/packages/shared/routes/onboarding/views/storage-protection-setup/views/SetupPinProtectionView.svelte
@@ -3,14 +3,17 @@
     import {
         initialiseFirstShimmerClaimingAccount,
         initialisePincodeManager,
+        isOnboardingLedgerProfile,
         onboardingProfile,
         ProfileSetupType,
     } from '@contexts/onboarding'
     import { mobile } from '@core/app'
     import { localize } from '@core/i18n'
+    import { pollLedgerNanoStatus, stopPollingLedgerNanoStatus } from '@core/ledger'
     import { ProfileType } from '@core/profile'
     import { storageProtectionSetupRouter } from '@core/router'
     import { validatePinFormat } from '@lib/utils'
+    import { onMount } from 'svelte'
 
     export let busy = false
 
@@ -34,10 +37,29 @@
     }
 
     function onBackClick(): void {
+        if ($isOnboardingLedgerProfile) {
+            /**
+             * CAUTION: We must make sure to stop polling if the user
+             * goes back as we've started it when this view is mounted.
+             */
+            stopPollingLedgerNanoStatus()
+        }
         $storageProtectionSetupRouter.previous()
     }
 
     async function onSetPinClick(): Promise<void> {
+        resetPinInputErrors()
+        if (arePinInputsValid && arePinInputsMatching) {
+            await handleSetPin()
+        }
+    }
+
+    function resetPinInputErrors(): void {
+        setPinInputError = ''
+        confirmPinInputError = ''
+    }
+
+    async function handleSetPin(): Promise<void> {
         await initialisePincodeManager(setPinInput)
 
         const canInitialiseFirstShimmerClaimingAccount =
@@ -51,17 +73,19 @@
         $storageProtectionSetupRouter.next()
     }
 
-    async function handleSetPinSubmit(): Promise<void> {
-        resetPinInputErrors()
-        if (arePinInputsValid && arePinInputsMatching) {
-            await onSetPinClick()
+    onMount(() => {
+        /**
+         * NOTE: We begin Ledger Nano status polling
+         * here because it's the closest common view between
+         * all Ledger flows that comes before the status
+         * check page, improving the UX as the status will
+         * already have been set by that point rather than setting
+         * it on mount.
+         */
+        if ($isOnboardingLedgerProfile) {
+            pollLedgerNanoStatus()
         }
-    }
-
-    function resetPinInputErrors(): void {
-        setPinInputError = ''
-        confirmPinInputError = ''
-    }
+    })
 </script>
 
 <OnboardingLayout {onBackClick} {busy}>
@@ -77,7 +101,7 @@
                 >{localize('views.onboarding.storageProtectionSetup.setupPinProtection.body2')}</Text
             >
         </div>
-        <form id="setup-pin" class="flex flex-col" on:submit={handleSetPinSubmit}>
+        <form id="setup-pin" class="flex flex-col" on:submit={onSetPinClick}>
             <PinInput
                 bind:value={setPinInput}
                 glimpse
@@ -87,7 +111,7 @@
                 error={setPinInputError}
                 label={localize('actions.setPin')}
                 on:filled={confirmPinInputElement.focus}
-                on:submit={handleSetPinSubmit}
+                on:submit={onSetPinClick}
             />
             <PinInput
                 bind:value={confirmPinInput}
@@ -98,7 +122,7 @@
                 label={localize('actions.confirmPin')}
                 bind:this={confirmPinInputElement}
                 on:filled={submitButtonElement.resetAndFocus}
-                on:submit={handleSetPinSubmit}
+                on:submit={onSetPinClick}
             />
         </form>
     </div>


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

To improve UX, it is better to initiate the Ledger Nano status polling a few pages earlier before it's actually checked in the connection view. 

The PIN setup page was chosen as that was the common view between all Ledger flows that was closest to connection check view. If the views were chosen where the user decides between software vs Ledger or mnemonic vs Stronghold vs Ledger, then there would have been duplicate logic to initiate and clear any status polling.

## Changelog

```
- Remove Ledger Nano status polling from connection check view
- Add Ledger Nano status polling to
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Closes #4551 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Test going back and forth, between Ledger onboarding flows. Should always have immediately green checks on the connection view (so long as testing device / sim is _actually_ connected).

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation
