### PR TITLE
fix: only show delete wallet when available

### DIFF
--- a/packages/shared/components/modals/AccountActionsMenu.svelte
+++ b/packages/shared/components/modals/AccountActionsMenu.svelte
@@ -9,15 +9,11 @@
 
     export let modal: Modal
 
-    const showDelete = $selectedAccount.meta.index === $activeAccounts?.length - 1 && $visibleActiveAccounts?.length > 1
+    const showDeleteAccount =
+        $selectedAccount.meta.index === $activeAccounts?.length - 1 && $visibleActiveAccounts?.length > 1
 
     const handleCustomiseAccountClick = () => {
         openPopup({ type: 'manageAccount' })
-        modal.close()
-    }
-
-    function handleExportTransactionHistoryClick() {
-        openPopup({ type: 'exportTransactionHistory', props: { account: selectedAccount }, hideClose: false })
         modal.close()
     }
 
@@ -47,19 +43,13 @@
             first
         />
         <MenuItem
-            icon={Icon.Export}
-            title={localize('actions.exportTransactionHistory')}
-            onClick={handleExportTransactionHistoryClick}
-            disabled
-        />
-        <MenuItem
             icon={Icon.Customize}
             title={localize('actions.customizeAcount')}
             onClick={handleCustomiseAccountClick}
         />
         <ToggleHiddenAccountMenuItem onClick={() => modal.close()} last />
         <HR />
-        {#if showDelete}
+        {#if showDeleteAccount}
             <MenuItem
                 icon={Icon.Delete}
                 title={localize('actions.deleteAccount')}

--- a/packages/shared/components/modals/AccountActionsMenu.svelte
+++ b/packages/shared/components/modals/AccountActionsMenu.svelte
@@ -9,8 +9,7 @@
 
     export let modal: Modal
 
-    const hideDelete =
-        $selectedAccount.meta.index !== $activeAccounts?.length - 1 && $visibleActiveAccounts?.length <= 1
+    const showDelete = $selectedAccount.meta.index === $activeAccounts?.length - 1 && $visibleActiveAccounts?.length > 1
 
     const handleCustomiseAccountClick = () => {
         openPopup({ type: 'manageAccount' })
@@ -60,7 +59,7 @@
         />
         <ToggleHiddenAccountMenuItem onClick={() => modal.close()} last />
         <HR />
-        {#if !hideDelete}
+        {#if showDelete}
             <MenuItem
                 icon={Icon.Delete}
                 title={localize('actions.deleteAccount')}

--- a/packages/shared/components/modals/AccountActionsMenu.svelte
+++ b/packages/shared/components/modals/AccountActionsMenu.svelte
@@ -9,7 +9,8 @@
 
     export let modal: Modal
 
-    const shouldDisableDelete = $selectedAccount.meta.index !== $activeAccounts?.length - 1
+    const hideDelete =
+        $selectedAccount.meta.index !== $activeAccounts?.length - 1 && $visibleActiveAccounts?.length <= 1
 
     const handleCustomiseAccountClick = () => {
         openPopup({ type: 'manageAccount' })
@@ -31,7 +32,6 @@
             type: 'deleteAccount',
             props: {
                 account: selectedAccount,
-                hasMultipleAccounts: $visibleActiveAccounts?.length > 1,
                 deleteAccount,
             },
         })
@@ -60,13 +60,14 @@
         />
         <ToggleHiddenAccountMenuItem onClick={() => modal.close()} last />
         <HR />
-        <MenuItem
-            icon={Icon.Delete}
-            title={localize('actions.deleteAccount')}
-            onClick={handleDeleteAccountClick}
-            first
-            last
-            disabled={shouldDisableDelete}
-        />
+        {#if !hideDelete}
+            <MenuItem
+                icon={Icon.Delete}
+                title={localize('actions.deleteAccount')}
+                onClick={handleDeleteAccountClick}
+                first
+                last
+            />
+        {/if}
     </div>
 </Modal>

--- a/packages/shared/components/popups/DeleteAccount.svelte
+++ b/packages/shared/components/popups/DeleteAccount.svelte
@@ -8,19 +8,16 @@
     import { BaseError } from '@core/error'
 
     export let deleteAccount: (id: string) => Promise<void> = async () => {}
-    export let hasMultipleAccounts: boolean
 
     let password: string
     let error: BaseError
     let isBusy = false
 
     async function handleDeleteClick(): Promise<void> {
-        if (hasMultipleAccounts) {
-            error = null
-            isBusy = true
-            await deleteStrongholdAccount(password)
-            isBusy = false
-        }
+        error = null
+        isBusy = true
+        await deleteStrongholdAccount(password)
+        isBusy = false
     }
 
     async function deleteStrongholdAccount(password: string): Promise<void> {
@@ -42,50 +39,44 @@
 
 <div class="mb-5">
     <Text type="h4">
-        {localize(`popups.deleteAccount.${hasMultipleAccounts ? 'title' : 'errorTitle'}`, {
+        {localize('popups.deleteAccount.title', {
             values: { name: $selectedAccount?.getAlias() },
         })}
     </Text>
 </div>
 <div class="flex w-full flex-row flex-wrap">
-    {#if hasMultipleAccounts}
-        <Text type="p" secondary classes="mb-5">{localize('popups.deleteAccount.body')}</Text>
-        {#if $isSoftwareProfile}
-            <Text type="p" secondary classes="mb-3">{localize('popups.deleteAccount.typePassword')}</Text>
-            <PasswordInput
-                classes="w-full mb-3"
-                bind:value={password}
-                showRevealToggle
-                placeholder={localize('general.password')}
-                autofocus
-                submitHandler={handleDeleteClick}
-                disabled={isBusy}
-            />
-        {/if}
-        {#if error}
-            <Error error={error.message} />
-        {/if}
-    {:else}
-        <Error error={localize('popups.deleteAccount.errorBody1')} />
+    <Text type="p" secondary classes="mb-5">{localize('popups.deleteAccount.body')}</Text>
+    {#if $isSoftwareProfile}
+        <Text type="p" secondary classes="mb-3">{localize('popups.deleteAccount.typePassword')}</Text>
+        <PasswordInput
+            classes="w-full mb-3"
+            bind:value={password}
+            showRevealToggle
+            placeholder={localize('general.password')}
+            autofocus
+            submitHandler={handleDeleteClick}
+            disabled={isBusy}
+        />
+    {/if}
+    {#if error}
+        <Error error={error.message} />
     {/if}
     <div class="flex flex-row w-full space-x-4 justify-center mt-5">
         <Button secondary classes="w-1/2" onClick={handleCancelClick} disabled={isBusy}>
-            {localize(hasMultipleAccounts ? 'actions.cancel' : 'actions.close')}
+            {localize('actions.cancel')}
         </Button>
-        {#if hasMultipleAccounts}
-            <Button
-                warning
-                classes="w-1/2"
-                onClick={handleDeleteClick}
-                type="submit"
-                disabled={(!password && $isSoftwareProfile) || isBusy}
-            >
-                {#if isBusy}
-                    <Spinner busy classes="justify-center" />
-                {:else}
-                    {localize('actions.deleteAccount')}
-                {/if}
-            </Button>
-        {/if}
+        <Button
+            warning
+            classes="w-1/2"
+            onClick={handleDeleteClick}
+            type="submit"
+            disabled={(!password && $isSoftwareProfile) || isBusy}
+        >
+            {#if isBusy}
+                <Spinner busy classes="justify-center" />
+            {:else}
+                {localize('actions.deleteAccount')}
+            {/if}
+        </Button>
     </div>
 </div>

--- a/packages/shared/lib/core/profile-manager/actions/deleteAccount.ts
+++ b/packages/shared/lib/core/profile-manager/actions/deleteAccount.ts
@@ -1,14 +1,8 @@
-import { get } from 'svelte/store'
 import { setSelectedAccount } from '@core/account'
 import { removeAccountFromActiveAccounts, visibleActiveAccounts } from '@core/profile'
-import {
-    CannotRemoveAccountError,
-    RemoveAccountWithBalanceError,
-    removeLatestAccount,
-    RemoveNotLastAccountError,
-} from '@core/profile-manager'
+import { CannotRemoveAccountError, removeLatestAccount, RemoveNotLastAccountError } from '@core/profile-manager'
 import { resetWalletRoute } from '@core/router'
-import { parseCurrency } from '@lib/currency'
+import { get } from 'svelte/store'
 
 export async function deleteAccount(id: string): Promise<void> {
     const accountToBeDeleted = get(visibleActiveAccounts).find((account) => account?.id === id)
@@ -16,10 +10,6 @@ export async function deleteAccount(id: string): Promise<void> {
 
     if (accountToBeDeleted !== accounts[accounts.length - 1]) {
         throw new RemoveNotLastAccountError()
-    }
-
-    if (parseCurrency(accountToBeDeleted?.balances?.baseCoin?.total) > 0) {
-        throw new RemoveAccountWithBalanceError()
     }
 
     try {


### PR DESCRIPTION
## Summary
This PR hides the delete wallet button when it is not available

## Changelog
```
- Only show delete wallet button when it is available
- Removes hasMultipleAccounts props in DeleteAccount.svelte and the code around it
```

## Relevant Issues
closes #4462 

## Testing
### Platforms
- __Desktop__
  - [x] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
