### PR TITLE
fix: enforce one claiming transaction per account

### DIFF
--- a/packages/shared/routes/onboarding/views/shimmer-claiming/views/ClaimRewardsView.svelte
+++ b/packages/shared/routes/onboarding/views/shimmer-claiming/views/ClaimRewardsView.svelte
@@ -33,7 +33,8 @@
         (shimmerClaimingAccount) => shimmerClaimingAccount.state === ShimmerClaimingAccountState.Claiming
     )
 
-    $: shouldSearchForRewardsButtonBeEnabled = !isSearchingForRewards && !isClaimingRewards
+    $: shouldSearchForRewardsButtonBeEnabled =
+        !isSearchingForRewards && !isClaimingRewards && !hasUserClaimedRewards(shimmerClaimingAccounts)
     $: shouldClaimRewardsButtonBeEnabled =
         canUserClaimRewards(shimmerClaimingAccounts) && !isSearchingForRewards && !isClaimingRewards
     $: shouldShowContinueButton =


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

Currently the UI allows the user to continue making claimed transactions if they searched after making a previous one. The library logic does not support it, so we must enforce it also on the UI level.

## Changelog

```
- Only allow searching if no claiming transactions have been made
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Closes #4664

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Make a claiming transaction (either single account or multiple) and try to search afterwards.

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [x] I have made corresponding changes to the documentation