### PR TITLE
fix: fix claim status for native tokens

### DIFF
--- a/packages/shared/lib/core/profile-manager/actions/events-handlers/handleSpentOutputEvent.ts
+++ b/packages/shared/lib/core/profile-manager/actions/events-handlers/handleSpentOutputEvent.ts
@@ -22,15 +22,16 @@ export async function handleSpentOutputEventInternal(
     payload: ISpentOutputEventPayload
 ): Promise<void> {
     await syncBalance(accountIndex.toString())
-    const transactionId = payload?.output?.metadata?.transactionId
-    const activity = get(allAccountActivities)?.[Number(accountIndex.toString())]?.find(
-        (_activity) => _activity.id === transactionId
+    const outputId = payload?.output?.outputId
+    const activity = get(allAccountActivities)?.[accountIndex]?.find(
+        (_activity) =>
+            _activity.data.type === ActivityType.Transaction &&
+            _activity.data.asyncStatus === ActivityAsyncStatus.Unclaimed &&
+            _activity.data.outputId === outputId
     )
 
-    if (
-        activity?.data.type === ActivityType.Transaction &&
-        activity?.data.asyncStatus === ActivityAsyncStatus.Unclaimed
-    ) {
+    if (activity) {
+        const transactionId = payload?.output?.metadata?.transactionId
         updateActivityDataByTransactionId(accountIndex.toString(), transactionId, {
             type: ActivityType.Transaction,
             isClaimed: true,


### PR DESCRIPTION
## Summary
The problem with the claim bug:
if i send some native tokens, it always uses an output which bundles all of my native tokens (https://explorer.shimmer.network/testnet/transaction/0xc30bb63eea931c9eb9538b8f9a7e2dc58c1d20ee6cc55246fc84acf0f538217e). Then we get the output for the recipient (outputA) and the remainder back to me which contains all remaining native tokens (outputB). 
When i send another portion of native tokens, i get the event that outputB  is spent. Because we matched the spent event with the activity by transactionid we think that it is claimed. Now i match the spent event with the activity by outputId 

## Changelog

```
- fix claim status for native tokens
```

## Relevant Issues

Closes #4721 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
