### PR TITLE
fix: NumberInput

### DIFF
--- a/packages/shared/components/inputs/NumberInput.svelte
+++ b/packages/shared/components/inputs/NumberInput.svelte
@@ -1,24 +1,39 @@
 <script lang="typescript">
-    import { TextInput } from 'shared/components'
     import { localize } from '@core/i18n'
+    import Input from './Input.svelte'
+    import { FontWeight, TextPropTypes, TextType } from 'shared/components/Text.svelte'
 
     export let inputElement: HTMLInputElement
-
-    export let disabled = false
-    export let hasFocus = false
+    export let disabled: boolean = false
+    export let hasFocus: boolean = false
+    export let isInteger: boolean = false
     export let value: string
-    export let isInteger: boolean
+    export let error: string
+
+    // Text Props
+    export let type = TextType.p
+    export let fontWeight = FontWeight.normal
+    export let fontSize = 'sm'
+    export let lineHeight = '140'
+    export let alignment: 'left' | 'right' | 'center' | 'justify' = 'left'
+
+    let textProps: TextPropTypes
+    $: textProps = { type, fontSize, lineHeight, fontWeight }
 </script>
 
-<TextInput
+<Input
     bind:inputElement
     bind:value
     bind:hasFocus
-    {disabled}
-    placeholder={localize('general.amount')}
+    type="number"
     float={!isInteger}
     integer={isInteger}
+    placeholder={localize('general.amount')}
+    {disabled}
+    {error}
+    {textProps}
+    {alignment}
     {...$$restProps}
 >
     <slot />
-</TextInput>
+</Input>

--- a/packages/shared/components/inputs/TextInput.svelte
+++ b/packages/shared/components/inputs/TextInput.svelte
@@ -1,35 +1,23 @@
 <script lang="typescript">
-    import { FontWeight, TextType } from 'shared/components/Text.svelte'
     import Input from './Input.svelte'
+    import { FontWeight, TextPropTypes, TextType } from 'shared/components/Text.svelte'
 
     export let inputElement: HTMLInputElement
-
+    export let hasFocus: boolean = false
     export let value: string
-    export let hasFocus: boolean
-    export let error = ''
+    export let error: string
 
     // Text Props
     export let type = TextType.p
+    export let fontWeight = FontWeight.normal
     export let fontSize = 'sm'
     export let lineHeight = '140'
-    export let fontWeight = FontWeight.normal
     export let alignment: 'left' | 'right' | 'center' | 'justify' = 'left'
+
+    let textProps: TextPropTypes
+    $: textProps = { type, fontSize, lineHeight, fontWeight }
 </script>
 
-<Input
-    bind:inputElement
-    bind:value
-    bind:hasFocus
-    type="text"
-    {error}
-    textProps={{
-        type,
-        fontSize,
-        lineHeight,
-        fontWeight,
-    }}
-    {alignment}
-    {...$$restProps}
->
+<Input bind:inputElement bind:value bind:hasFocus type="text" {error} {textProps} {alignment} {...$$restProps}>
     <slot />
 </Input>


### PR DESCRIPTION
## Summary
Number input needs to have the native HTML `type=number`, otherwise it leads to problems in parsing numbers as it is happening with big.js
So in this PR I've changed the component to not be a wrapper for TextInput, but have the same customizability as it

## Changelog
```markdown
- Changes from `TextInput` to `Input` in `NumberInput`
- Adds text props in `NumberInput`
- Improves code readability in `TextInput`
```

## Relevant Issues
closes #4769 

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions
- Try to type `.` in AssetAmountInput
- If the app is still interactable so the fix has worked

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
