### PR TITLE
fix: button debounce

### DIFF
--- a/packages/shared/components/Button.svelte
+++ b/packages/shared/components/Button.svelte
@@ -2,7 +2,7 @@
     import { ButtonSize, ButtonVariant, HTMLButtonType, Icon, Spinner } from 'shared/components'
     import { onMount } from 'svelte'
     import { appSettings } from '@core/app'
-    import { bindEvents } from '@lib/utils'
+    import { bindEvents, debounce } from '@lib/utils'
     import { Icon as IconEnum } from '@lib/auxiliary/icon'
     import type { Event } from '@lib/typings/events'
 
@@ -32,6 +32,7 @@
     export let events: Event<unknown>[] = []
 
     export let onClick: () => unknown = () => {}
+    export let isDebounceEnabled: boolean = true
 
     export function resetAndFocus(): void {
         if (disabled) {
@@ -68,7 +69,7 @@
     class:is-busy={isBusy}
     style:--border-width={outline ? '1px' : '0px'}
     use:bindEvents={events}
-    on:click|stopPropagation={onClick}
+    on:click|stopPropagation={isDebounceEnabled ? debounce(onClick) : onClick}
     bind:this={buttonElement}
 >
     {#if isBusy}


### PR DESCRIPTION
## Summary
Adds button click debounce as default to prevent breaking the app/flow because of clicking the button multiple times in a short period of time

## Changelog
```
- Adds isDebounceEnabled boolean prop in Button.svelte
- Imports debounce function from `@lib/utils` in Button.svelte
- Adds ternary in `on:click` to debounce `onClick` function callback
```

## Relevant Issues
closes #4319 

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
