### PR TITLE
ui: dashboard header setup

### DIFF
--- a/packages/mobile/components/AccountSwitcher.svelte
+++ b/packages/mobile/components/AccountSwitcher.svelte
@@ -1,0 +1,15 @@
+<script lang="typescript">
+    import { Icon as IconEnum } from '@auxiliary/icon'
+    import { selectedAccount } from '@core/account'
+    import { Icon } from 'shared/components'
+    import { AccountLabel } from 'shared/components/atoms/'
+
+    function onClick(): void {}
+</script>
+
+<button on:click={onClick} class="flex flex-row justify-center items-center space-x-2">
+    <AccountLabel account={$selectedAccount} />
+    <div class="rotate-180">
+        <Icon height="18" width="18" icon={IconEnum.ChevronDown} classes="text-gray-500 dark:text-white" />
+    </div>
+</button>

--- a/packages/mobile/components/TopBar.svelte
+++ b/packages/mobile/components/TopBar.svelte
@@ -3,14 +3,20 @@
     import features from '../features/features'
 </script>
 
-<div class="flex flex-row justify-between">
-    {#if features?.wallet?.profileActions?.enabled}
-        <ProfileActionsButton />
-    {/if}
-    {#if features?.wallet?.accountSwitcher?.enabled}
-        <AccountSwitcher />
-    {/if}
-    {#if features?.wallet?.accountActions?.enabled}
-        <AccountActionsButton />
-    {/if}
+<div class="grid grid-cols-4 h-10">
+    <div class="col-span-1">
+        {#if features?.wallet?.profileActions?.enabled}
+            <ProfileActionsButton />
+        {/if}
+    </div>
+    <div class="flex justify-center col-span-2 content-center">
+        {#if features?.wallet?.accountSwitcher?.enabled}
+            <AccountSwitcher />
+        {/if}
+    </div>
+    <div class="flex justify-end col-span-1">
+        {#if features?.wallet?.accountActions?.enabled}
+            <AccountActionsButton />
+        {/if}
+    </div>
 </div>

--- a/packages/mobile/components/TopBar.svelte
+++ b/packages/mobile/components/TopBar.svelte
@@ -1,0 +1,9 @@
+<script lang="typescript">
+    import { AccountSwitcher, AccountActionsButton, ProfileActionsButton } from './'
+</script>
+
+<div class="flex flex-row justify-between">
+    <ProfileActionsButton />
+    <AccountSwitcher />
+    <AccountActionsButton />
+</div>

--- a/packages/mobile/components/TopBar.svelte
+++ b/packages/mobile/components/TopBar.svelte
@@ -4,13 +4,13 @@
 </script>
 
 <div class="flex flex-row justify-between">
-    {#if features?.profileActions?.enabled}
+    {#if features?.wallet?.profileActions?.enabled}
         <ProfileActionsButton />
     {/if}
-    {#if features?.accountSwitcher?.enabled}
+    {#if features?.wallet?.accountSwitcher?.enabled}
         <AccountSwitcher />
     {/if}
-    {#if features?.accountActions?.enabled}
+    {#if features?.wallet?.accountActions?.enabled}
         <AccountActionsButton />
     {/if}
 </div>

--- a/packages/mobile/components/TopBar.svelte
+++ b/packages/mobile/components/TopBar.svelte
@@ -1,9 +1,16 @@
 <script lang="typescript">
     import { AccountSwitcher, AccountActionsButton, ProfileActionsButton } from './'
+    import features from '../features/features'
 </script>
 
 <div class="flex flex-row justify-between">
-    <ProfileActionsButton />
-    <AccountSwitcher />
-    <AccountActionsButton />
+    {#if features?.profileActions?.enabled}
+        <ProfileActionsButton />
+    {/if}
+    {#if features?.accountSwitcher?.enabled}
+        <AccountSwitcher />
+    {/if}
+    {#if features?.accountActions?.enabled}
+        <AccountActionsButton />
+    {/if}
 </div>

--- a/packages/mobile/components/buttons/AccountActionsButton.svelte
+++ b/packages/mobile/components/buttons/AccountActionsButton.svelte
@@ -2,4 +2,4 @@
     import { MeatballMenuButton } from 'shared/components'
 </script>
 
-<MeatballMenuButton classes="items-center text-gray-500" />
+<MeatballMenuButton onClick={() => {}} classes="items-center text-gray-500" />

--- a/packages/mobile/components/buttons/AccountActionsButton.svelte
+++ b/packages/mobile/components/buttons/AccountActionsButton.svelte
@@ -1,0 +1,5 @@
+<script lang="typescript">
+    import { MeatballMenuButton } from 'shared/components'
+</script>
+
+<MeatballMenuButton classes="items-center text-gray-500" />

--- a/packages/mobile/components/buttons/ProfileActionsButton.svelte
+++ b/packages/mobile/components/buttons/ProfileActionsButton.svelte
@@ -1,0 +1,12 @@
+<script>
+    import { activeProfile } from '@core/profile'
+    import { getInitials } from '@lib/helpers'
+
+    // @TODO fix the linting error that profileInitial isn't used
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    $: profileInitial = getInitials($activeProfile?.name, 1)
+</script>
+
+<button class="w-10 h-10 relative flex items-center justify-center rounded-full bg-blue-500 leading-100">
+    <span class="text-12 text-center text-white uppercase">{profileInitial}</span>
+</button>

--- a/packages/mobile/components/buttons/ProfileActionsButton.svelte
+++ b/packages/mobile/components/buttons/ProfileActionsButton.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
     import { activeProfile } from '@core/profile'
     import { getInitials } from '@lib/helpers'
 

--- a/packages/mobile/components/buttons/index.js
+++ b/packages/mobile/components/buttons/index.js
@@ -1,1 +1,3 @@
+export { default as AccountActionsButton } from './AccountActionsButton.svelte'
+export { default as ProfileActionsButton } from './ProfileActionsButton.svelte'
 export { default as ProfileButton } from './ProfileButton.svelte'

--- a/packages/mobile/components/index.js
+++ b/packages/mobile/components/index.js
@@ -1,5 +1,7 @@
 export * from './buttons'
 
+export { default as AccountSwitcher } from './AccountSwitcher.svelte'
 export { default as OnboardingLayout } from './OnboardingLayout.svelte'
 export { default as RecoveryPhrase } from './RecoveryPhrase.svelte'
+export { default as TopBar } from './TopBar.svelte'
 export { default as Route } from './Route.svelte'

--- a/packages/mobile/features/features.ts
+++ b/packages/mobile/features/features.ts
@@ -119,6 +119,18 @@ const features = {
     collectibles: {
         enabled: false,
     },
+    balance: {
+        enabled: false,
+    },
+    profileActions: {
+        enabled: false,
+    },
+    accountSwitcher: {
+        enabled: false,
+    },
+    accountActions: {
+        enabled: false,
+    },
 }
 
 export default features

--- a/packages/mobile/features/features.ts
+++ b/packages/mobile/features/features.ts
@@ -92,7 +92,7 @@ const features = {
             enabled: false,
         },
         sendAndReceive: {
-            enabled: true,
+            enabled: false,
         },
         assets: {
             enabled: false,

--- a/packages/mobile/features/features.ts
+++ b/packages/mobile/features/features.ts
@@ -92,7 +92,7 @@ const features = {
             enabled: false,
         },
         sendAndReceive: {
-            enabled: false,
+            enabled: true,
         },
         assets: {
             enabled: false,

--- a/packages/mobile/features/features.ts
+++ b/packages/mobile/features/features.ts
@@ -88,9 +88,6 @@ const features = {
     },
     wallet: {
         enabled: false,
-        balance: {
-            enabled: false,
-        },
         profileActions: {
             enabled: false,
         },

--- a/packages/mobile/features/features.ts
+++ b/packages/mobile/features/features.ts
@@ -88,7 +88,16 @@ const features = {
     },
     wallet: {
         enabled: false,
-        accountSummary: {
+        balance: {
+            enabled: false,
+        },
+        profileActions: {
+            enabled: false,
+        },
+        accountSwitcher: {
+            enabled: false,
+        },
+        accountActions: {
             enabled: false,
         },
         sendAndReceive: {
@@ -117,18 +126,6 @@ const features = {
         enabled: false,
     },
     collectibles: {
-        enabled: false,
-    },
-    balance: {
-        enabled: false,
-    },
-    profileActions: {
-        enabled: false,
-    },
-    accountSwitcher: {
-        enabled: false,
-    },
-    accountActions: {
         enabled: false,
     },
 }

--- a/packages/mobile/routes/dashboard/DashboardRouter.svelte
+++ b/packages/mobile/routes/dashboard/DashboardRouter.svelte
@@ -16,14 +16,12 @@
     <div class="flex flex-col w-screen h-screen bg-gray-50 dark:bg-gray-900">
         <div class="px-5 py-6">
             <TopBar />
-            {#if features?.wallet?.balance?.enabled}
-                <div class="flex justify-center w-full mt-5">
-                    <TogglableAmountLabel
-                        amount={$selectedAccount.balances?.baseCoin?.available}
-                        tokenMetadata={BASE_TOKEN[$activeProfile?.networkProtocol]}
-                    />
-                </div>
-            {/if}
+            <div class="flex justify-center w-full mt-5">
+                <TogglableAmountLabel
+                    amount={$selectedAccount.balances?.baseCoin?.available}
+                    tokenMetadata={BASE_TOKEN[$activeProfile?.networkProtocol]}
+                />
+            </div>
             {#if features?.wallet?.sendAndReceive?.enabled}
                 <div class="flex flex-row items-center justify-center w-full space-x-2 mt-8">
                     <Button classes="w-1/2 h-10">

--- a/packages/mobile/routes/dashboard/DashboardRouter.svelte
+++ b/packages/mobile/routes/dashboard/DashboardRouter.svelte
@@ -16,7 +16,7 @@
     <div class="flex flex-col w-screen h-screen bg-gray-50 dark:bg-gray-900">
         <div class="px-5 py-6">
             <TopBar />
-            {#if features?.balance?.enabled}
+            {#if features?.wallet?.balance?.enabled}
                 <div class="flex justify-center w-full mt-5">
                     <TogglableAmountLabel
                         amount={$selectedAccount.balances?.baseCoin?.available}

--- a/packages/mobile/routes/dashboard/DashboardRouter.svelte
+++ b/packages/mobile/routes/dashboard/DashboardRouter.svelte
@@ -16,12 +16,14 @@
     <div class="flex flex-col w-screen h-screen bg-gray-50 dark:bg-gray-900">
         <div class="px-5 py-6">
             <TopBar />
-            <div class="flex justify-center w-full mt-5">
-                <TogglableAmountLabel
-                    amount={$selectedAccount.balances?.baseCoin?.available}
-                    tokenMetadata={BASE_TOKEN[$activeProfile?.networkProtocol]}
-                />
-            </div>
+            {#if features?.balance?.enabled}
+                <div class="flex justify-center w-full mt-5">
+                    <TogglableAmountLabel
+                        amount={$selectedAccount.balances?.baseCoin?.available}
+                        tokenMetadata={BASE_TOKEN[$activeProfile?.networkProtocol]}
+                    />
+                </div>
+            {/if}
             {#if features?.wallet?.sendAndReceive?.enabled}
                 <div class="flex flex-row items-center justify-center w-full space-x-2 mt-8">
                     <Button classes="w-1/2 h-10">

--- a/packages/mobile/routes/dashboard/DashboardRouter.svelte
+++ b/packages/mobile/routes/dashboard/DashboardRouter.svelte
@@ -1,14 +1,38 @@
 <script lang="typescript">
+    import { TopBar } from '../../components'
     import { selectedAccount } from '@core/account'
+    import { localize } from '@core/i18n'
+    import { BASE_TOKEN } from '@core/network'
+    import { activeProfile } from '@core/profile'
+    import features from '../../features/features'
     import { activeWalletTab, WALLET_TAB_COMPONENT } from '../../lib/contexts/wallet'
+    import { Button, TogglableAmountLabel } from 'shared/components'
     import { TabNavigator } from './wallet/tabs'
 
     $: activeWalletTabComponent = WALLET_TAB_COMPONENT[$activeWalletTab]
 </script>
 
 {#if $selectedAccount}
-    <div class="flex flex-col w-screen h-screen bg-white dark:bg-gray-800">
-        <div class="w-full h-18">BALANCE PLACEHOLDER</div>
+    <div class="flex flex-col w-screen h-screen bg-gray-50 dark:bg-gray-900">
+        <div class="px-5 py-6">
+            <TopBar />
+            <div class="flex justify-center w-full mt-5">
+                <TogglableAmountLabel
+                    amount={$selectedAccount.balances?.baseCoin?.available}
+                    tokenMetadata={BASE_TOKEN[$activeProfile?.networkProtocol]}
+                />
+            </div>
+            {#if features?.wallet?.sendAndReceive?.enabled}
+                <div class="flex flex-row items-center justify-center w-full space-x-2 mt-8">
+                    <Button classes="w-1/2 h-10">
+                        {localize('actions.send')}
+                    </Button>
+                    <Button classes="w-1/2 h-10">
+                        {localize('actions.receive')}
+                    </Button>
+                </div>
+            {/if}
+        </div>
         {#if activeWalletTabComponent}
             <div class="relative flex flex-col flex-auto w-full">
                 <div class="flex-auto">

--- a/packages/shared/components/atoms/buttons/AccountActionsButton.svelte
+++ b/packages/shared/components/atoms/buttons/AccountActionsButton.svelte
@@ -4,5 +4,5 @@
     let modal: Modal
 </script>
 
-<MeatballMenuButton onClick={() => {}} includeBackground />
+<MeatballMenuButton onClick={modal?.toggle} includeBackground />
 <AccountActionsMenu bind:modal />

--- a/packages/shared/components/atoms/buttons/AccountActionsButton.svelte
+++ b/packages/shared/components/atoms/buttons/AccountActionsButton.svelte
@@ -4,5 +4,5 @@
     let modal: Modal
 </script>
 
-<MeatballMenuButton onClick={modal?.toggle} includeBackground />
+<MeatballMenuButton onClick={() => {}} includeBackground />
 <AccountActionsMenu bind:modal />


### PR DESCRIPTION
## Summary

This PR initializes the dashboard header

## Changelog

```
- Adds a header section inside the dashboard
- Adds a top bar with buttons for the profile menu, account actions and account switcher to the dashboard header
- Adds a balance display to the dashboard header
- Adds send and receive buttons to the dahsboard header
```

## Relevant Issues

Closes #4934 
Closes #4935 
Closes #4936 
Closes #4937 
Closes #4938

## Testing
In order to test, you have to:

- in `packages/desktop/index.js` replace `import App from './App.svelte'` with `import App from '../mobile/App.svelte'`
- in `packages/shared/lib/core/profile/actions/active-profile/login.ts` replace `import { loginRouter } from '@core/router'` with `import { loginRouter } from '../../../../../../mobile/lib/core/router'`. 

Activate features in './packages/mobile/features/features.ts':
- balance
- profileActions
- accountSwitcher
- accountActions

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [x] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
