### PR TITLE
feat: add mobile tokens list

### DIFF
--- a/packages/mobile/components/AssetList.svelte
+++ b/packages/mobile/components/AssetList.svelte
@@ -1,0 +1,35 @@
+<script lang="typescript">
+    import { localize } from '@core/i18n'
+    import { IAccountAssets, IAsset } from '@core/wallet'
+    import VirtualList from '@sveltejs/svelte-virtual-list'
+    import { AssetTile, Text } from 'shared/components'
+
+    export let assets: IAccountAssets
+
+    let assetList: IAsset[]
+    $: assets, (assetList = getAssetList())
+
+    function getAssetList(): IAsset[] {
+        const list = []
+
+        if (assets?.baseCoin) {
+            list.push(assets.baseCoin)
+        }
+        list.push(...assets?.nativeTokens)
+        return list
+    }
+</script>
+
+{#if assets}
+    <div class="asset-list h-full flex flex-auto flex-col flex-grow flex-shrink-0">
+        {#if assetList.length > 0}
+            <VirtualList items={assetList} let:item>
+                <AssetTile classes="mb-2" onClick={() => {}} asset={item} />
+            </VirtualList>
+        {:else}
+            <div class="h-full flex flex-col items-center justify-center text-center">
+                <Text secondary>{localize('general.noAssets')}</Text>
+            </div>
+        {/if}
+    </div>
+{/if}

--- a/packages/mobile/components/TabPane.svelte
+++ b/packages/mobile/components/TabPane.svelte
@@ -1,0 +1,22 @@
+<script lang="typescript">
+    import { appSettings } from '@core/app'
+
+    let darkModeEnabled
+    $: darkModeEnabled = $appSettings.darkMode
+</script>
+
+<tab-pane
+    class:darkmode={darkModeEnabled}
+    class="w-full overflow-y-auto flex flex-auto h-1 p-5 pb-0 bg-white dark:bg-gray-800 rounded-t-2xl"
+>
+    <slot />
+</tab-pane>
+
+<style type="text/scss">
+    tab-pane {
+        box-shadow: 0px 4px 4px rgb(0 0 0 / 25%), 0px 2px 12px rgb(0 25 66 / 10%);
+        &.darkmode {
+            box-shadow: 0px 4px 4px rgb(0 0 0 / 25%), 0px 2px 12px rgb(0 25 66 / 20%);
+        }
+    }
+</style>

--- a/packages/mobile/components/index.js
+++ b/packages/mobile/components/index.js
@@ -1,5 +1,7 @@
-export * from './buttons'
-
+export { default as AssetList } from './AssetList.svelte'
 export { default as OnboardingLayout } from './OnboardingLayout.svelte'
 export { default as RecoveryPhrase } from './RecoveryPhrase.svelte'
 export { default as Route } from './Route.svelte'
+export { default as TabPane } from './TabPane.svelte'
+
+export * from './buttons'

--- a/packages/mobile/features/features.ts
+++ b/packages/mobile/features/features.ts
@@ -108,7 +108,7 @@ const features = {
         },
     },
     tokens: {
-        enabled: false,
+        enabled: true,
     },
     activity: {
         enabled: false,

--- a/packages/mobile/routes/dashboard/DashboardRouter.svelte
+++ b/packages/mobile/routes/dashboard/DashboardRouter.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { selectedAccount } from '@core/account'
+    import { TabPane } from '../../../mobile/components'
     import { activeWalletTab, WALLET_TAB_COMPONENT } from '../../lib/contexts/wallet'
     import { TabNavigator } from './wallet/tabs'
 
@@ -11,9 +12,9 @@
         <div class="w-full h-18">BALANCE PLACEHOLDER</div>
         {#if activeWalletTabComponent}
             <div class="relative flex flex-col flex-auto w-full">
-                <div class="flex-auto">
+                <TabPane>
                     <svelte:component this={WALLET_TAB_COMPONENT[$activeWalletTab]} />
-                </div>
+                </TabPane>
                 <TabNavigator />
             </div>
         {/if}

--- a/packages/mobile/routes/dashboard/wallet/tabs/TokensTab.svelte
+++ b/packages/mobile/routes/dashboard/wallet/tabs/TokensTab.svelte
@@ -1,1 +1,6 @@
-<h1>TokensTab</h1>
+<script lang="typescript">
+    import { selectedAccountAssets } from '@core/wallet'
+    import { AssetList } from '../../../../../mobile/components'
+</script>
+
+<AssetList assets={$selectedAccountAssets} />


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

This PR adds the token list tab to mobile and enables th feature
Filtering is not yet added, neither for hidden assets because the functionality is not yet added to mobile, this will display always all assets.

## Changelog

```
feat: add mobile tokens list
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Close #4940

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

In order to test, you have to:

- in `packages/desktop/index.js` replace `import App from './App.svelte'` with `import App from '../mobile/App.svelte'`
- in `packages/shared/lib/core/profile/actions/active-profile/login.ts` replace `import { loginRouter } from '@core/router'` with `import { loginRouter } from '../../../../../../mobile/lib/core/router'`. We have to refactor a bit the shared core modules to welcome mobile, in the meantime, we teak

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
