### PR TITLE
fix: add default date to expiration date picker

### DIFF
--- a/packages/shared/components/inputs/ExpirationDateTimePicker.svelte
+++ b/packages/shared/components/inputs/ExpirationDateTimePicker.svelte
@@ -2,10 +2,10 @@
     import { createEventDispatcher } from 'svelte'
     import { DateTimePicker } from 'shared/components'
     import { localize } from '@core/i18n'
-    import { isValidExpirationDateTime } from '@core/utils'
+    import { isValidExpirationDateTime, MILLISECONDS_PER_SECOND, SECONDS_PER_MINUTE } from '@core/utils'
     import { showAppNotification } from '@auxiliary/notification'
 
-    export let value: Date = new Date()
+    export let value: Date = new Date(Date.now() + 5 * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND)
 
     const dispatch = createEventDispatcher()
 

--- a/packages/shared/components/inputs/ExpirationDateTimePicker.svelte
+++ b/packages/shared/components/inputs/ExpirationDateTimePicker.svelte
@@ -5,7 +5,7 @@
     import { isValidExpirationDateTime } from '@core/utils'
     import { showAppNotification } from '@auxiliary/notification'
 
-    export let value: Date
+    export let value: Date = new Date()
 
     const dispatch = createEventDispatcher()
 


### PR DESCRIPTION
## Summary

ExpirationDatePicker now defaults to the current date

## Changelog

```
- add default value to ExpirationDatePicker
```

## Relevant Issues

Closes #5139 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
