### PR TITLE
fix: fix send on token-info-popup

### DIFF
--- a/packages/shared/components/popups/TokenInformationPopup.svelte
+++ b/packages/shared/components/popups/TokenInformationPopup.svelte
@@ -3,11 +3,12 @@
     import {
         TokenStandard,
         IAsset,
-        setNewTransactionDetails,
+        updateNewTransactionDetails,
         unverifyAsset,
         verifyAsset,
         NotVerifiedStatus,
         VerifiedStatus,
+        NewTransactionType,
     } from '@core/wallet'
     import { openPopup, updatePopupProps } from '@auxiliary/popup'
     import { AssetIcon, Button, Text, TextHint, AssetActionsButton, KeyValueBox, FontWeight } from 'shared/components'
@@ -44,7 +45,7 @@
     }
 
     function onSendClick(): void {
-        setNewTransactionDetails({ asset })
+        updateNewTransactionDetails({ type: NewTransactionType.TokenTransfer, assetId: asset.id })
         openPopup({
             type: 'sendForm',
             overflow: true,


### PR DESCRIPTION
## Summary

This PR fixes the "Send"-button click on TokenInformationPopup , such that it opens the Asset SendForm


## Changelog

```
- open Asset SendForm with the selected asset, if the users clicks on AssetInformationPopup on "Send"
```

## Relevant Issues
Closes #5291

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
