### PR TITLE
fix: NetworkInput initial value given by network address

### DIFF
--- a/packages/shared/components/inputs/NetworkInput.svelte
+++ b/packages/shared/components/inputs/NetworkInput.svelte
@@ -16,7 +16,8 @@
 
     $: networkOptions = showLayer2 ? getLayer2NetworkOptions() : [LAYER_1_NETWORK_OPTION]
 
-    let selected: IOption = LAYER_1_NETWORK_OPTION
+    let selected: IOption =
+        getLayer2NetworkOptions().find((option) => option.value === networkAddress) ?? LAYER_1_NETWORK_OPTION
     $: if (!showLayer2) {
         selected = LAYER_1_NETWORK_OPTION
     }

--- a/packages/shared/lib/core/utils/crypto/utils/validateEthereumAddress.ts
+++ b/packages/shared/lib/core/utils/crypto/utils/validateEthereumAddress.ts
@@ -8,6 +8,7 @@ import { KECCAK_HASH_SIZE } from '../constants'
 import { validateBech32Address } from './validateBech32Address'
 import { Layer1RecipientError } from '@core/layer-2/errors'
 import { InvalidAddressError } from '@auxiliary/deep-link'
+import { localize } from '@core/i18n'
 
 export function validateEthereumAddress(address: string): void {
     throwIfBech32Address(address)
@@ -45,7 +46,7 @@ function throwIfBech32Address(address: string): void {
         validateBech32Address(get(networkHrp), address)
         throw new Layer1RecipientError()
     } catch (err) {
-        if (err === new Layer1RecipientError()) {
+        if (err.message === localize('error.layer2.layer1Recipient')) {
             throw err
         }
     }


### PR DESCRIPTION
## Summary
Fixes the destination network selection when going backwards in send flow

## Changelog

```
- Changes initial value of `selected` in NetworkInput
```

## Relevant Issues
closes #5275 

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
