### PR TITLE
fix: network input validation

### DIFF
--- a/packages/shared/components/inputs/NetworkInput.svelte
+++ b/packages/shared/components/inputs/NetworkInput.svelte
@@ -44,7 +44,9 @@
 
     export function validate(): Promise<void> {
         try {
-            validateBech32Address(addressPrefix, networkAddress)
+            if (networkAddress !== networkAddresses[DestinationNetwork.Shimmer]) {
+                validateBech32Address(addressPrefix, networkAddress)
+            }
             return Promise.resolve()
         } catch (err) {
             error = err?.message ?? err


### PR DESCRIPTION
## Summary
Adds condition to only validate network input address if it is not layer1 address

## Relevant Issues
closes #5311 

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
