### PR TITLE
fix: custom network for l2 destination

### DIFF
--- a/packages/shared/lib/core/layer-2/constants/network-address.constant.ts
+++ b/packages/shared/lib/core/layer-2/constants/network-address.constant.ts
@@ -10,4 +10,7 @@ export const NETWORK_ADDRESS: Readonly<{ [key in NetworkType]?: { [key in Destin
         [DestinationNetwork.Shimmer]: '-',
         [DestinationNetwork.ShimmerTestnetEvm]: 'rms1pzw5y4e4y6gzkytvjp0ukgjgs37vd33uvnju9tuf6rrztnnw4tj7crw72ar',
     },
+    [NetworkType.PrivateNet]: {
+        [DestinationNetwork.Shimmer]: '-',
+    },
 }


### PR DESCRIPTION
## Summary

Adds the mainnet configuration to the network selector for private networks

...

## Changelog

```
- Added DestinationNetwork.Shimmer to private network addresses.
```

## Relevant Issues
closes: #5300 

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
