### PR TITLE
enhancement: reset router on tab change

### DIFF
--- a/packages/desktop/views/dashboard/Sidebar.svelte
+++ b/packages/desktop/views/dashboard/Sidebar.svelte
@@ -6,7 +6,14 @@
     import { appVersionDetails, mobile } from '@core/app/stores'
     import { getInitials, isRecentDate } from '@core/utils'
     import { activeProfile } from '@core/profile/stores'
-    import { DashboardRoute, dashboardRouter, settingsRoute, SettingsRoute, settingsRouter } from '@core/router'
+    import {
+        collectiblesRouter,
+        DashboardRoute,
+        dashboardRouter,
+        settingsRoute,
+        SettingsRoute,
+        settingsRouter,
+    } from '@core/router'
     import { localize } from '@core/i18n'
     import { ISidebarTab } from '../../lib/routers'
 
@@ -62,6 +69,7 @@
 
     function openCollectibles(): void {
         $dashboardRouter.goTo(DashboardRoute.Collectibles)
+        $collectiblesRouter.reset()
     }
 
     function openDeveloper(): void {


### PR DESCRIPTION
## Summary

With this PR the router gets reset if you click the corresponding Sidebar Tab.

## Changelog

```
- reset router on tab change
```

## Relevant Issues

Closes #5317 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
