### PR TITLE
fix: height recipient input

### DIFF
--- a/packages/shared/components/inputs/RecipientInput.svelte
+++ b/packages/shared/components/inputs/RecipientInput.svelte
@@ -75,6 +75,7 @@
     bind:error
     {disabled}
     options={accountOptions}
+    maxHeight="max-h-48"
     {...$$restProps}
     let:option
 >


### PR DESCRIPTION
## Summary

Smaller height for recipient input, so it fits the screen on minimum size

...

## Changelog

```
- maxHeight set to max-h-48
```

## Relevant Issues

closes: https://github.com/iotaledger/firefly/issues/5314
...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
