### PR TITLE
enhancement: disable nft/asset select if using nft/asset send button

### DIFF
--- a/packages/desktop/views/dashboard/collectibles/views/DetailsView.svelte
+++ b/packages/desktop/views/dashboard/collectibles/views/DetailsView.svelte
@@ -66,13 +66,11 @@
             type: NewTransactionType.NftTransfer,
             nftId: id,
             recipient: undefined,
+            disableAssetSelection: true,
         })
         openPopup({
             type: 'sendForm',
             overflow: true,
-            props: {
-                disableAssetSelection: true,
-            },
         })
     }
 </script>

--- a/packages/desktop/views/dashboard/collectibles/views/DetailsView.svelte
+++ b/packages/desktop/views/dashboard/collectibles/views/DetailsView.svelte
@@ -70,6 +70,9 @@
         openPopup({
             type: 'sendForm',
             overflow: true,
+            props: {
+                disableAssetSelection: true,
+            },
         })
     }
 </script>

--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -19,6 +19,7 @@
     export let asset: IAsset = $visibleSelectedAccountAssets?.baseCoin
     export let rawAmount: string = undefined
     export let unit: string = undefined
+    export let disableAssetSelection: boolean = false
 
     let amount: string = rawAmount
         ? formatTokenAmountDefault(Number(rawAmount), asset?.metadata, unit, false)
@@ -93,7 +94,7 @@
     on:clickOutside={() => (isFocused = false)}
 >
     <div class="flex flex-row w-full items-center space-x-0.5 relative">
-        <AssetDropdown bind:asset />
+        <AssetDropdown bind:asset readonly={disableAssetSelection} />
         <AmountInput
             bind:inputElement={amountInputElement}
             bind:amount

--- a/packages/shared/components/inputs/AssetDropdown.svelte
+++ b/packages/shared/components/inputs/AssetDropdown.svelte
@@ -10,7 +10,7 @@
     let isDropdownOpen = false
     let icon: string
 
-    $: isReadonly = readonly || $visibleSelectedAccountAssets?.nativeTokens.length < 1
+    $: isReadonly = readonly || $visibleSelectedAccountAssets?.nativeTokens.length === 0
     $: switch (asset?.metadata?.name?.toLocaleLowerCase()) {
         case NetworkProtocol.IOTA:
         case NetworkProtocol.Shimmer:

--- a/packages/shared/components/inputs/AssetDropdown.svelte
+++ b/packages/shared/components/inputs/AssetDropdown.svelte
@@ -5,11 +5,12 @@
     import { clickOutside } from '@core/utils'
 
     export let asset = $visibleSelectedAccountAssets?.baseCoin
+    export let readonly: boolean = false
 
     let isDropdownOpen = false
     let icon: string
 
-    $: hasMultipleAssets = $visibleSelectedAccountAssets?.nativeTokens.length >= 1
+    $: hasMultipleAssets = $visibleSelectedAccountAssets?.nativeTokens.length >= 1 && !readonly
     $: switch (asset?.metadata?.name?.toLocaleLowerCase()) {
         case NetworkProtocol.IOTA:
         case NetworkProtocol.Shimmer:

--- a/packages/shared/components/inputs/AssetDropdown.svelte
+++ b/packages/shared/components/inputs/AssetDropdown.svelte
@@ -10,7 +10,7 @@
     let isDropdownOpen = false
     let icon: string
 
-    $: hasMultipleAssets = $visibleSelectedAccountAssets?.nativeTokens.length >= 1 && !readonly
+    $: isReadonly = readonly || $visibleSelectedAccountAssets?.nativeTokens.length < 1
     $: switch (asset?.metadata?.name?.toLocaleLowerCase()) {
         case NetworkProtocol.IOTA:
         case NetworkProtocol.Shimmer:
@@ -21,7 +21,7 @@
     }
 
     function handleDropdownClick(): void {
-        if (hasMultipleAssets) {
+        if (!isReadonly) {
             isDropdownOpen = !isDropdownOpen
         }
     }
@@ -40,7 +40,7 @@
     <div class="flex flex-col" use:clickOutside on:clickOutside={handleOnClickOutside}>
         <div
             class="flex flex-row items-center p-2 space-x-2 text-left bg-gray-100 dark:bg-gray-700 rounded-md cursor-default"
-            class:cursor-pointer={hasMultipleAssets}
+            class:cursor-pointer={!isReadonly}
             on:click={handleDropdownClick}
         >
             <AssetIcon small {asset} />
@@ -55,13 +55,13 @@
                     {asset?.metadata?.name ?? asset?.id}
                 </Text>
             </div>
-            {#if hasMultipleAssets}
+            {#if !isReadonly}
                 <div class="transform rotate-0">
                     <Icon height="18" width="18" icon="chevron-down" classes="text-gray-600 dark:text-gray-500" />
                 </div>
             {/if}
         </div>
-        {#if isDropdownOpen && hasMultipleAssets}
+        {#if isDropdownOpen && !isReadonly}
             <div
                 class="dropdown bg-white dark:bg-gray-800 absolute flex flex-col top-12 -left-5 -right-5 border border-solid border-blue-500 rounded-xl z-10 p-4 max-h-96"
             >

--- a/packages/shared/components/inputs/NftInput.svelte
+++ b/packages/shared/components/inputs/NftInput.svelte
@@ -7,6 +7,7 @@
 
     export let nftId: string = ''
     export let error: string = ''
+    export let readonly: boolean = false
 
     let inputElement: HTMLInputElement = undefined
     let modal: Modal = undefined
@@ -44,6 +45,7 @@
     bind:inputElement
     bind:modal
     bind:error
+    {readonly}
     options={nftOptions}
     let:option
 >

--- a/packages/shared/components/modals/CollectibleDetailsMenu.svelte
+++ b/packages/shared/components/modals/CollectibleDetailsMenu.svelte
@@ -7,7 +7,7 @@
     import { INft } from '@core/nfts'
     import { CollectiblesRoute, collectiblesRouter } from '@core/router'
 
-    export let modal: Modal
+    export let modal: Modal = undefined
     export let nft: INft
 
     function openBurnNft(): void {

--- a/packages/shared/components/molecules/SelectorInput.svelte
+++ b/packages/shared/components/molecules/SelectorInput.svelte
@@ -12,6 +12,7 @@
     export let options: IOption[] = []
     export let selected: IOption = undefined
     export let maxHeight: string = 'max-h-64'
+    export let readonly: boolean = false
 
     let value: string = selected?.key ?? selected?.value
     let previousValue: string = value
@@ -65,6 +66,7 @@
         label={localize(labelLocale)}
         placeholder={localize(labelLocale)}
         fontSize="sm"
+        {readonly}
         {...$$restProps}
     >
         <div slot="right">
@@ -76,7 +78,7 @@
         </div>
     </TextInput>
 
-    {#if filteredOptions.length > 0}
+    {#if filteredOptions.length > 0 && !readonly}
         <Modal
             bind:this={modal}
             position={{ left: '0', top: '100%' }}

--- a/packages/shared/components/popups/TokenInformationPopup.svelte
+++ b/packages/shared/components/popups/TokenInformationPopup.svelte
@@ -3,6 +3,7 @@
     import {
         TokenStandard,
         IAsset,
+        resetNewTokenTransactionDetails,
         updateNewTransactionDetails,
         unverifyAsset,
         verifyAsset,
@@ -45,13 +46,15 @@
     }
 
     function onSendClick(): void {
-        updateNewTransactionDetails({ type: NewTransactionType.TokenTransfer, assetId: asset.id })
+        resetNewTokenTransactionDetails()
+        updateNewTransactionDetails({
+            type: NewTransactionType.TokenTransfer,
+            assetId: asset.id,
+            disableAssetSelection: true,
+        })
         openPopup({
             type: 'sendForm',
             overflow: true,
-            props: {
-                disableAssetSelection: true,
-            },
         })
     }
 </script>

--- a/packages/shared/components/popups/TokenInformationPopup.svelte
+++ b/packages/shared/components/popups/TokenInformationPopup.svelte
@@ -49,6 +49,9 @@
         openPopup({
             type: 'sendForm',
             overflow: true,
+            props: {
+                disableAssetSelection: true,
+            },
         })
     }
 </script>

--- a/packages/shared/components/popups/send/SendFormPopup.svelte
+++ b/packages/shared/components/popups/send/SendFormPopup.svelte
@@ -142,7 +142,13 @@
             <Tabs bind:activeTab {tabs} />
         {/if}
         {#if activeTab === SendForm.SendToken}
-            <AssetAmountInput bind:this={assetAmountInput} bind:asset bind:rawAmount bind:unit />
+            <AssetAmountInput
+                bind:this={assetAmountInput}
+                bind:asset
+                bind:rawAmount
+                bind:unit
+                {disableAssetSelection}
+            />
         {:else}
             <NftInput bind:this={nftInput} bind:nftId readonly={disableAssetSelection} />
         {/if}

--- a/packages/shared/components/popups/send/SendFormPopup.svelte
+++ b/packages/shared/components/popups/send/SendFormPopup.svelte
@@ -25,6 +25,8 @@
     } from 'shared/components'
     import { get } from 'svelte/store'
 
+    export let disableAssetSelection: boolean = false
+
     enum SendForm {
         SendToken = 'general.sendToken',
         SendNft = 'general.sendNft',
@@ -136,13 +138,13 @@
         {localize('popups.transaction.title')}
     </Text>
     <send-form-inputs class="flex flex-col space-y-4">
-        {#if hasSpendableNfts}
+        {#if hasSpendableNfts && !disableAssetSelection}
             <Tabs bind:activeTab {tabs} />
         {/if}
         {#if activeTab === SendForm.SendToken}
             <AssetAmountInput bind:this={assetAmountInput} bind:asset bind:rawAmount bind:unit />
         {:else}
-            <NftInput bind:this={nftInput} bind:nftId />
+            <NftInput bind:this={nftInput} bind:nftId readonly={disableAssetSelection} />
         {/if}
         <NetworkInput bind:this={networkInput} bind:networkAddress showLayer2={isSendTokenTab} />
         <RecipientInput bind:this={recipientInput} bind:recipient {isLayer2} />

--- a/packages/shared/components/popups/send/SendFormPopup.svelte
+++ b/packages/shared/components/popups/send/SendFormPopup.svelte
@@ -25,15 +25,13 @@
     } from 'shared/components'
     import { get } from 'svelte/store'
 
-    export let disableAssetSelection: boolean = false
-
     enum SendForm {
         SendToken = 'general.sendToken',
         SendNft = 'general.sendNft',
     }
 
     const transactionDetails = get(newTransactionDetails)
-    let { metadata, recipient, tag, layer2Parameters } = transactionDetails
+    let { metadata, recipient, tag, layer2Parameters, disableAssetSelection } = transactionDetails
 
     let assetAmountInput: AssetAmountInput
     let nftInput: NftInput
@@ -78,6 +76,7 @@
                 tag,
                 metadata,
                 layer2Parameters,
+                disableAssetSelection,
             })
         } else {
             setNewTransactionDetails({
@@ -86,6 +85,7 @@
                 nftId,
                 tag,
                 metadata,
+                disableAssetSelection,
             })
         }
     }

--- a/packages/shared/lib/core/wallet/types/new-transaction-details.type.ts
+++ b/packages/shared/lib/core/wallet/types/new-transaction-details.type.ts
@@ -14,6 +14,7 @@ type NewBaseTransactionDetails = {
     disableToggleGift?: boolean
     disableChangeExpiration?: boolean
     addSenderFeature?: boolean
+    disableAssetSelection?: boolean
 }
 
 export type NewTokenTransactionDetails = NewBaseTransactionDetails & {


### PR DESCRIPTION
## Summary

This PR improves the send flow if navigated through the NFT or Native Token "SendButton". In both cases, the asset selection will be disabled

## Changelog

```
- add flag in SendForm if navigated with NFT or Native Token "SendButton"
- disable Tabs
- disable AssetSelection
- disable NFT selection
```

## Relevant Issues

Closes #5316 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
