### PR TITLE
fix: selector input unwanted readonly

### DIFF
--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -20,7 +20,7 @@
     export let rawAmount: string = undefined
     export let unit: string = undefined
     export let containsSlider: boolean = false
-    export let disableAssetSelection: boolean = false
+    export let disableAssetSelection: boolean = null
 
     let amount: string = rawAmount
         ? formatTokenAmountDefault(Number(rawAmount), asset?.metadata, unit, false)

--- a/packages/shared/components/inputs/NftInput.svelte
+++ b/packages/shared/components/inputs/NftInput.svelte
@@ -7,7 +7,7 @@
 
     export let nftId: string = ''
     export let error: string = ''
-    export let readonly: boolean = false
+    export let readonly: boolean = null
 
     let inputElement: HTMLInputElement = undefined
     let modal: Modal = undefined

--- a/packages/shared/components/molecules/SelectorInput.svelte
+++ b/packages/shared/components/molecules/SelectorInput.svelte
@@ -12,7 +12,7 @@
     export let options: IOption[] = []
     export let selected: IOption = undefined
     export let maxHeight: string = 'max-h-64'
-    export let readonly: boolean = false
+    export let readonly: boolean = null
 
     let value: string = selected?.key ?? selected?.value
     let previousValue: string = value

--- a/packages/shared/components/molecules/SelectorInput.svelte
+++ b/packages/shared/components/molecules/SelectorInput.svelte
@@ -12,6 +12,8 @@
     export let options: IOption[] = []
     export let selected: IOption = undefined
     export let maxHeight: string = 'max-h-64'
+    // HTML checks whether this value is absent to determine whether the field is readonly
+    // If the attribute is set to false, HTML interprets it as a readonly field.
     export let readonly: boolean = null
 
     let value: string = selected?.key ?? selected?.value


### PR DESCRIPTION
## Summary
`readonly` prop should have an initial value of null or undefined, because svelte is adding the attribute in the HTML, and the HTML does not understand the `readonly` attribute with false or true value, just understand the absence of `readonly` prop

## Changelog
```
- Sets the initial value of readonly prop in SelectorInput to null
```

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android
  
## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
