### PR TITLE
Refactor: remove collectibles folder from core library

### DIFF
--- a/packages/shared/lib/core/collectibles/enums/attribute-display-type.enum.ts
+++ b/packages/shared/lib/core/collectibles/enums/attribute-display-type.enum.ts
@@ -1,1 +1,0 @@
-export enum NftAttributeDisplayType {}

--- a/packages/shared/lib/core/collectibles/enums/index.ts
+++ b/packages/shared/lib/core/collectibles/enums/index.ts
@@ -1,2 +1,0 @@
-export * from './attribute-display-type.enum'
-export * from './standard.enum'

--- a/packages/shared/lib/core/collectibles/enums/standard.enum.ts
+++ b/packages/shared/lib/core/collectibles/enums/standard.enum.ts
@@ -1,1 +1,0 @@
-export enum NftStandard {}

--- a/packages/shared/lib/core/collectibles/index.ts
+++ b/packages/shared/lib/core/collectibles/index.ts
@@ -1,3 +1,0 @@
-export * from './enums'
-export * from './interfaces'
-export * from './types'

--- a/packages/shared/lib/core/collectibles/interfaces/attribute.interface.ts
+++ b/packages/shared/lib/core/collectibles/interfaces/attribute.interface.ts
@@ -1,8 +1,0 @@
-import { NftAttributeDisplayType } from '../enums'
-import { NftAttributeTrait, NftAttributeValue } from '../types'
-
-export interface INftAttribute {
-    trait_type: NftAttributeTrait
-    value: NftAttributeValue
-    display_type?: NftAttributeDisplayType
-}

--- a/packages/shared/lib/core/collectibles/interfaces/index.ts
+++ b/packages/shared/lib/core/collectibles/interfaces/index.ts
@@ -1,2 +1,0 @@
-export * from './attribute.interface'
-export * from './nft.interface'

--- a/packages/shared/lib/core/collectibles/interfaces/nft.interface.ts
+++ b/packages/shared/lib/core/collectibles/interfaces/nft.interface.ts
@@ -1,6 +1,0 @@
-import { NftStandard } from '../enums'
-
-export interface INft {
-    id: string
-    standard: NftStandard | undefined
-}

--- a/packages/shared/lib/core/collectibles/types/attribute.type.ts
+++ b/packages/shared/lib/core/collectibles/types/attribute.type.ts
@@ -1,3 +1,0 @@
-export type NftAttributeTrait = string
-
-export type NftAttributeValue = boolean | number | string

--- a/packages/shared/lib/core/collectibles/types/collection.type.ts
+++ b/packages/shared/lib/core/collectibles/types/collection.type.ts
@@ -1,5 +1,0 @@
-import { INft } from '../interfaces'
-
-export type NftCollection = {
-    [id: string]: INft[]
-}

--- a/packages/shared/lib/core/collectibles/types/index.ts
+++ b/packages/shared/lib/core/collectibles/types/index.ts
@@ -1,3 +1,0 @@
-export * from './attribute.type'
-export * from './collection.type'
-export * from './royalties.type'

--- a/packages/shared/lib/core/collectibles/types/royalties.type.ts
+++ b/packages/shared/lib/core/collectibles/types/royalties.type.ts
@@ -1,5 +1,0 @@
-export type NftRoyalties = {
-    // Key-value pairs of valid IOTA/SMR addresses
-    // and the decimal representation of the required royalty percentage
-    [address: string]: number
-}


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

There are two NFT related folders in `lib/core`: `collectibles` and `nft`. `collectibles` is deprecated in favor of `nft` and an artifact of initial work on the NFT milestone.

## Changelog

```
- Delete collectibles folder from lib/core
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
