### PR TITLE
enhancement: link to nft details from nft activity popup

### DIFF
--- a/packages/shared/components/molecules/NftActivityDetails.svelte
+++ b/packages/shared/components/molecules/NftActivityDetails.svelte
@@ -20,6 +20,7 @@
     export let activity: NftActivity
 
     $: nft = getNftByIdFromAllAccountNfts($selectedAccountIndex, activity.nftId)
+    $: nftIsOwned = $selectedAccountNfts.some((nft) => nft.id === activity.nftId)
     $: isTimelocked = activity?.asyncData?.timelockDate > $time
 
     function handleClick(): void {
@@ -32,25 +33,17 @@
 
 <nft-transaction-details class="w-full space-y-6 flex flex-auto flex-col flex-shrink-0">
     <main-content class="flex flex-auto w-full flex-col items-center justify-center space-y-3 overflow-hidden">
-        {#if $selectedAccountNfts.some((nft) => nft.id === activity.nftId)}
-            <button
-                on:click|preventDefault={handleClick}
-                class="flex w-full items-center justify-center w-full space-x-2"
-            >
-                <NftImageOrIconBox nftId={activity.nftId} size="small" />
-                <Text type={TextType.h3} fontWeight={FontWeight.semibold} classes="whitespace-pre truncate">
-                    {nft?.name}
-                </Text>
-            </button>
-        {:else}
-            <div class="flex w-full items-center justify-center w-full space-x-2">
-                <NftImageOrIconBox nftId={activity.nftId} size="small" />
-                <Text type={TextType.h3} fontWeight={FontWeight.semibold} classes="whitespace-pre truncate">
-                    {nft?.name}
-                </Text>
-            </div>
-        {/if}
-
+        <!-- kraftjs: rerouting to detailsView sends to galleryView in some wallets -->
+        <button
+            on:click|preventDefault={handleClick}
+            disabled={!nftIsOwned}
+            class="flex w-max items-center justify-center space-x-2 cursor-{nftIsOwned ? 'pointer' : 'default'}"
+        >
+            <NftImageOrIconBox nftId={activity.nftId} size="small" />
+            <Text type={TextType.h3} fontWeight={FontWeight.semibold} classes="whitespace-pre truncate">
+                {nft?.name}
+            </Text>
+        </button>
         <transaction-status class="flex flex-row w-full space-x-2 justify-center">
             {#if activity?.inclusionState && activity?.direction}
                 <TransactionActivityStatusPill

--- a/packages/shared/components/molecules/NftActivityDetails.svelte
+++ b/packages/shared/components/molecules/NftActivityDetails.svelte
@@ -9,13 +9,14 @@
     import {
         ActivityAsyncStatusPill,
         FontWeight,
+        NftImageOrIconBox,
         Pill,
         SubjectBox,
         Text,
         TextType,
         TransactionActivityStatusPill,
     } from 'shared/components'
-    import NftImageOrIconBox from './NftImageOrIconBox.svelte'
+    import { tick } from 'svelte'
 
     export let activity: NftActivity
 
@@ -23,17 +24,17 @@
     $: nftIsOwned = $selectedAccountNfts.some((nft) => nft.id === activity.nftId)
     $: isTimelocked = activity?.asyncData?.timelockDate > $time
 
-    function handleClick(): void {
+    async function handleClick(): Promise<void> {
+        closePopup()
         $selectedNftId = activity.nftId
         $dashboardRouter.goTo(DashboardRoute.Collectibles)
+        await tick()
         $collectiblesRouter.goTo(CollectiblesRoute.Details)
-        closePopup()
     }
 </script>
 
 <nft-transaction-details class="w-full space-y-6 flex flex-auto flex-col flex-shrink-0">
     <main-content class="flex flex-auto w-full flex-col items-center justify-center space-y-3 overflow-hidden">
-        <!-- kraftjs: rerouting to detailsView sends to galleryView in some wallets -->
         <button
             on:click|preventDefault={handleClick}
             disabled={!nftIsOwned}

--- a/packages/shared/components/molecules/NftActivityDetails.svelte
+++ b/packages/shared/components/molecules/NftActivityDetails.svelte
@@ -1,8 +1,10 @@
 <script lang="typescript">
+    import { closePopup } from '@auxiliary/popup'
     import { selectedAccountIndex } from '@core/account/stores'
     import { time } from '@core/app'
     import { localize } from '@core/i18n'
-    import { getNftByIdFromAllAccountNfts } from '@core/nfts'
+    import { getNftByIdFromAllAccountNfts, selectedAccountNfts, selectedNftId } from '@core/nfts'
+    import { CollectiblesRoute, collectiblesRouter, DashboardRoute, dashboardRouter } from '@core/router'
     import { NftActivity } from '@core/wallet'
     import {
         ActivityAsyncStatusPill,
@@ -19,16 +21,36 @@
 
     $: nft = getNftByIdFromAllAccountNfts($selectedAccountIndex, activity.nftId)
     $: isTimelocked = activity?.asyncData?.timelockDate > $time
+
+    function handleClick(): void {
+        $selectedNftId = activity.nftId
+        $dashboardRouter.goTo(DashboardRoute.Collectibles)
+        $collectiblesRouter.goTo(CollectiblesRoute.Details)
+        closePopup()
+    }
 </script>
 
 <nft-transaction-details class="w-full space-y-6 flex flex-auto flex-col flex-shrink-0">
     <main-content class="flex flex-auto w-full flex-col items-center justify-center space-y-3 overflow-hidden">
-        <nft-summary class="flex w-full items-center justify-center w-full space-x-2">
-            <NftImageOrIconBox nftId={activity.nftId} size="small" />
-            <Text type={TextType.h3} fontWeight={FontWeight.semibold} classes="whitespace-pre truncate">
-                {nft?.name}
-            </Text>
-        </nft-summary>
+        {#if $selectedAccountNfts.some((nft) => nft.id === activity.nftId)}
+            <button
+                on:click|preventDefault={handleClick}
+                class="flex w-full items-center justify-center w-full space-x-2"
+            >
+                <NftImageOrIconBox nftId={activity.nftId} size="small" />
+                <Text type={TextType.h3} fontWeight={FontWeight.semibold} classes="whitespace-pre truncate">
+                    {nft?.name}
+                </Text>
+            </button>
+        {:else}
+            <div class="flex w-full items-center justify-center w-full space-x-2">
+                <NftImageOrIconBox nftId={activity.nftId} size="small" />
+                <Text type={TextType.h3} fontWeight={FontWeight.semibold} classes="whitespace-pre truncate">
+                    {nft?.name}
+                </Text>
+            </div>
+        {/if}
+
         <transaction-status class="flex flex-row w-full space-x-2 justify-center">
             {#if activity?.inclusionState && activity?.direction}
                 <TransactionActivityStatusPill

--- a/packages/shared/components/molecules/NftImageOrIconBox.svelte
+++ b/packages/shared/components/molecules/NftImageOrIconBox.svelte
@@ -10,18 +10,21 @@
     $: nft = getNftByIdFromAllAccountNfts($selectedAccountIndex, nftId)
     $: nftType = nft?.parsedMetadata?.type
     $: parentType = nftType?.split('/')?.[0]
+
+    let isLoaded = false
 </script>
 
 <div
     class="
-        flex overflow-hidden flex-shrink-0 rounded-md bg-gray-500 items-center justify-center
+        flex overflow-hidden flex-shrink-0 rounded-md items-center justify-center
+        {isLoaded ? '' : 'bg-gray-500'}
         {size === 'small' && 'w-6 h-6'}
         {size === 'medium' && 'w-8 h-8'}
         {size === 'large' && 'w-10 h-10'}
     "
 >
     {#if parentType === 'image'}
-        <NftMedia {nftId} classes="min-w-full min-h-full object-cover">
+        <NftMedia {nftId} bind:isLoaded classes="min-w-full min-h-full object-cover">
             <div
                 slot="placeholder"
                 class="

--- a/packages/shared/components/molecules/NftMedia.svelte
+++ b/packages/shared/components/molecules/NftMedia.svelte
@@ -14,11 +14,11 @@
     export let error: string = ''
     export let warning: string = ''
     export let translationSuffix: string = 'long'
+    export let isLoaded = false
 
     const bgColor = 'gray-200'
     const darkBgColor = 'gray-700'
 
-    let isLoaded = false
     let hasError = false
 
     $: nft = getNftByIdFromAllAccountNfts($selectedAccountIndex, nftId)

--- a/packages/shared/components/popups/ActivityDetailsPopup.svelte
+++ b/packages/shared/components/popups/ActivityDetailsPopup.svelte
@@ -142,7 +142,7 @@
         </Text>
         {#if explorerUrl && activity.transactionId}
             <button
-                class="action w-fit flex justify-start text-center font-medium text-14 text-blue-500"
+                class="action w-max flex justify-start text-center font-medium text-14 text-blue-500"
                 on:click={handleExplorerClick}
             >
                 {localize('general.viewOnExplorer')}


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

When receiving / minting NFTs, users might want to easily access the details view of the specific NFT without needing to traverse through the CollectiblesGallery and find the specific NFT. Adding a direct link to the DetailsView from the ActivityDetails component would make this much easier for the user.

## Changelog

```
- Add button to NftActivityDetails that is shown when nft is in selectedAccountNfts
- Fix placeholder borders showing behind loaded image
- Fix viewOnExplorer button taking up full parent width
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Closes #5450 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
