### PR TITLE
feat: adds node authentication flow in voting

### DIFF
--- a/packages/shared/components/popups/AuthenticationRequiredPopup.svelte
+++ b/packages/shared/components/popups/AuthenticationRequiredPopup.svelte
@@ -1,0 +1,73 @@
+<script lang="typescript">
+    import { Button, TextInput, Text, TextType, HTMLButtonType } from 'shared/components'
+    import { localize } from '@core/i18n'
+    import { closePopup } from '@auxiliary/popup'
+    import { handleError } from '@core/error/handlers'
+    import type { Auth } from '@iota/wallet'
+
+    export let onSubmit: (auth: Auth) => unknown = () => {}
+
+    let username: string
+    let password: string
+    let jwt: string
+
+    let usernameError: string
+    let passwordError: string
+    let jwtError: string
+
+    $: disabled = !username && !password && !jwt
+
+    async function handleSubmit(): Promise<void> {
+        try {
+            const auth = { username, password, jwt }
+            await onSubmit(auth)
+        } catch (err) {
+            const authenticationError = err?.error?.match(/(username)|(password)|(jwt)/g)?.[0]
+            switch (authenticationError) {
+                case 'username':
+                    usernameError = err.error
+                    break
+                case 'password':
+                    passwordError = err.error
+                    break
+                case 'jwt':
+                    jwtError = err.error
+                    break
+                default:
+                    handleError(err)
+                    break
+            }
+        }
+    }
+</script>
+
+<form id="authentication-required" on:submit|preventDefault={handleSubmit}>
+    <Text type={TextType.h3} classes="mb-6">{localize('popups.authenticationRequired.title')}</Text>
+    <Text fontSize="15">{localize('popups.authenticationRequired.body')}</Text>
+    <div class="flex flex-col w-full space-y-4 mt-4">
+        <TextInput
+            bind:value={username}
+            bind:error={usernameError}
+            placeholder={localize('general.username')}
+            label={localize('general.username')}
+        />
+        <TextInput
+            bind:value={password}
+            bind:error={passwordError}
+            placeholder={localize('general.password')}
+            label={localize('general.password')}
+        />
+        <TextInput
+            bind:value={jwt}
+            bind:error={jwtError}
+            placeholder={localize('general.jwt')}
+            label={localize('general.jwt')}
+        />
+    </div>
+    <div class="flex w-full space-x-4 mt-6">
+        <Button outline classes="w-full" onClick={closePopup}>{localize('actions.cancel')}</Button>
+        <Button {disabled} type={HTMLButtonType.Submit} classes="w-full">
+            {localize('actions.confirm')}
+        </Button>
+    </div>
+</form>

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -11,6 +11,7 @@
     import AliasConfirmationPopup from './AliasConfirmationPopup.svelte'
     import ActivityDetailsPopup from './ActivityDetailsPopup.svelte'
     import AddNodePopup from './AddNodePopup.svelte'
+    import AuthenticationRequiredPopup from './AuthenticationRequiredPopup.svelte'
     import BackupStrongholdPopup from './BackupStrongholdPopup.svelte'
     import BurnNativeTokensPopup from './BurnNativeTokensPopup.svelte'
     import BurnNativeTokensConfirmationPopup from './BurnNativeTokensConfirmationPopup.svelte'
@@ -93,6 +94,7 @@
         activityDetails: ActivityDetailsPopup,
         addNode: AddNodePopup,
         aliasConfirmation: AliasConfirmationPopup,
+        authenticationRequired: AuthenticationRequiredPopup,
         backupStronghold: BackupStrongholdPopup,
         burnNativeTokens: BurnNativeTokensPopup,
         burnNativeTokensConfirm: BurnNativeTokensConfirmationPopup,

--- a/packages/shared/components/popups/Index.svelte
+++ b/packages/shared/components/popups/Index.svelte
@@ -11,7 +11,6 @@
     import AliasConfirmationPopup from './AliasConfirmationPopup.svelte'
     import ActivityDetailsPopup from './ActivityDetailsPopup.svelte'
     import AddNodePopup from './AddNodePopup.svelte'
-    import AuthenticationRequiredPopup from './AuthenticationRequiredPopup.svelte'
     import BackupStrongholdPopup from './BackupStrongholdPopup.svelte'
     import BurnNativeTokensPopup from './BurnNativeTokensPopup.svelte'
     import BurnNativeTokensConfirmationPopup from './BurnNativeTokensConfirmationPopup.svelte'
@@ -33,6 +32,7 @@
     import MintNativeTokenConfirmationPopup from './MintNativeTokenConfirmationPopup.svelte'
     import MintNftFormPopup from './MintNftFormPopup.svelte'
     import MintNftConfirmationPopup from './MintNftConfirmationPopup.svelte'
+    import NodeAuthRequiredPopup from './NodeAuthRequiredPopup.svelte'
     import NodeInfoPopup from './NodeInfoPopup.svelte'
     import ReceiveAddressPopup from './ReceiveAddressPopup.svelte'
     import RegisterProposalPopup from './RegisterProposalPopup.svelte'
@@ -94,7 +94,6 @@
         activityDetails: ActivityDetailsPopup,
         addNode: AddNodePopup,
         aliasConfirmation: AliasConfirmationPopup,
-        authenticationRequired: AuthenticationRequiredPopup,
         backupStronghold: BackupStrongholdPopup,
         burnNativeTokens: BurnNativeTokensPopup,
         burnNativeTokensConfirm: BurnNativeTokensConfirmationPopup,
@@ -116,6 +115,7 @@
         mintNativeTokenForm: MintNativeTokenFormPopup,
         mintNftConfirmation: MintNftConfirmationPopup,
         mintNftForm: MintNftFormPopup,
+        nodeAuthRequired: NodeAuthRequiredPopup,
         nodeInfo: NodeInfoPopup,
         receiveAddress: ReceiveAddressPopup,
         registerProposal: RegisterProposalPopup,

--- a/packages/shared/components/popups/NodeAuthRequiredPopup.svelte
+++ b/packages/shared/components/popups/NodeAuthRequiredPopup.svelte
@@ -41,9 +41,9 @@
     }
 </script>
 
-<form id="authentication-required" on:submit|preventDefault={handleSubmit}>
-    <Text type={TextType.h3} classes="mb-6">{localize('popups.authenticationRequired.title')}</Text>
-    <Text fontSize="15">{localize('popups.authenticationRequired.body')}</Text>
+<form id="node-auth-required" on:submit|preventDefault={handleSubmit}>
+    <Text type={TextType.h3} classes="mb-6">{localize('popups.nodeAuthRequired.title')}</Text>
+    <Text fontSize="15">{localize('popups.nodeAuthRequired.body')}</Text>
     <div class="flex flex-col w-full space-y-4 mt-4">
         <TextInput
             bind:value={username}

--- a/packages/shared/components/popups/NodeAuthRequiredPopup.svelte
+++ b/packages/shared/components/popups/NodeAuthRequiredPopup.svelte
@@ -1,9 +1,9 @@
 <script lang="typescript">
-    import { Button, TextInput, Text, TextType, HTMLButtonType } from 'shared/components'
-    import { localize } from '@core/i18n'
-    import { closePopup } from '@auxiliary/popup'
-    import { handleError } from '@core/error/handlers'
+    import { Button, HTMLButtonType, Text, TextInput, TextType } from 'shared/components'
     import type { Auth } from '@iota/wallet'
+    import { handleError } from '@core/error/handlers'
+    import { localize } from '@core/i18n'
+    import { closePopup } from '@auxiliary/popup/actions'
 
     export let onSubmit: (auth: Auth) => unknown = () => {}
 

--- a/packages/shared/components/popups/RegisterProposalPopup.svelte
+++ b/packages/shared/components/popups/RegisterProposalPopup.svelte
@@ -1,12 +1,12 @@
 <script lang="typescript">
     import { Button, TextInput, Text, TextType } from 'shared/components'
-    import { localize } from '@core/i18n'
-    import { closePopup, openPopup } from '@auxiliary/popup'
-    import { registerParticipationEvent } from '@core/profile-manager/api'
-    import { isValidUrl } from '@core/utils'
-    import { handleError } from '@core/error/handlers/handleError'
-    import { showAppNotification } from '@auxiliary/notification'
     import type { Auth } from '@iota/wallet'
+    import { showAppNotification } from '@auxiliary/notification/actions'
+    import { closePopup, openPopup } from '@auxiliary/popup/actions'
+    import { handleError } from '@core/error/handlers/handleError'
+    import { localize } from '@core/i18n'
+    import { registerParticipationEvent } from '@core/profile-manager/api'
+    import { isValidUrl } from '@core/utils/validation'
 
     let eventId: string
     let nodeUrl: string

--- a/packages/shared/components/popups/RegisterProposalPopup.svelte
+++ b/packages/shared/components/popups/RegisterProposalPopup.svelte
@@ -7,9 +7,10 @@
     import { handleError } from '@core/error/handlers/handleError'
     import { showAppNotification } from '@auxiliary/notification'
     import type { Auth } from '@iota/wallet'
+    import { activeProfile } from '@core/profile/stores'
 
     let eventId: string
-    let nodeUrl: string
+    let nodeUrl: string = $activeProfile?.clientOptions?.nodes[0]?.url
 
     let eventIdError: string
     let nodeUrlError: string

--- a/packages/shared/components/popups/RegisterProposalPopup.svelte
+++ b/packages/shared/components/popups/RegisterProposalPopup.svelte
@@ -27,16 +27,16 @@
         } catch (err) {
             const isAuthenticationError = err?.error?.match(/(username)|(password)|(jwt)/g).length > 0
             if (isAuthenticationError) {
-                openAuthenticationRequiredPopup()
+                openNodeAuthRequiredPopup()
             } else if (!nodeUrlError && !eventIdError) {
                 handleError(err)
             }
         }
     }
 
-    function openAuthenticationRequiredPopup(): void {
+    function openNodeAuthRequiredPopup(): void {
         openPopup({
-            type: 'authenticationRequired',
+            type: 'nodeAuthRequired',
             props: { onSubmit: registerParticipationWrapper },
         })
     }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1026,7 +1026,7 @@
             "body": "You're about to stop voting for the {proposalName} proposal.",
             "hint": "Please note that stopping voting during the counting period won't impact any votes that have already been counted."
         },
-        "authenticationRequired": {
+        "nodeAuthRequired": {
             "title": "Authentication required",
             "body": "This node requires additional authentication. Please fill in the appropriate information."
         }

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1025,6 +1025,10 @@
             "title": "Stop voting",
             "body": "You're about to stop voting for the {proposalName} proposal.",
             "hint": "Please note that stopping voting during the counting period won't impact any votes that have already been counted."
+        },
+        "authenticationRequired": {
+            "title": "Authentication required",
+            "body": "This node requires additional authentication. Please fill in the appropriate information."
         }
     },
     "charts": {
@@ -1453,7 +1457,9 @@
         "details": "Details",
         "availableAmount": "{amount} available",
         "properties": "Properties",
-        "statistics": "Statistics"
+        "statistics": "Statistics",
+        "username": "Username",
+        "jwt": "JSON web token"
     },
     "filters":{
         "title": "Filters",


### PR DESCRIPTION
## Summary
Opens the node authentication popup when the register proposal function error returns messages related to auth.
Extra: adds default value for node URL input

## Relevant Issues
closes #5257 

## Testing
### Platforms
- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

## Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
