### PR TITLE
fix: fix on available balance click

### DIFF
--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -52,7 +52,6 @@
         if (isRawAmount) {
             const parsedAmount = formatTokenAmountDefault(availableBalance, asset?.metadata, unit, false)
             amount = parsedAmount
-            unit = asset?.metadata?.unit
             return
         }
         amount = availableBalance.toString() ?? '0'

--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -48,7 +48,7 @@
     function onClickAvailableBalance(): void {
         const isRawAmount = asset?.metadata?.decimals && asset?.metadata?.unit
         if (isRawAmount) {
-            const parsedAmount = formatTokenAmountDefault(asset?.balance?.available, asset?.metadata, unit)
+            const parsedAmount = formatTokenAmountDefault(asset?.balance?.available, asset?.metadata, unit, false)
             amount = parsedAmount
             unit = asset?.metadata?.unit
             return


### PR DESCRIPTION
## Summary

If clicked on the available balance, a non-grouped amount will be inserted into the input

## Changelog

```
- If clicked on the available balance, a non-grouped amount will be inserted into the input
```

## Relevant Issues

Closes #5529 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
