### PR TITLE
fix: de-bounce buttons on Governance actions

### DIFF
--- a/packages/shared/components/popups/ManageVotingPowerPopup.svelte
+++ b/packages/shared/components/popups/ManageVotingPowerPopup.svelte
@@ -16,11 +16,11 @@
 
     $: isTransferring = $selectedAccount?.isTransferring
 
-    function handleBack(): void {
+    function onCancelClick(): void {
         closePopup()
     }
 
-    async function handleConfirm(): Promise<void> {
+    async function onConfirmClick(): Promise<void> {
         try {
             await assetAmountInput?.validate()
             await checkActiveProfileAuth(async () => {
@@ -41,13 +41,13 @@
     <TextHint info text={localize('popups.manageVotingPower.hint')} />
 </div>
 <div class="flex flex-row flex-nowrap w-full space-x-4">
-    <Button outline classes="w-full" disabled={isTransferring} onClick={handleBack}>
-        {localize('actions.back')}
+    <Button outline classes="w-full" disabled={isTransferring} onClick={onCancelClick}>
+        {localize('actions.cancel')}
     </Button>
     <Button
         classes="w-full"
         disabled={$selectedAccount.isTransferring}
-        onClick={handleConfirm}
+        onClick={onConfirmClick}
         isBusy={$selectedAccount.isTransferring}
     >
         {localize('actions.confirm')}

--- a/packages/shared/components/popups/RegisterProposalPopup.svelte
+++ b/packages/shared/components/popups/RegisterProposalPopup.svelte
@@ -6,6 +6,7 @@
     import { handleError } from '@core/error/handlers/handleError'
     import { localize } from '@core/i18n'
     import { registerParticipationEvent } from '@core/profile-manager/api'
+    import { truncateString } from '@core/utils/string'
     import { isValidUrl } from '@core/utils/validation'
 
     export let eventId: string
@@ -32,9 +33,25 @@
             busy = false
         } catch (err) {
             busy = false
-            const isAuthenticationError = err?.error?.match(/(username)|(password)|(jwt)/g).length > 0
+            const isAuthenticationError = err?.error?.match(/(username)|(password)|(jwt)/g)?.length > 0
+            const isEventError = err?.error?.match(/(the requested data)|(was not found)/)?.length > 0
+            const isNodeError = err?.error?.match(/(failed to lookup address information)|(dns error)/)?.length > 0
             if (isAuthenticationError) {
                 openNodeAuthRequiredPopup()
+            } else if (isEventError) {
+                showAppNotification({
+                    type: 'error',
+                    alert: true,
+                    message: localize('error.governance.unableToRegisterProposal.long', {
+                        values: { proposalId: truncateString(eventId) },
+                    }),
+                })
+            } else if (isNodeError) {
+                showAppNotification({
+                    type: 'error',
+                    alert: true,
+                    message: localize('error.node.dns'),
+                })
             } else if (!nodeUrlError && !eventIdError) {
                 handleError(err)
             }

--- a/packages/shared/components/popups/RegisterProposalPopup.svelte
+++ b/packages/shared/components/popups/RegisterProposalPopup.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Button, HTMLButtonType, Spinner, TextInput, Text, TextType } from 'shared/components'
+    import { Button, HTMLButtonType, TextInput, Text, TextType } from 'shared/components'
     import type { Auth } from '@iota/wallet'
     import { showAppNotification } from '@auxiliary/notification/actions'
     import { closePopup, openPopup } from '@auxiliary/popup/actions'
@@ -15,7 +15,7 @@
     let eventIdError: string
     let nodeUrlError: string
 
-    let busy = false
+    let isBusy = false
 
     $: disabled = !eventId || !nodeUrl
 
@@ -25,14 +25,14 @@
 
     async function onConfirmClick(): Promise<void> {
         try {
-            busy = true
+            isBusy = true
 
             await Promise.all([validateEventId(), validateNodeUrl()])
             await registerParticipationWrapper()
 
-            busy = false
+            isBusy = false
         } catch (err) {
-            busy = false
+            isBusy = false
             const isAuthenticationError = err?.error?.match(/(username)|(password)|(jwt)/g)?.length > 0
             const isEventError = err?.error?.match(/(the requested data)|(was not found)/)?.length > 0
             const isNodeError = err?.error?.match(/(failed to lookup address information)|(dns error)/)?.length > 0
@@ -117,12 +117,8 @@
     </div>
     <div class="flex w-full space-x-4 mt-6">
         <Button outline classes="w-full" onClick={onCloseClick}>{localize('actions.cancel')}</Button>
-        <Button disabled={disabled || busy} classes="w-full" type={HTMLButtonType.Submit}>
-            {#if busy}
-                <Spinner {busy} />
-            {:else}
-                {localize('actions.confirm')}
-            {/if}
+        <Button disabled={disabled || isBusy} {isBusy} classes="w-full" type={HTMLButtonType.Submit}>
+            {localize('actions.confirm')}
         </Button>
     </div>
 </form>

--- a/packages/shared/lib/contexts/governance/interfaces/proposal-state.interface.ts
+++ b/packages/shared/lib/contexts/governance/interfaces/proposal-state.interface.ts
@@ -2,7 +2,7 @@ import type { EventStatus } from '@iota/wallet'
 
 export interface IProposalState {
     [profileId: string]: {
-        [eventId: string]: {
+        [proposalId: string]: {
             state: EventStatus
             nodeUrl: string
         }

--- a/packages/shared/lib/core/error/handlers/handleError.ts
+++ b/packages/shared/lib/core/error/handlers/handleError.ts
@@ -1,5 +1,6 @@
 import { WalletRsError } from '../enums'
 import { IError } from '../interfaces'
+
 import { handleGenericError } from './handleGenericError'
 import { handleWalletRsError } from './walletRs'
 

--- a/packages/shared/lib/core/error/handlers/handleGenericError.ts
+++ b/packages/shared/lib/core/error/handlers/handleGenericError.ts
@@ -1,5 +1,5 @@
-import { IError } from '../interfaces'
 import { logAndNotifyError } from '../actions'
+import { IError } from '../interfaces'
 
 export function handleGenericError(error: IError | string): void {
     let message: string

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1738,7 +1738,7 @@
         },
         "node": {
             "invalid": "Please enter a valid URL.",
-            "dns": "Could not find DNS resolution for node.",
+            "dns": "Unable to find DNS resolution for node",
             "timedOut": "The connection timed out.",
             "refused": "The connection was refused.",
             "handshake": "Could not complete handshake with node.",
@@ -1852,6 +1852,12 @@
             "loadingError": {
                 "short": "Unable to load",
                 "long": "An error occurred while loading the NFT"
+            }
+        },
+        "governance": {
+            "unableToRegisterProposal": {
+                "short": "Unable to register proposal",
+                "long": "An error occurred while trying to register proposal {proposalId}"
             }
         }
     },


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

The register proposal popup needed to be slightly more robust.

## Changelog

```
- Add de-bouncing / spinner to action button in register proposal popup
- Improve error handling around registering a proposal
- Cleanup some import statements, mainly alphabetizing them
```

## Relevant Issues

> Please list any related issues using [development keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Closes #5480 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
  - [ ] MacOS
  - [x] Linux
  - [ ] Windows
- __Mobile__
  - [ ] iOS
  - [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Test registering a proposal, trying invalid event IDs, valid (but non-existent) event IDs, invalid node URLs, etc.

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
