### PR TITLE
feat: add input validation option to confirmation popup

### DIFF
--- a/packages/shared/components/modals/CollectibleDetailsMenu.svelte
+++ b/packages/shared/components/modals/CollectibleDetailsMenu.svelte
@@ -23,9 +23,11 @@
                     },
                 }),
                 description: localize('actions.confirmNftBurn.description'),
+                inputCheckLabel: localize('general.nftName'),
+                inputCheckValidation: nft.name,
                 hint: localize('actions.confirmNftBurn.hint'),
                 warning: true,
-                confirmText: localize('actions.burnToken'),
+                confirmText: localize('actions.burnNft'),
                 onConfirm: () => {
                     checkActiveProfileAuth(
                         async () => {

--- a/packages/shared/components/popups/ConfirmationPopup.svelte
+++ b/packages/shared/components/popups/ConfirmationPopup.svelte
@@ -1,10 +1,12 @@
 <script lang="typescript">
-    import { Button, Text, TextHint, FontWeight, TextType, ButtonVariant } from 'shared/components'
+    import { Button, Text, TextHint, TextInput, FontWeight, TextType, ButtonVariant } from 'shared/components'
     import { localize } from '@core/i18n'
     import { closePopup } from '@auxiliary/popup'
 
     export let title: string
     export let description: string = ''
+    export let inputCheckLabel: string = ''
+    export let inputCheckValidation: string = ''
     export let hint: string = ''
     export let info: boolean = false
     export let success: boolean = false
@@ -14,8 +16,14 @@
     export let onConfirm: () => void = undefined
     export let onCancel: () => void = undefined
 
+    let value: string = ''
+    let isBusy: boolean = false
+
+    $: confirmationEnabled = !inputCheckLabel || !inputCheckValidation || value === inputCheckValidation
+
     function confirmClick(): void {
         if (onConfirm) {
+            isBusy = true
             onConfirm()
         } else {
             closePopup()
@@ -39,6 +47,9 @@
         {#if description}
             <Text fontSize="14" classes="text-left break-words">{description}</Text>
         {/if}
+        {#if inputCheckLabel && inputCheckValidation}
+            <TextInput bind:value label={inputCheckLabel} placeholder={inputCheckLabel} fontSize="sm" />
+        {/if}
         {#if hint}
             <TextHint {info} {success} {warning} {danger} text={hint} />
         {/if}
@@ -49,6 +60,8 @@
             classes="w-full"
             variant={warning || danger ? ButtonVariant.Warning : ButtonVariant.Primary}
             onClick={confirmClick}
+            disabled={!confirmationEnabled}
+            {isBusy}
         >
             {confirmText}
         </Button>

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1073,8 +1073,8 @@
         },
         "confirmNftBurn": {
             "title": "Burn {nftName}",
-            "description": "Are you sure you want to burn this NFT?",
-            "hint": "Please note that burning a token frees the storage deposit attached to it and is not reversible."
+            "description": "Are you sure you want to burn this NFT? Please input the NFT name to confirm.",
+            "hint": "Please note that burning an NFT is not reversible and frees the storage deposit attached to it."
         },
         "proceedAnyway": "Proceed anyway",
         "save": "Save",
@@ -1208,6 +1208,7 @@
         "hideToken": "Hide token",
         "unhideToken": "Unhide token",
         "burnToken": "Burn token",
+        "burnNft": "Burn NFT",
         "faucetRequest": "Get {token} tokens",
         "refreshTokenMetadata": "Refresh token metadata",
         "test": "Test",
@@ -1309,6 +1310,7 @@
         "createAccount": "Create a Wallet",
         "addAWallet": "Add a wallet",
         "accountName": "Wallet name",
+        "nftName": "NFT name",
         "latestTransactions": "Latest Transactions",
         "transactions": "Transactions",
         "activity": "Activity",


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

Add an option to the confirmationPopup to require user input before confirmation can be issued by the user. This new feature is then used to require user input before burning NFTs.

## Changelog

```
- Added functionality to ConfirmationPopup.svelte
- Updated en.json strings
- Used new functionality in CollectiblesDetailsMenu for the burn nft option
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
	- [x] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
