### PR TITLE
feat-mobile: set up keyboard plugin to detect keyboard height

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -27,6 +27,7 @@
         resetRouters,
     } from './lib/routers'
     import { DashboardView, LoginRouter, OnboardingRouter } from './views'
+    import { Keyboard } from '@capacitor/keyboard'
     import { SplashScreen } from '@capacitor/splash-screen'
 
     appStage.set(AppStage[process.env.STAGE?.toUpperCase()] ?? AppStage.ALPHA)
@@ -69,8 +70,18 @@
         setPlatform(platform)
     })
 
-    $keyboardHeight = window.innerHeight / 2
-    // Press ctrl + k to toggle the fake keyboard
+    $keyboardHeight = window.screen.height / 2
+
+    void Keyboard.addListener('keyboardWillShow', (info) => {
+        // Listen for when the keyboard is about to be showed.
+        $keyboardHeight = info.keyboardHeight
+        $isKeyboardOpen = true
+    })
+    void Keyboard.addListener('keyboardWillHide', () => {
+        // Listen for when the keyboard is about to be hidden.
+        $isKeyboardOpen = false
+    })
+
     document.onkeydown = function (e): void {
         if (e.ctrlKey && e.key === 'c') {
             $appSettings.theme = $appSettings.theme === AppTheme.Light ? AppTheme.Dark : AppTheme.Light
@@ -78,9 +89,6 @@
         }
         if (e.ctrlKey && e.key === 'd') {
             $onboardingProfile.isDeveloperProfile = true
-        }
-        if (e.ctrlKey && e.key === 'k') {
-            $isKeyboardOpen = !$isKeyboardOpen
         }
     }
 </script>
@@ -100,9 +108,6 @@
 </Route>
 
 <ToastContainer />
-{#if $isKeyboardOpen}
-    <div class="keyboard" />
-{/if}
 
 <style global type="text/scss">
     @tailwind base;
@@ -172,14 +177,5 @@
     }
     img {
         -webkit-user-drag: none;
-    }
-
-    .keyboard {
-        position: absolute;
-        bottom: 0;
-        height: 50%;
-        width: 100%;
-        background-color: black;
-        z-index: 100;
     }
 </style>

--- a/packages/mobile/components/Drawer.svelte
+++ b/packages/mobile/components/Drawer.svelte
@@ -2,6 +2,7 @@
     import { Icon as IconEnum } from '@lib/auxiliary/icon'
     import { Icon, Text, TextType } from 'shared/components'
     import { fade, fly } from 'svelte/transition'
+    import { isKeyboardOpen, keyboardHeight } from '../lib/auxiliary/keyboard'
     import { DRAWER_IN_ANIMATION_DURATION_MS, DRAWER_OUT_ANIMATION_DURATION_MS } from '../lib/contexts/dashboard'
 
     export let onClose: () => unknown = () => {}
@@ -16,8 +17,11 @@
     let panelHeight = 0
     let panelWidth = 0
     let touchStart = 0
+    let drawer: HTMLDivElement
 
     const directon = enterFromSide ? { x: -100 } : { y: 100 }
+
+    $: $isKeyboardOpen, updateFooterMargin()
 
     function onTouchStart(event): void {
         moving = true
@@ -42,10 +46,21 @@
             position = 0
         }
     }
+
+    function updateFooterMargin(): void {
+        const footer = drawer?.querySelector<HTMLElement>('.drawer-footer')
+        if (footer) {
+            if ($isKeyboardOpen) {
+                footer.style.setProperty('margin-bottom', `${$keyboardHeight}px`)
+            } else {
+                footer.style.removeProperty('margin-bottom')
+            }
+        }
+    }
 </script>
 
 <svelte:window on:touchend={onTouchEnd} on:touchmove={onTouchMove} />
-<drawer class="fixed top-0 left-0 z-30 w-screen h-screen z-40">
+<drawer class="fixed top-0 left-0 z-30 w-screen h-screen z-40" bind:this={drawer}>
     <overlay
         in:fade|local={{ duration: DRAWER_IN_ANIMATION_DURATION_MS }}
         out:fade|local={{ duration: DRAWER_OUT_ANIMATION_DURATION_MS }}

--- a/packages/mobile/components/OnboardingLayout.svelte
+++ b/packages/mobile/components/OnboardingLayout.svelte
@@ -1,5 +1,6 @@
 <script lang="typescript">
     import { Animation, Icon, Text, TextType } from 'shared/components'
+    import { Icon as IconType } from '@lib/auxiliary/icon'
     import { isKeyboardOpen, keyboardHeight } from '../lib/auxiliary/keyboard'
 
     export let allowBack = true
@@ -24,7 +25,7 @@
         {#if allowBack}
             <button on:click={onBackClick} class="absolute left-0" disabled={busy}>
                 <Icon
-                    icon="arrow-left"
+                    icon={IconType.ArrowLeft}
                     classes={busy ? 'pointer-events-none text-gray-500' : 'cursor-pointer text-blue-500'}
                 />
             </button>

--- a/packages/mobile/components/StrongholdUnlock.svelte
+++ b/packages/mobile/components/StrongholdUnlock.svelte
@@ -48,7 +48,7 @@
         placeholder={localize('general.password')}
         autofocus
     />
-    <div 
+    <div
         style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}
         class="flex flex-row justify-between w-full space-x-4"
     >

--- a/packages/mobile/components/StrongholdUnlock.svelte
+++ b/packages/mobile/components/StrongholdUnlock.svelte
@@ -2,6 +2,7 @@
     import { localize } from '@core/i18n'
     import { unlockStronghold } from '@core/profile'
     import { Button, HTMLButtonType, PasswordInput, Text } from 'shared/components'
+    import { isKeyboardOpen, keyboardHeight } from '../lib/auxiliary/keyboard'
 
     export let busyMessage: string = ''
 
@@ -47,7 +48,10 @@
         placeholder={localize('general.password')}
         autofocus
     />
-    <div class="flex flex-row justify-between w-full space-x-4">
+    <div 
+        style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}
+        class="flex flex-row justify-between w-full space-x-4"
+    >
         <Button outline classes="w-1/2" onClick={handleCancelClick} disabled={isBusy}>
             {localize('actions.cancel')}
         </Button>

--- a/packages/mobile/views/dashboard/drawers/account-switcher/views/CreateAccount.svelte
+++ b/packages/mobile/views/dashboard/drawers/account-switcher/views/CreateAccount.svelte
@@ -6,8 +6,7 @@
     import { onMount } from 'svelte'
     import { ColorPicker } from '../../../../../components'
     import { handleError } from '@core/error/handlers/handleError'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
-    
+
     export let accountAlias: string = ''
     export let color: string = getRandomAccountColor()
     export let isBusy: boolean = false
@@ -66,7 +65,7 @@
             <ColorPicker title={localize('general.accountColor')} bind:active={color} classes="mb-4" />
         </div>
     </div>
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`} class="flex flex-row justify-between px-2">
+    <div class="drawer-footer flex flex-row justify-between px-2">
         <Button outline classes="-mx-2 w-1/2" onClick={handleCancelClick} disabled={isBusy}>
             {localize('actions.cancel')}
         </Button>

--- a/packages/mobile/views/dashboard/drawers/account-switcher/views/CreateAccount.svelte
+++ b/packages/mobile/views/dashboard/drawers/account-switcher/views/CreateAccount.svelte
@@ -6,7 +6,8 @@
     import { onMount } from 'svelte'
     import { ColorPicker } from '../../../../../components'
     import { handleError } from '@core/error/handlers/handleError'
-
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
+    
     export let accountAlias: string = ''
     export let color: string = getRandomAccountColor()
     export let isBusy: boolean = false
@@ -65,7 +66,7 @@
             <ColorPicker title={localize('general.accountColor')} bind:active={color} classes="mb-4" />
         </div>
     </div>
-    <div class="flex flex-row justify-between px-2">
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`} class="flex flex-row justify-between px-2">
         <Button outline classes="-mx-2 w-1/2" onClick={handleCancelClick} disabled={isBusy}>
             {localize('actions.cancel')}
         </Button>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangePasswordView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangePasswordView.svelte
@@ -3,8 +3,7 @@
     import { MAX_STRONGHOLD_PASSWORD_LENGTH } from '@core/profile'
     import { changePasswordAndUnlockStronghold } from '@core/profile-manager'
     import { PASSWORD_REASON_MAP } from '@core/stronghold'
-    import { Button, ButtonSize, PasswordInput, Text, TextType } from 'shared/components'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../../../lib/auxiliary/keyboard'
+    import { Button, PasswordInput, Text, TextType } from 'shared/components'
     import zxcvbn from 'zxcvbn'
 
     let startOfPasswordChange: number
@@ -127,9 +126,9 @@
             submitHandler={isPasswordValid}
         />
     </div>
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+    <div class="drawer-footer">
         <Button
-            classes="w-full"    
+            classes="w-full"
             disabled={!currentPassword || !newPassword || !confirmedPassword || busy}
             onClick={changePassword}
         >

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangePasswordView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangePasswordView.svelte
@@ -4,6 +4,7 @@
     import { changePasswordAndUnlockStronghold } from '@core/profile-manager'
     import { PASSWORD_REASON_MAP } from '@core/stronghold'
     import { Button, ButtonSize, PasswordInput, Text, TextType } from 'shared/components'
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../../../lib/auxiliary/keyboard'
     import zxcvbn from 'zxcvbn'
 
     let startOfPasswordChange: number
@@ -126,11 +127,13 @@
             submitHandler={isPasswordValid}
         />
     </div>
-    <Button
-        size={ButtonSize.Medium}
-        disabled={!currentPassword || !newPassword || !confirmedPassword || busy}
-        onClick={changePassword}
-    >
-        {localize('views.settings.changePassword.title')}
-    </Button>
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+        <Button
+            classes="w-full"    
+            disabled={!currentPassword || !newPassword || !confirmedPassword || busy}
+            onClick={changePassword}
+        >
+            {localize('views.settings.changePassword.title')}
+        </Button>
+    </div>
 </div>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangeProfileNameView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangeProfileNameView.svelte
@@ -3,6 +3,7 @@
     import { localize } from '@core/i18n'
     import { activeProfile, updateActiveProfile, validateProfileName } from '@core/profile'
     import { Button, ButtonSize, HTMLButtonType, Input, Text, TextType } from 'shared/components'
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../../../lib/auxiliary/keyboard'
 
     let newName = $activeProfile?.name
     let error = ''
@@ -42,7 +43,10 @@
         </Text>
         <Input {error} placeholder={$activeProfile?.name} bind:value={newName} />
     </div>
-    <Button size={ButtonSize.Medium} type={HTMLButtonType.Submit} {disabled}>
-        {localize('views.settings.changeProfileName.title')}
-    </Button>
+
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+        <Button classes="w-full" type={HTMLButtonType.Submit} {disabled}>
+            {localize('views.settings.changeProfileName.title')}
+        </Button>
+    </div>
 </form>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangeProfileNameView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ChangeProfileNameView.svelte
@@ -2,8 +2,7 @@
     import { showAppNotification } from '@auxiliary/notification'
     import { localize } from '@core/i18n'
     import { activeProfile, updateActiveProfile, validateProfileName } from '@core/profile'
-    import { Button, ButtonSize, HTMLButtonType, Input, Text, TextType } from 'shared/components'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../../../lib/auxiliary/keyboard'
+    import { Button, HTMLButtonType, Input, Text, TextType } from 'shared/components'
 
     let newName = $activeProfile?.name
     let error = ''
@@ -44,7 +43,7 @@
         <Input {error} placeholder={$activeProfile?.name} bind:value={newName} />
     </div>
 
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+    <div class="drawer-footer">
         <Button classes="w-full" type={HTMLButtonType.Submit} {disabled}>
             {localize('views.settings.changeProfileName.title')}
         </Button>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/DeleteProfileView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/DeleteProfileView.svelte
@@ -4,7 +4,7 @@
     import { isSoftwareProfile } from '@core/profile'
     import { setStrongholdPassword } from '@core/profile-manager'
     import { Button, ButtonSize, ButtonVariant, PasswordInput, Text, TextType } from 'shared/components'
-
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../../../lib/auxiliary/keyboard'
     let isBusy = false
     let error = ''
     let password: string
@@ -41,14 +41,15 @@
             />
         {/if}
     </div>
-    <Button
-        disabled={(!password && $isSoftwareProfile) || isBusy}
-        size={ButtonSize.Medium}
-        classes="w-full"
-        onClick={handleDeleteClick}
-        variant={ButtonVariant.Warning}
-        {isBusy}
-    >
-        {localize('actions.delete')}
-    </Button>
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+        <Button
+            disabled={(!password && $isSoftwareProfile) || isBusy}
+            classes="w-full"
+            onClick={handleDeleteClick}
+            variant={ButtonVariant.Warning}
+            {isBusy}
+        >
+            {localize('actions.delete')}
+        </Button>
+    </div>
 </div>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/DeleteProfileView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/DeleteProfileView.svelte
@@ -3,8 +3,8 @@
     import { localize } from '@core/i18n'
     import { isSoftwareProfile } from '@core/profile'
     import { setStrongholdPassword } from '@core/profile-manager'
-    import { Button, ButtonSize, ButtonVariant, PasswordInput, Text, TextType } from 'shared/components'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../../../lib/auxiliary/keyboard'
+    import { Button, ButtonVariant, PasswordInput, Text, TextType } from 'shared/components'
+
     let isBusy = false
     let error = ''
     let password: string
@@ -41,7 +41,7 @@
             />
         {/if}
     </div>
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+    <div class="drawer-footer">
         <Button
             disabled={(!password && $isSoftwareProfile) || isBusy}
             classes="w-full"

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/DiagnosticsView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/DiagnosticsView.svelte
@@ -3,7 +3,7 @@
     import { localize } from '@core/i18n'
     import { activeProfile } from '@core/profile'
     import { setClipboard } from '@core/utils'
-    import { Button, ButtonSize, Text, TextType } from 'shared/components'
+    import { Button, Text, TextType } from 'shared/components'
     import { onMount } from 'svelte'
 
     let contentApp = ''
@@ -48,5 +48,5 @@
         <Text type={TextType.pre} secondary>{contentApp}</Text>
         <Text type={TextType.pre} secondary>{contentSystem}</Text>
     </div>
-    <Button size={ButtonSize.Medium} classes="w-full" onClick={handleCopyClick}>{localize('actions.copy')}</Button>
+    <Button classes="w-full" onClick={handleCopyClick}>{localize('actions.copy')}</Button>
 </div>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ErrorLogView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/ErrorLogView.svelte
@@ -2,7 +2,7 @@
     import { errorLog } from '@core/error'
     import { localize } from '@core/i18n'
     import { setClipboard } from '@core/utils'
-    import { Button, ButtonSize, Text, TextType } from 'shared/components'
+    import { Button, Text, TextType } from 'shared/components'
 
     function handleClearClick(): void {
         errorLog.set([])
@@ -38,11 +38,11 @@
         {/if}
     </div>
     {#if $errorLog.length > 0}
-        <div class="flex w-full justify-center space-x-4">
-            <Button size={ButtonSize.Medium} classes="w-full" onClick={handleClearClick}>
+        <div class="flex flex-col space-y-4 w-full">
+            <Button outline classes="w-full" onClick={handleClearClick}>
                 {localize('actions.clear')}
             </Button>
-            <Button size={ButtonSize.Medium} classes="w-full" onClick={handleCopyClick}>
+            <Button classes="w-full" onClick={handleCopyClick}>
                 {localize('actions.copy')}
             </Button>
         </div>

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/WalletFinderView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/WalletFinderView.svelte
@@ -20,7 +20,7 @@
         generateAndStoreActivitiesForAllAccounts,
         refreshAccountAssetsForActiveProfile,
     } from '@core/wallet'
-    import { Button, ButtonSize, KeyValueBox, Text, TextHint, TextType } from 'shared/components'
+    import { Button, KeyValueBox, Text, TextHint, TextType } from 'shared/components'
     import { onDestroy } from 'svelte'
     import { settingsRouter } from '../../../../../../../lib/routers'
 
@@ -124,7 +124,6 @@
     </div>
     <Button
         classes="w-full"
-        size={ButtonSize.Medium}
         onClick={handleFindBalances}
         disabled={isBusy}
         {isBusy}

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/networkConfiguration/views/NetworkConfigurationInitNodeInfoView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/networkConfiguration/views/NetworkConfigurationInitNodeInfoView.svelte
@@ -4,7 +4,7 @@
     import { INode, INodeInfo } from '@core/network'
     import { getNodeInfo } from '@core/profile-manager'
     import { resolveObjectPath, setClipboard } from '@core/utils'
-    import { Button, ButtonSize, Checkbox, CopyableBox, FontWeight, Spinner, Text, TextType } from 'shared/components'
+    import { Button, Checkbox, CopyableBox, FontWeight, Spinner, Text, TextType } from 'shared/components'
     import { onMount } from 'svelte'
 
     enum NodeInfoTab {
@@ -157,7 +157,6 @@
             isBusy={!nodeInfo || !nodeInfoTab}
             disabled={!nodeInfo}
             classes="w-full"
-            size={ButtonSize.Medium}
             outline
             onClick={handleCopyAllInformationClick}
         >

--- a/packages/mobile/views/dashboard/drawers/profile/views/settings/views/networkConfiguration/views/NetworkConfigurationInitView.svelte
+++ b/packages/mobile/views/dashboard/drawers/profile/views/settings/views/networkConfiguration/views/NetworkConfigurationInitView.svelte
@@ -11,7 +11,7 @@
         nodeInfo,
     } from '@core/network'
     import { activeProfile } from '@core/profile'
-    import { Button, ButtonSize, HR, Text, TextType } from 'shared/components'
+    import { Button, HR, Text, TextType } from 'shared/components'
     import { NodeListTable } from '../../../../../../../../../components'
     import { networkConfigurationSettingsRouter } from '../../../../../../../../../lib/routers'
 
@@ -62,11 +62,11 @@
     </div>
     <div class="flex flex-col space-y-4 w-full">
         {#if networkType !== NetworkType.PrivateNet}
-            <Button outline size={ButtonSize.Medium} classes="w-full" onClick={addOfficialNodesToClientOptions}>
+            <Button outline classes="w-full" onClick={addOfficialNodesToClientOptions}>
                 {localize('actions.addOfficialNodes')}
             </Button>
         {/if}
-        <Button inlineStyle="min-width: 156px;" size={ButtonSize.Medium} classes="w-full" onClick={handleAddNodeClick}>
+        <Button inlineStyle="min-width: 156px;" classes="w-full" onClick={handleAddNodeClick}>
             {localize('actions.addNode')}
         </Button>
     </div>

--- a/packages/mobile/views/dashboard/drawers/send/views/AmountView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/AmountView.svelte
@@ -20,6 +20,7 @@
     import { getAssetById } from '@core/wallet'
     import { TokenUnitSwapper, TokenWithMax } from '../../../../../components'
     import { sendRouter } from '../../../../../lib/routers'
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
 
     let amount: string
     let rawAmount: string
@@ -136,7 +137,10 @@
         </div>
         <Text color="gray-600" darkColor="gray-500" fontSize="xs">{formatCurrency(marketAmount) ?? ''}</Text>
     </div>
-    <div class="flex flex-col space-y-8 w-full">
+    <div 
+        style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}
+        class="flex flex-col space-y-8 w-full"
+    >
         {#if $newTransactionDetails?.type === NewTransactionType.TokenTransfer}
             <HR overrideColor classes="border-gray-200 dark:border-gray-700" />
             <TokenWithMax {asset} onMaxClick={onClickAvailableBalance} />

--- a/packages/mobile/views/dashboard/drawers/send/views/AmountView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/AmountView.svelte
@@ -20,7 +20,6 @@
     import { getAssetById } from '@core/wallet'
     import { TokenUnitSwapper, TokenWithMax } from '../../../../../components'
     import { sendRouter } from '../../../../../lib/routers'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
 
     let amount: string
     let rawAmount: string
@@ -137,7 +136,7 @@
         </div>
         <Text color="gray-600" darkColor="gray-500" fontSize="xs">{formatCurrency(marketAmount) ?? ''}</Text>
     </div>
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`} class="flex flex-col space-y-8 w-full">
+    <div class="drawer-footer flex flex-col space-y-8 w-full">
         {#if $newTransactionDetails?.type === NewTransactionType.TokenTransfer}
             <HR overrideColor classes="border-gray-200 dark:border-gray-700" />
             <TokenWithMax {asset} onMaxClick={onClickAvailableBalance} />

--- a/packages/mobile/views/dashboard/drawers/send/views/AmountView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/AmountView.svelte
@@ -137,10 +137,7 @@
         </div>
         <Text color="gray-600" darkColor="gray-500" fontSize="xs">{formatCurrency(marketAmount) ?? ''}</Text>
     </div>
-    <div 
-        style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}
-        class="flex flex-col space-y-8 w-full"
-    >
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`} class="flex flex-col space-y-8 w-full">
         {#if $newTransactionDetails?.type === NewTransactionType.TokenTransfer}
             <HR overrideColor classes="border-gray-200 dark:border-gray-700" />
             <TokenWithMax {asset} onMaxClick={onClickAvailableBalance} />

--- a/packages/mobile/views/dashboard/drawers/send/views/RecipientView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/RecipientView.svelte
@@ -82,12 +82,7 @@
         {/each}
     </div>
     <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
-        <Button 
-            disabled={!!recipientValidationError} 
-            outline 
-            classes="w-full" 
-            onClick={onContinueClick}
-        >
+        <Button disabled={!!recipientValidationError} outline classes="w-full" onClick={onContinueClick}>
             {recipientValidationError ?? localize('actions.continue')}
         </Button>
     </div>

--- a/packages/mobile/views/dashboard/drawers/send/views/RecipientView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/RecipientView.svelte
@@ -9,6 +9,7 @@
     import { onMount } from 'svelte'
     import { RecipientInput } from '../../../../../components'
     import { sendRouter } from '../../../../../lib/routers'
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
 
     let recipient: IAddressSubject | IAccountSubject
     let recipientValidationError: string
@@ -80,7 +81,14 @@
             </button>
         {/each}
     </div>
-    <Button disabled={!!recipientValidationError} outline classes="w-full" onClick={onContinueClick}>
-        {recipientValidationError ?? localize('actions.continue')}
-    </Button>
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+        <Button 
+            disabled={!!recipientValidationError} 
+            outline 
+            classes="w-full" 
+            onClick={onContinueClick}
+        >
+            {recipientValidationError ?? localize('actions.continue')}
+        </Button>
+    </div>
 </div>

--- a/packages/mobile/views/dashboard/drawers/send/views/RecipientView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/RecipientView.svelte
@@ -9,7 +9,6 @@
     import { onMount } from 'svelte'
     import { RecipientInput } from '../../../../../components'
     import { sendRouter } from '../../../../../lib/routers'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
 
     let recipient: IAddressSubject | IAccountSubject
     let recipientValidationError: string
@@ -81,7 +80,7 @@
             </button>
         {/each}
     </div>
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+    <div class="drawer-footer">
         <Button disabled={!!recipientValidationError} outline classes="w-full" onClick={onContinueClick}>
             {recipientValidationError ?? localize('actions.continue')}
         </Button>

--- a/packages/mobile/views/dashboard/drawers/send/views/ReferenceView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/ReferenceView.svelte
@@ -5,7 +5,6 @@
     import { Button, FontWeight, TextInput } from 'shared/components'
     import { onMount } from 'svelte'
     import { sendRouter } from '../../../../../lib/routers'
-    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
 
     let metadata, tag: string
     let error: string = undefined
@@ -55,7 +54,7 @@
             />
         </div>
     </div>
-    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+    <div class="drawer-footer">
         <Button onClick={onContinueClick} classes="w-full" disabled={!!error}>
             {error ?? localize('actions.continue')}
         </Button>

--- a/packages/mobile/views/dashboard/drawers/send/views/ReferenceView.svelte
+++ b/packages/mobile/views/dashboard/drawers/send/views/ReferenceView.svelte
@@ -5,6 +5,7 @@
     import { Button, FontWeight, TextInput } from 'shared/components'
     import { onMount } from 'svelte'
     import { sendRouter } from '../../../../../lib/routers'
+    import { isKeyboardOpen, keyboardHeight } from '../../../../../lib/auxiliary/keyboard'
 
     let metadata, tag: string
     let error: string = undefined
@@ -54,7 +55,9 @@
             />
         </div>
     </div>
-    <Button onClick={onContinueClick} classes="w-full" disabled={!!error}>
-        {error ?? localize('actions.continue')}
-    </Button>
+    <div style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}>
+        <Button onClick={onContinueClick} classes="w-full" disabled={!!error}>
+            {error ?? localize('actions.continue')}
+        </Button>
+    </div>
 </div>

--- a/packages/mobile/views/onboarding/views/profile-setup/views/EnterNameView.svelte
+++ b/packages/mobile/views/onboarding/views/profile-setup/views/EnterNameView.svelte
@@ -56,7 +56,7 @@
     })
 </script>
 
-<OnboardingLayout {onBackClick} {title} animation="profile-desktop">
+<OnboardingLayout {onBackClick} {title}>
     <div slot="content">
         <Text type={TextType.p} secondary classes="mb-4"
             >{localize('views.onboarding.profileSetup.enterName.body1')}</Text

--- a/packages/mobile/views/onboarding/views/storage-protection-setup/views/SetupPinProtectionView.svelte
+++ b/packages/mobile/views/onboarding/views/storage-protection-setup/views/SetupPinProtectionView.svelte
@@ -94,7 +94,7 @@
     })
 </script>
 
-<OnboardingLayout {onBackClick} {busy} {title} animation="pin-desktop">
+<OnboardingLayout {onBackClick} {busy} {title}>
     <div slot="content">
         <div class="flex flex-col">
             <Text type={TextType.p} secondary classes="mb-4"

--- a/packages/mobile/views/onboarding/views/stronghold-setup/views/SetupStrongholdPasswordView.svelte
+++ b/packages/mobile/views/onboarding/views/stronghold-setup/views/SetupStrongholdPasswordView.svelte
@@ -97,7 +97,7 @@
     } // zxcvbn lib recommends to not validate long passwords because of performance issues https://github.com/dropbox/zxcvbn#user-content-performance
 </script>
 
-<OnboardingLayout {onBackClick} {busy} {title} animation="password-desktop">
+<OnboardingLayout {onBackClick} {busy} {title}>
     <div slot="content" class="mb-5">
         <form on:submit|preventDefault={onContinueClick} id="password-form">
             <Text type={TextType.p} secondary


### PR DESCRIPTION
## Summary

This PR adds listeners of the @capacitor/keyboard plugin to detect the keyboard height like in the chrysalis version.
Some of the onboarding animations have been removed also, since they cause strange UI behaviour when the keyboard opens automatically. (e.g. when the view changes from EnterName -> EnterPassword)

## Changelog

```
- Adds keyboard listeners to App.svelte
- removes animations from EnterName, SetupStrongholdPassword and SetupPinProtection view.
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [x] iOS
	- [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
