### PR TITLE
fix: add hint if no voting power

### DIFF
--- a/packages/shared/components/popups/VoteForProposalPopup.svelte
+++ b/packages/shared/components/popups/VoteForProposalPopup.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-    import { Button, Text, FontWeight, TextType, KeyValueBox } from 'shared/components'
+    import { Button, Text, FontWeight, TextHint, TextType, KeyValueBox } from 'shared/components'
     import { HTMLButtonType } from 'shared/components/enums'
     import { selectedAccount } from '@core/account/stores'
     import { localize } from '@core/i18n'
@@ -46,6 +46,9 @@
     </Text>
     <div class="space-y-4">
         <KeyValueBox keyText={localize('popups.voteForProposal.key')} valueText={formattedVotingPower} />
+        {#if !hasVotingPower}
+            <TextHint danger text={localize('popups.voteForProposal.noVotingPower')} />
+        {/if}
     </div>
     <popup-buttons class="flex flex-row flex-nowrap w-full space-x-4">
         <Button classes="w-full" outline onClick={closePopup}>{localize('actions.cancel')}</Button>

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1019,7 +1019,6 @@
             "title": "Vote for proposal",
             "body": "You're about to vote for {proposal} proposal.",
             "key": "Your voting power",
-            "hint": "Please note that your voting power depends on the amount of funds you hold in your wallet. The more funds you hold, the higher your voting power is.",
             "noVotingPower": "You do not have any voting power. Please increase your voting power from the Governance dashboard."
         },
         "revote": {


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing __what__ they are and __why__ they were made.

If the user has no voting power, they are not warned or hinted that they need to increase it. 

## Changelog

```
- Add text hint back
- Remove unneeded locale
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
	- [ ] MacOS
	- [x] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

Try voting with no voting power and some voting power.

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation