### PR TITLE
fix: open locahost in electron instead of external browser

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -179,12 +179,20 @@ if (app.isPackaged) {
  * Handles url navigation events
  */
 const handleNavigation = (e, url) => {
-    e.preventDefault()
+    if (url === 'http://localhost:8080/') {
+        // if localhost would be opened on the build versions, we need to block it to prevent errors
+        if (app.isPackaged) {
+            e.preventDefault()
+        }
+        // else: re-open localhost in electron for hot reload
+    } else {
+        e.preventDefault()
 
-    try {
-        shell.openExternal(url)
-    } catch (err) {
-        console.error(err)
+        try {
+            shell.openExternal(url)
+        } catch (err) {
+            console.error(err)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

When we change something in a `.ts` file. webpack tries to refresh the browser, there `localhost` gets opened.
This PR includes a fix such that locahost doesnt get opened externally, but internally. Currently something on the walletrs side crashes, so a `ctrl`+`r` is necessary. 

If we're on a prod build, every localhost gets blocked immediatly to prevent errors



## Changelog

```
- block `localhost` on prod builds
- use default behavior for `localhost` in development
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
