### PR TITLE
enhancement: loading state on confirmation popup

### DIFF
--- a/packages/shared/components/modals/CollectibleDetailsMenu.svelte
+++ b/packages/shared/components/modals/CollectibleDetailsMenu.svelte
@@ -26,8 +26,8 @@
                 hint: localize('actions.confirmNftBurn.hint'),
                 warning: true,
                 confirmText: localize('actions.burnToken'),
-                onConfirm: () => {
-                    checkActiveProfileAuth(
+                onConfirm: async () => {
+                    await checkActiveProfileAuth(
                         async () => {
                             await burnNft(nft.id)
                             $collectiblesRouter.goTo(CollectiblesRoute.Gallery)

--- a/packages/shared/components/popups/BurnNativeTokensConfirmationPopup.svelte
+++ b/packages/shared/components/popups/BurnNativeTokensConfirmationPopup.svelte
@@ -4,9 +4,13 @@
     import { closePopup, openPopup } from '@auxiliary/popup'
     import { burnAsset, formatTokenAmountBestMatch, IAsset } from '@core/wallet'
     import { checkActiveProfileAuth } from '@core/profile'
+    import { handleError } from '@core/error/handlers'
+    import { onMount } from 'svelte'
+    import { selectedAccount } from '@core/account'
 
     export let asset: IAsset
     export let rawAmount: string
+    export let _onMount: (..._: any[]) => Promise<void> = async () => {}
 
     $: formattedAmount = formatTokenAmountBestMatch(Number(rawAmount), asset.metadata)
 
@@ -17,16 +21,27 @@
         })
     }
 
-    function confirmClick(): void {
+    async function confirmClick(): Promise<void> {
         try {
-            checkActiveProfileAuth(async () => {
-                await burnAsset(asset.id, rawAmount)
-                closePopup()
-            })
+            await checkActiveProfileAuth(
+                async () => {
+                    await burnAsset(asset.id, rawAmount)
+                    closePopup()
+                },
+                { stronghold: true }
+            )
         } catch (err) {
             console.error(err)
         }
     }
+
+    onMount(async () => {
+        try {
+            await _onMount()
+        } catch (err) {
+            handleError(err)
+        }
+    })
 </script>
 
 <div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0">
@@ -44,7 +59,12 @@
     </div>
     <popup-buttons class="flex flex-row flex-nowrap w-full space-x-4">
         <Button classes="w-full" outline onClick={onBack}>{localize('actions.back')}</Button>
-        <Button classes="w-full" variant={ButtonVariant.Warning} onClick={confirmClick}>
+        <Button
+            classes="w-full"
+            variant={ButtonVariant.Warning}
+            isBusy={$selectedAccount.isTransferring}
+            onClick={confirmClick}
+        >
             {localize('actions.burnToken')}
         </Button>
     </popup-buttons>

--- a/packages/shared/components/popups/ConfirmationPopup.svelte
+++ b/packages/shared/components/popups/ConfirmationPopup.svelte
@@ -2,6 +2,9 @@
     import { Button, Text, TextHint, FontWeight, TextType, ButtonVariant } from 'shared/components'
     import { localize } from '@core/i18n'
     import { closePopup } from '@auxiliary/popup'
+    import { handleError } from '@core/error/handlers'
+    import { onMount } from 'svelte'
+    import { selectedAccount } from '@core/account'
 
     export let title: string
     export let description: string = ''
@@ -13,6 +16,7 @@
     export let confirmText: string = localize('actions.confirm')
     export let onConfirm: () => void = undefined
     export let onCancel: () => void = undefined
+    export let _onMount: (..._: any[]) => Promise<void> = async () => {}
 
     function confirmClick(): void {
         if (onConfirm) {
@@ -29,6 +33,14 @@
             closePopup()
         }
     }
+
+    onMount(async () => {
+        try {
+            await _onMount()
+        } catch (err) {
+            handleError(err)
+        }
+    })
 </script>
 
 <div class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0">
@@ -48,6 +60,8 @@
         <Button
             classes="w-full"
             variant={warning || danger ? ButtonVariant.Warning : ButtonVariant.Primary}
+            disabled={$selectedAccount.isTransferring}
+            isBusy={$selectedAccount.isTransferring}
             onClick={confirmClick}
         >
             {confirmText}

--- a/packages/shared/components/popups/StorageDepositBreakdownPopup.svelte
+++ b/packages/shared/components/popups/StorageDepositBreakdownPopup.svelte
@@ -45,8 +45,8 @@
                 description: localize('popups.minimizeStorageDeposit.description'),
                 confirmText: localize('popups.minimizeStorageDeposit.confirmButton'),
                 info: true,
-                onConfirm: () => {
-                    checkActiveProfileAuth(async () => {
+                onConfirm: async () => {
+                    await checkActiveProfileAuth(async () => {
                         await consolidateOutputs()
                         closePopup()
                     })

--- a/packages/shared/components/popups/StorageDepositBreakdownPopup.svelte
+++ b/packages/shared/components/popups/StorageDepositBreakdownPopup.svelte
@@ -46,10 +46,13 @@
                 confirmText: localize('popups.minimizeStorageDeposit.confirmButton'),
                 info: true,
                 onConfirm: async () => {
-                    await checkActiveProfileAuth(async () => {
-                        await consolidateOutputs()
-                        closePopup()
-                    })
+                    await checkActiveProfileAuth(
+                        async () => {
+                            await consolidateOutputs()
+                            closePopup()
+                        },
+                        { stronghold: true }
+                    )
                 },
             },
         })

--- a/packages/shared/lib/core/wallet/actions/burnAsset.ts
+++ b/packages/shared/lib/core/wallet/actions/burnAsset.ts
@@ -1,5 +1,5 @@
 import { showAppNotification } from '@auxiliary/notification'
-import { selectedAccount } from '@core/account/stores/selected-account.store'
+import { selectedAccount, updateSelectedAccount } from '@core/account/stores/selected-account.store'
 import { handleError } from '@core/error/handlers/handleError'
 import { localize } from '@core/i18n'
 import { handleLedgerError } from '@core/ledger'
@@ -13,6 +13,7 @@ export async function burnAsset(assetId: string, rawAmount: string): Promise<voi
     const account = get(selectedAccount)
     const _activeProfile = get(activeProfile)
     try {
+        updateSelectedAccount({ isTransferring: true })
         const burnTokenTransaction = await account.burnNativeToken(
             assetId,
             Converter.decimalToHex(Number(rawAmount), true)
@@ -34,5 +35,7 @@ export async function burnAsset(assetId: string, rawAmount: string): Promise<voi
         } else {
             handleError(err)
         }
+    } finally {
+        updateSelectedAccount({ isTransferring: false })
     }
 }

--- a/packages/shared/lib/core/wallet/actions/burnNft.ts
+++ b/packages/shared/lib/core/wallet/actions/burnNft.ts
@@ -1,5 +1,5 @@
 import { showAppNotification } from '@auxiliary/notification'
-import { selectedAccount } from '@core/account/stores/selected-account.store'
+import { selectedAccount, updateSelectedAccount } from '@core/account/stores/selected-account.store'
 import { handleError } from '@core/error/handlers/handleError'
 import { localize } from '@core/i18n'
 import { handleLedgerError } from '@core/ledger'
@@ -13,6 +13,7 @@ export async function burnNft(nftId: string): Promise<void> {
     const account = get(selectedAccount)
     const _activeProfile = get(activeProfile)
     try {
+        updateSelectedAccount({ isTransferring: true })
         const burnNftTransaction = await account.burnNft(nftId)
 
         // Generate Activity
@@ -35,5 +36,7 @@ export async function burnNft(nftId: string): Promise<void> {
             handleError(err)
         }
         throw err
+    } finally {
+        updateSelectedAccount({ isTransferring: false })
     }
 }

--- a/packages/shared/lib/core/wallet/actions/consolidateOutputs.ts
+++ b/packages/shared/lib/core/wallet/actions/consolidateOutputs.ts
@@ -1,4 +1,4 @@
-import { selectedAccount } from '@core/account'
+import { selectedAccount, updateSelectedAccount } from '@core/account'
 import { handleError } from '@core/error/handlers/handleError'
 import { handleLedgerError } from '@core/ledger'
 import { activeProfile, ProfileType } from '@core/profile'
@@ -10,6 +10,8 @@ export async function consolidateOutputs(): Promise<void> {
     const account = get(selectedAccount)
     const _activeProfile = get(activeProfile)
     try {
+        updateSelectedAccount({ isTransferring: true })
+
         const transaction = await account.consolidateOutputs(false, 2)
         const processedTransaction = await preprocessTransaction(transaction, account)
         const activities = generateActivities(processedTransaction, account)
@@ -20,5 +22,7 @@ export async function consolidateOutputs(): Promise<void> {
         } else {
             handleError(err)
         }
+    } finally {
+        updateSelectedAccount({ isTransferring: false })
     }
 }


### PR DESCRIPTION
## Summary

This PR includes the adding of loading states to various confirmation popups

## Changelog

```
- add loading state to burn nft popup
- add loading state to burn native token popup
- add loading state to consolidation popup
```

## Relevant Issues
Closes #5648 
Closes #5647 
Closes #5646 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

- __Desktop__
	- [ ] MacOS
	- [ ] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to __test and verify__ that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or modified tests that prove my changes work as intended
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have verified that my latest changes pass CI workflows for testing and linting
- [ ] I have made corresponding changes to the documentation
