### PR TITLE
feat: add location where profiles are stored to handbook

### DIFF
--- a/docs/guides/developer-tips.md
+++ b/docs/guides/developer-tips.md
@@ -101,3 +101,15 @@ Wallet.initLogger({
 ```
 
 in `desktop/electron/preload.js` after `const Wallet = binding`. Debug logs will then be added to the `wallet.log` file in the same location where Firefly or the Electron / Capacitor development instance is installed.
+
+## Resetting Firefly 
+
+### Desktop
+
+If you want to reset Firefly your profiles are stored in the following places on the different OS'es for the official release:
+
+- Windows: `%APPDATA%\Roaming\Firefly\__storage__/`
+- MacOS: `$HOME/Library/Application\ Support/Firefly/__storage/`
+- Linux: `~/.config/Firefly/__storage__/`
+
+For developer/alpha/beta builds you have to look for `Electron`/`'Firefly Shimmer - Alpha'`/`'Firefly Shimmer - Beta'` respectively.


### PR DESCRIPTION
## Summary

Added section on where profile information is stored to handbook.

...

## Changelog

```
- Added information to handbook on where profiles are stored
```

## Relevant Issues


## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
