### PR TITLE
enhancement: event phases disabled vote

### DIFF
--- a/packages/desktop/views/dashboard/governance/views/DetailsView.svelte
+++ b/packages/desktop/views/dashboard/governance/views/DetailsView.svelte
@@ -13,6 +13,7 @@
         ProposalStatusPill,
         Text,
         TextType,
+        TextHint,
     } from '@ui'
     import { openPopup } from '@auxiliary/popup/actions'
     import { activeProfileId } from '@core/profile/stores'
@@ -39,7 +40,7 @@
     let votingPayload: VotingEventPayload
     let totalVotes = 0
     let hasMounted = false
-    let voteButtonText = localize('actions.vote')
+    let textHintString = ''
     let proposalQuestions: HTMLElement
 
     $: $selectedAccountIndex, void updateParticipationOverview()
@@ -66,7 +67,7 @@
         selectedAnswerValues?.includes(undefined)
 
     $: isTransferring = $selectedAccount?.isTransferring
-    $: proposalState, (voteButtonText = getVoteButtonText())
+    $: proposalState, (textHintString = getTextHintString())
 
     async function setVotingEventPayload(eventId: string): Promise<void> {
         const event = await getVotingEvent(eventId)
@@ -134,18 +135,14 @@
         }, 250)
     }
 
-    function getVoteButtonText(): string {
-        if ($selectedProposal?.status === ProposalStatus.Upcoming) {
-            const millis =
-                milestoneToDate(
-                    $networkStatus.currentMilestone,
-                    $selectedProposal.milestones[ProposalStatus.Commencing]
-                ).getTime() - new Date().getTime()
-            const timeString = getBestTimeDuration(millis, 'second')
-            return localize('views.governance.details.voteOpens', { values: { time: timeString } })
-        } else {
-            return localize('actions.vote')
-        }
+    function getTextHintString(): string {
+        const millis =
+            milestoneToDate(
+                $networkStatus.currentMilestone,
+                $selectedProposal.milestones[ProposalStatus.Commencing]
+            ).getTime() - new Date().getTime()
+        const timeString = getBestTimeDuration(millis, 'second')
+        return localize('views.governance.details.hintVote', { values: { time: timeString } })
     }
 
     onMount(async () => {
@@ -210,16 +207,20 @@
                 {/each}
             {/if}
         </proposal-questions>
-        <buttons-container class="flex w-full space-x-4 mt-6">
-            <Button outline classes="w-full" onClick={handleCancelClick}>{localize('actions.cancel')}</Button>
-            <Button
-                classes="w-full"
-                disabled={isVotingDisabled || isTransferring}
-                isBusy={isTransferring}
-                onClick={handleVoteClick}
-            >
-                {voteButtonText}
-            </Button>
-        </buttons-container>
+        {#if $selectedProposal?.status === ProposalStatus.Upcoming}
+            <TextHint info text={textHintString} />
+        {:else if [ProposalStatus.Commencing, ProposalStatus.Holding].includes($selectedProposal.status)}
+            <buttons-container class="flex w-full space-x-4 mt-6">
+                <Button outline classes="w-full" onClick={handleCancelClick}>{localize('actions.cancel')}</Button>
+                <Button
+                    classes="w-full"
+                    disabled={isVotingDisabled || isTransferring}
+                    isBusy={isTransferring}
+                    onClick={handleVoteClick}
+                >
+                    {localize('actions.vote')}
+                </Button>
+            </buttons-container>
+        {/if}
     </Pane>
 </div>

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -610,8 +610,8 @@
                     "eventId": "Event ID",
                     "nodeUrl": "Node URL"
                 },
-                "voteOpens": "Vote opens in {time}",
-                "fetching": "Fetching proposal data"
+                "fetching": "Fetching proposal data",
+                "hintVote": "You can not vote on a proposal that is in the announcement phase, voting will open in {time}."
             }
         }
     },


### PR DESCRIPTION
## Summary
@MyMonk089 has opened a bug report about not being able to vote in the `Announcement` phase and then @Phyloiota commented that the UI should highlight that it is not possible to vote. So the design has changed and this PR implements it.

## Changelog
```
- Removes `Cancel` and `Vote` buttons in the  `Announcement` and `Closed` phases
- Adds TextHint in `Announcement` phase
```

## Relevant Issues
closes #5628 

## Testing
### Platforms
-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist
-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
