### PR TITLE
fix: remove submission if key value box is clicked

### DIFF
--- a/packages/shared/components/atoms/boxes/CopyableBox.svelte
+++ b/packages/shared/components/atoms/boxes/CopyableBox.svelte
@@ -33,6 +33,7 @@
 
 {#if value !== null && value !== undefined}
     <button
+        type="button"
         bind:this={tooltipAnchor}
         on:click={onClick}
         class="{clearPadding ? '' : 'w-full'} {isCopyable ? 'cursor-pointer' : 'cursor-default'}"


### PR DESCRIPTION
## Summary

The Key-Value box is a specific `button` component, where we didnt set the `type` to `button`. This means, a click always dispatches the `submit` event to the parent form. 

## Changelog

```
- `type=button` to key value box
```

## Relevant Issues

Clsoes #5620 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
