### PR TITLE
fix: percentages undefined

### DIFF
--- a/packages/shared/components/ProposalQuestion.svelte
+++ b/packages/shared/components/ProposalQuestion.svelte
@@ -7,7 +7,7 @@
     import { selectedProposal } from '@contexts/governance/stores'
     import { Icon as IconEnum } from '@auxiliary/icon'
     import { Position } from './enums'
-    import { getPercentagesFromAnswerStatuses } from '@contexts/governance'
+    import { getPercentagesFromAnswerStatuses, IProposalAnswerPercentages } from '@contexts/governance'
 
     const dispatch = createEventDispatcher()
 
@@ -18,7 +18,7 @@
     export let selectedAnswerValue: number = undefined
     export let votedAnswerValue: number = undefined
 
-    let percentages: { [key: number]: string } = {}
+    let percentages: IProposalAnswerPercentages = {}
     let winnerAnswerIndex: number
 
     $: answers = [...question?.answers, { value: 0, text: 'Abstain', additionalInfo: '' }]

--- a/packages/shared/lib/contexts/governance/interfaces/index.ts
+++ b/packages/shared/lib/contexts/governance/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './organization.interface'
+export * from './proposal-answer-percentages.interface'
 export * from './proposal-filter.interface'
 export * from './proposal-state.interface'
 export * from './proposal.interface'

--- a/packages/shared/lib/contexts/governance/interfaces/proposal-answer-percentages.interface.ts
+++ b/packages/shared/lib/contexts/governance/interfaces/proposal-answer-percentages.interface.ts
@@ -1,0 +1,3 @@
+export interface IProposalAnswerPercentages {
+    [answerIndex: number]: string
+}

--- a/packages/shared/lib/contexts/governance/utils/getPercentagesFromAnswerStatuses.ts
+++ b/packages/shared/lib/contexts/governance/utils/getPercentagesFromAnswerStatuses.ts
@@ -3,7 +3,7 @@ import type { AnswerStatus } from '@iota/wallet'
 export function getPercentagesFromAnswerStatuses(answerStatuses: AnswerStatus[]): { [key: number]: string } {
     const totalVotes = answerStatuses.reduce((acc, answerStatus) => acc + answerStatus.accumulated, 0)
     if (totalVotes === 0 || Number.isNaN(totalVotes)) {
-        return
+        return {}
     }
 
     let percentages: { [key: number]: string } = {}

--- a/packages/shared/lib/contexts/governance/utils/getPercentagesFromAnswerStatuses.ts
+++ b/packages/shared/lib/contexts/governance/utils/getPercentagesFromAnswerStatuses.ts
@@ -1,4 +1,5 @@
-import type { AnswerStatus } from '@iota/wallet'
+import type { AnswerStatus } from '@iota/wallet/out/types'
+import { IProposalAnswerPercentages } from '../interfaces'
 
 export function getPercentagesFromAnswerStatuses(answerStatuses: AnswerStatus[]): { [key: number]: string } {
     const totalVotes = answerStatuses.reduce((acc, answerStatus) => acc + answerStatus.accumulated, 0)
@@ -6,7 +7,7 @@ export function getPercentagesFromAnswerStatuses(answerStatuses: AnswerStatus[])
         return {}
     }
 
-    let percentages: { [key: number]: string } = {}
+    let percentages: IProposalAnswerPercentages = {}
     answerStatuses.forEach((answerStatus) => {
         if (answerStatus.value !== undefined) {
             const divisionResult = (answerStatus.accumulated ?? 0) / totalVotes

--- a/packages/shared/lib/contexts/governance/utils/getPercentagesFromAnswerStatuses.ts
+++ b/packages/shared/lib/contexts/governance/utils/getPercentagesFromAnswerStatuses.ts
@@ -1,7 +1,7 @@
 import type { AnswerStatus } from '@iota/wallet/out/types'
 import { IProposalAnswerPercentages } from '../interfaces'
 
-export function getPercentagesFromAnswerStatuses(answerStatuses: AnswerStatus[]): { [key: number]: string } {
+export function getPercentagesFromAnswerStatuses(answerStatuses: AnswerStatus[]): IProposalAnswerPercentages {
     const totalVotes = answerStatuses.reduce((acc, answerStatus) => acc + answerStatus.accumulated, 0)
     if (totalVotes === 0 || Number.isNaN(totalVotes)) {
         return {}

--- a/packages/shared/lib/contexts/governance/utils/tests/getPercentagesFromAnswerStatuses.test.ts
+++ b/packages/shared/lib/contexts/governance/utils/tests/getPercentagesFromAnswerStatuses.test.ts
@@ -26,11 +26,11 @@ describe('File: getPercentagesFromAnswerStatuses.ts', () => {
         it('should return percentages from valid arguments', () => {
             expect(getPercentagesFromAnswerStatuses(ANSWER_STATUSES)).toEqual({ 0: '17%', 1: '33%', 2: '50%' })
         })
-        it('should return undefined from invalid arguments', () => {
-            expect(getPercentagesFromAnswerStatuses([{} as AnswerStatus])).toBeUndefined()
+        it('should return empty object from invalid arguments', () => {
+            expect(getPercentagesFromAnswerStatuses([{} as AnswerStatus])).toEqual({})
         })
-        it('should return undefined from empty arguments', () => {
-            expect(getPercentagesFromAnswerStatuses([])).toBeUndefined()
+        it('should return empty object from empty arguments', () => {
+            expect(getPercentagesFromAnswerStatuses([])).toEqual({})
         })
     })
 })


### PR DESCRIPTION
## Summary
Percentages object should never be undefined otherwise it throws an error if the variable is undefined and the code is trying to access a property from it

## Testing

### Platforms
-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist
-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
