### PR TITLE
fix: fix details view if account with proposal gets deleted

### DIFF
--- a/packages/shared/lib/contexts/governance/utils/isAnyAccountVotingForSelectedProposal.ts
+++ b/packages/shared/lib/contexts/governance/utils/isAnyAccountVotingForSelectedProposal.ts
@@ -1,11 +1,9 @@
-import { activeProfile } from '@core/profile'
+import { activeAccounts } from '@core/profile'
 import { get } from 'svelte/store'
 import { isVotingForSelectedProposal } from './isVotingForSelectedProposal'
 
 export async function isAnyAccountVotingForSelectedProposal(): Promise<boolean> {
-    const accountIndexes = Object.values(get(activeProfile)?.accountMetadata).map(
-        (accountMetadata) => accountMetadata.index
-    )
+    const accountIndexes = get(activeAccounts).map((account) => account.index)
     const isVotingPromises = accountIndexes.map(isVotingForSelectedProposal)
     const results = await Promise.all(isVotingPromises)
     return results.some((bool) => bool === true)


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/105642810/216104510-ebf491f2-a2f7-4e32-8c1b-e924b19a6988.png)

The error in the image is caused because by removing an account, it only updates the `activeAccounts` store, but not the `profile.metadata` (somehow even on loggout). Therefore, if an account had a proposal registered, and is then removed, the error `{type: "accountNotFound", text: "12"}` gets thrown

## Changelog

```
- Please write a list of changes
```

## Relevant Issues

Please list any related issues (e.g. bug, task).

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
