### PR TITLE
enhancement: show correct unit on slider min max

### DIFF
--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -119,10 +119,10 @@
             <SliderInput bind:value={amount} {max} decimals={allowedDecimals} {disabled} />
             <div class="flex flex-row justify-between">
                 <Text color="gray-800" darkColor="gray-500" fontSize="xs"
-                    >{formatTokenAmountBestMatch(0, asset?.metadata)}</Text
+                    >{formatTokenAmountDefault(0, asset?.metadata, unit)} {unit}</Text
                 >
                 <Text color="gray-800" darkColor="gray-500" fontSize="xs"
-                    >{formatTokenAmountBestMatch(availableBalance, asset?.metadata)}</Text
+                    >{formatTokenAmountDefault(availableBalance, asset?.metadata, unit)} {unit}</Text
                 >
             </div>
         </div>


### PR DESCRIPTION
## Summary

The min and max under the slider input should be in the selected unit


## Changelog

```
- update value and unit of min/max under slider input
```

## Relevant Issues

Please list any related issues (e.g. bug, task).

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick all of the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
