### PR TITLE
fix: correct name for deposit NFTs popup

### DIFF
--- a/packages/desktop/views/dashboard/collectibles/views/CollectiblesGalleryView.svelte
+++ b/packages/desktop/views/dashboard/collectibles/views/CollectiblesGalleryView.svelte
@@ -41,7 +41,7 @@
                         >{localize('views.collectibles.gallery.emptyDescription')}</Text
                     >
                 </div>
-                <ReceiveButton text={localize('actions.depositNft')} />
+                <ReceiveButton text={localize('actions.depositNft')} title={localize('actions.depositNft')} />
             </div>
         </div>
     {/if}

--- a/packages/shared/components/atoms/buttons/ReceiveButton.svelte
+++ b/packages/shared/components/atoms/buttons/ReceiveButton.svelte
@@ -3,17 +3,21 @@
     import { openPopup } from '@auxiliary/popup'
 
     export let text: string = localize('actions.receive')
+    export let title: string = localize('general.receiveFunds')
 
-    function handleReceiveClick(): void {
+    function onButtonClick(): void {
         openPopup({
             type: 'receiveAddress',
+            props: {
+                title,
+            },
         })
     }
 </script>
 
 <button
     class="action py-3 px-8 text-center rounded-lg font-medium text-14 bg-blue-500 text-white"
-    on:click={handleReceiveClick}
+    on:click={onButtonClick}
 >
     {text}
 </button>

--- a/packages/shared/components/popups/ReceiveAddressPopup.svelte
+++ b/packages/shared/components/popups/ReceiveAddressPopup.svelte
@@ -4,11 +4,13 @@
     import { localize } from '@core/i18n'
     import { selectedAccount } from '@core/account'
 
+    export let title: string = localize('general.receiveFunds')
+
     $: receiveAddress = $selectedAccount.depositAddress
 </script>
 
 <receive-details class="w-full h-full space-y-6 flex flex-auto flex-col flex-shrink-0">
-    <Text type="h3" fontWeight={FontWeight.semibold} classes="text-left">{localize('general.receiveFunds')}</Text>
+    <Text type="h3" fontWeight={FontWeight.semibold} classes="text-left">{title}</Text>
     <div class="flex w-full flex-col items-center space-y-6">
         <QR data={receiveAddress} classes="w-1/2 h-1/2" />
         <AddressBox address={receiveAddress} clearBackground isCopyable />


### PR DESCRIPTION
## Summary

Based on a discussion on Discord, I changed the name of `Receive funds` to `Deposit NFTs` on the Deposit NFTs popup.

```
- Added title prop to Receive Address popup
- Changed title of Receive Address popup
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
