### PR TITLE
fix: add selected account as a parameter in case store is cleared

### DIFF
--- a/packages/shared/components/popups/AliasConfirmationPopup.svelte
+++ b/packages/shared/components/popups/AliasConfirmationPopup.svelte
@@ -56,7 +56,7 @@
         try {
             updateSelectedAccount({ isTransferring: true })
             const transaction = await $selectedAccount.createAliasOutput()
-            await processAndAddToActivities(transaction)
+            await processAndAddToActivities(transaction, $selectedAccount)
             closePopup()
         } catch (err) {
             handleError(err)

--- a/packages/shared/components/popups/ManageVotingPowerPopup.svelte
+++ b/packages/shared/components/popups/ManageVotingPowerPopup.svelte
@@ -46,7 +46,7 @@
         try {
             await assetAmountInput?.validate(true)
 
-            const isVoting = await isSelectedAccountVoting()
+            const isVoting = isSelectedAccountVoting()
             if (amount === '0' && isVoting) {
                 openPopup({ type: 'votingPowerToZero' })
                 return

--- a/packages/shared/lib/contexts/governance/actions/setVotingPower.ts
+++ b/packages/shared/lib/contexts/governance/actions/setVotingPower.ts
@@ -31,7 +31,7 @@ export async function setVotingPower(rawAmount: string, isVoting: boolean): Prom
             const amountToDecrease = votingPower - amount
             transaction = await account.decreaseVotingPower(amountToDecrease.toString())
         }
-        await processAndAddToActivities(transaction)
+        await processAndAddToActivities(transaction, account)
     } catch (err) {
         hasToRevote.set(false)
         handleError(err)

--- a/packages/shared/lib/contexts/governance/actions/stopVotingForProposal.ts
+++ b/packages/shared/lib/contexts/governance/actions/stopVotingForProposal.ts
@@ -14,7 +14,7 @@ export async function stopVotingForProposal(eventId: string): Promise<Transactio
         setHasPendingGovernanceTransactionForAccount(account.index)
         const transaction = await account?.stopParticipating(eventId)
 
-        await processAndAddToActivities(transaction)
+        await processAndAddToActivities(transaction, account)
 
         showAppNotification({
             type: 'success',

--- a/packages/shared/lib/contexts/governance/actions/vote.ts
+++ b/packages/shared/lib/contexts/governance/actions/vote.ts
@@ -13,7 +13,7 @@ export async function vote(eventId?: string, answers?: number[]): Promise<void> 
 
         const transaction = await account.vote(eventId, answers)
 
-        await processAndAddToActivities(transaction)
+        await processAndAddToActivities(transaction, account)
 
         showAppNotification({
             type: 'success',

--- a/packages/shared/lib/core/wallet/actions/burnAsset.ts
+++ b/packages/shared/lib/core/wallet/actions/burnAsset.ts
@@ -15,7 +15,7 @@ export async function burnAsset(assetId: string, rawAmount: string): Promise<voi
             Converter.decimalToHex(Number(rawAmount), true)
         )
 
-        await processAndAddToActivities(burnTokenTransaction)
+        await processAndAddToActivities(burnTokenTransaction, account)
 
         showAppNotification({
             type: 'success',

--- a/packages/shared/lib/core/wallet/actions/burnNft.ts
+++ b/packages/shared/lib/core/wallet/actions/burnNft.ts
@@ -13,7 +13,7 @@ export async function burnNft(nftId: string): Promise<void> {
         const burnNftTransaction = await account.burnNft(nftId)
 
         // Generate Activity
-        await processAndAddToActivities(burnNftTransaction)
+        await processAndAddToActivities(burnNftTransaction, account)
 
         // Update NFT
         updateNftInAllAccountNfts(account.index, nftId, { isSpendable: false })

--- a/packages/shared/lib/core/wallet/actions/consolidateOutputs.ts
+++ b/packages/shared/lib/core/wallet/actions/consolidateOutputs.ts
@@ -9,7 +9,7 @@ export async function consolidateOutputs(): Promise<void> {
         updateSelectedAccount({ isTransferring: true })
 
         const transaction = await account.consolidateOutputs(false, 2)
-        await processAndAddToActivities(transaction)
+        await processAndAddToActivities(transaction, account)
     } catch (err) {
         handleError(err)
     } finally {

--- a/packages/shared/lib/core/wallet/actions/mintNativeToken.ts
+++ b/packages/shared/lib/core/wallet/actions/mintNativeToken.ts
@@ -37,7 +37,7 @@ export async function mintNativeToken(
         )
         addPersistedAsset(persistedAsset)
 
-        await processAndAddToActivities(mintTokenTransaction.transaction)
+        await processAndAddToActivities(mintTokenTransaction.transaction, account)
 
         showAppNotification({
             type: 'success',

--- a/packages/shared/lib/core/wallet/actions/sendOutput.ts
+++ b/packages/shared/lib/core/wallet/actions/sendOutput.ts
@@ -13,7 +13,7 @@ export async function sendOutput(output: Output): Promise<void> {
         // Reset transaction details state, since the transaction has been sent
         resetNewTokenTransactionDetails()
 
-        await processAndAddToActivities(transaction)
+        await processAndAddToActivities(transaction, account)
         updateSelectedAccount({ isTransferring: false })
         return
     } catch (err) {

--- a/packages/shared/lib/core/wallet/utils/processAndAddToActivities.ts
+++ b/packages/shared/lib/core/wallet/utils/processAndAddToActivities.ts
@@ -1,13 +1,14 @@
-import { get } from 'svelte/store'
 import type { Transaction } from '@iota/wallet/out/types'
 
-import { selectedAccount } from '@core/account/stores'
+import type { IAccountState } from '@core/account/interfaces'
 import { addActivitiesToAccountActivitiesInAllAccountActivities } from '../stores'
 
 import { generateActivities, preprocessTransaction } from '.'
 
-export async function processAndAddToActivities(transaction: Transaction): Promise<void> {
-    const account = get(selectedAccount)
+// We pass the account as a parameter,
+// because logging out while transaction is pending,
+// clears the the selectedAccount store at this point.
+export async function processAndAddToActivities(transaction: Transaction, account: IAccountState): Promise<void> {
     const preprocessedTransaction = await preprocessTransaction(transaction, account)
     const activities = generateActivities(preprocessedTransaction, account)
     addActivitiesToAccountActivitiesInAllAccountActivities(account.index, activities)


### PR DESCRIPTION
## Summary

Fixes an issue where we logout while awaiting the sending of a transaction from wallet.rs. This resulted in an error, since we were fetching the`selectedAccount` from the store that had been cleared at that point in time.


...

## Changelog

```
- Remove redundant await
- Pass account parameter to proccessAndAddToActivities()
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
