### PR TITLE
fix: await initialization correctly

### DIFF
--- a/packages/desktop/views/onboarding/views/profile-setup/views/SetupNewView.svelte
+++ b/packages/desktop/views/onboarding/views/profile-setup/views/SetupNewView.svelte
@@ -13,9 +13,9 @@
     } from '@contexts/onboarding'
     import { profileSetupRouter } from '@core/router'
 
-    function onProfileTypeSelectionClick(type: ProfileType): void {
+    async function onProfileTypeSelectionClick(type: ProfileType): Promise<void> {
         updateOnboardingProfile({ type })
-        initialiseProfileManagerFromOnboardingProfile()
+        await initialiseProfileManagerFromOnboardingProfile()
         $profileSetupRouter.next()
     }
 


### PR DESCRIPTION
## Summary

Correctly awaits initialization of the profile manager.
...

## Changelog

```
- Add async/await to initialiseProfileManager
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
