### PR TITLE
fix: correctly disable governance buttons

### DIFF
--- a/packages/shared/components/VotingPower.svelte
+++ b/packages/shared/components/VotingPower.svelte
@@ -5,6 +5,7 @@
     import { localize } from '@core/i18n'
     import { formatTokenAmountBestMatch, visibleSelectedAccountAssets } from '@core/wallet'
     import { openPopup } from '@auxiliary/popup'
+    import { hasPendingGovernanceTransaction } from '@contexts/governance/stores'
 
     const asset = $visibleSelectedAccountAssets?.baseCoin
 
@@ -12,6 +13,7 @@
     $: maxVotingPower = parseInt($selectedAccount?.balances?.baseCoin?.available) + votingPower
     $: formattedVotingPower = formatTokenAmountBestMatch(votingPower, asset?.metadata)
     $: formattedMaxVotingPower = formatTokenAmountBestMatch(maxVotingPower, asset?.metadata)
+    $: isTransferring = $hasPendingGovernanceTransaction?.[$selectedAccount.index] || $selectedAccount?.isTransferring
 
     function handleManageVotingPower(): void {
         openPopup({
@@ -32,8 +34,8 @@
         size={ButtonSize.Medium}
         onClick={handleManageVotingPower}
         classes="w-full"
-        disabled={$selectedAccount.isTransferring}
-        isBusy={$selectedAccount.isTransferring}
+        disabled={isTransferring}
+        isBusy={isTransferring}
     >
         {localize('views.governance.votingPower.manage')}
     </Button>

--- a/packages/shared/components/popups/ManageVotingPowerPopup.svelte
+++ b/packages/shared/components/popups/ManageVotingPowerPopup.svelte
@@ -20,22 +20,18 @@
     let assetAmountInput: AssetAmountInput
     let amount: string
     let rawAmount = newVotingPower ?? $selectedAccount?.votingPower
-    let confirmDisabled = false
 
     $: asset = $visibleSelectedAccountAssets?.baseCoin
     $: votingPower = parseInt($selectedAccount?.votingPower, 10)
     $: isTransferring = $hasPendingGovernanceTransaction?.[$selectedAccount.index] || $selectedAccount?.isTransferring
-    $: disabled = $hasToRevote || isTransferring
+    $: disabled = getDisabled(amount, $hasToRevote, isTransferring)
 
-    $: amount, disabled, setConfirmDisabled()
-
-    function setConfirmDisabled(): void {
-        if (disabled || !amount) {
-            confirmDisabled = true
-            return
+    function getDisabled(amount: string, hasToRevote: boolean, isTransferring: boolean): boolean {
+        if (!amount) {
+            return hasToRevote || isTransferring
         }
         const convertedSliderAmount = convertToRawAmount(amount, asset?.metadata).toString()
-        confirmDisabled = convertedSliderAmount === $selectedAccount?.votingPower || isTransferring
+        return convertedSliderAmount === $selectedAccount?.votingPower || isTransferring
     }
 
     function onCancelClick(): void {
@@ -102,7 +98,7 @@
         <Button outline disabled={isTransferring} classes="w-full" onClick={onCancelClick}>
             {localize('actions.cancel')}
         </Button>
-        <Button type={HTMLButtonType.Submit} disabled={confirmDisabled} isBusy={isTransferring} classes="w-full">
+        <Button type={HTMLButtonType.Submit} {disabled} isBusy={isTransferring} classes="w-full">
             {localize('actions.confirm')}
         </Button>
     </div>

--- a/packages/shared/components/popups/ManageVotingPowerPopup.svelte
+++ b/packages/shared/components/popups/ManageVotingPowerPopup.svelte
@@ -35,7 +35,7 @@
             return
         }
         const convertedSliderAmount = convertToRawAmount(amount, asset?.metadata).toString()
-        confirmDisabled = convertedSliderAmount === $selectedAccount?.votingPower || $selectedAccount?.isTransferring
+        confirmDisabled = convertedSliderAmount === $selectedAccount?.votingPower || isTransferring
     }
 
     function onCancelClick(): void {

--- a/packages/shared/components/popups/ManageVotingPowerPopup.svelte
+++ b/packages/shared/components/popups/ManageVotingPowerPopup.svelte
@@ -24,7 +24,7 @@
 
     $: asset = $visibleSelectedAccountAssets?.baseCoin
     $: votingPower = parseInt($selectedAccount?.votingPower, 10)
-    $: isTransferring = $hasPendingGovernanceTransaction?.[$selectedAccount.index]
+    $: isTransferring = $hasPendingGovernanceTransaction?.[$selectedAccount.index] || $selectedAccount?.isTransferring
     $: disabled = $hasToRevote || isTransferring
 
     $: amount, disabled, setConfirmDisabled()

--- a/packages/shared/components/popups/RevotePopup.svelte
+++ b/packages/shared/components/popups/RevotePopup.svelte
@@ -5,10 +5,10 @@
     import { closePopup } from '@auxiliary/popup/actions'
     import { checkActiveProfileAuth } from '@core/profile/actions'
     import { onDestroy } from 'svelte'
-    import { hasToRevote } from '@contexts/governance/stores'
+    import { hasPendingGovernanceTransaction, hasToRevote } from '@contexts/governance/stores'
     import { vote } from '@contexts/governance/actions'
 
-    $: disabled = $selectedAccount?.isTransferring
+    $: disabled = $hasPendingGovernanceTransaction?.[$selectedAccount.index]
 
     async function onSubmit(): Promise<void> {
         await checkActiveProfileAuth(async () => {

--- a/packages/shared/components/popups/VotingPowerToZeroPopup.svelte
+++ b/packages/shared/components/popups/VotingPowerToZeroPopup.svelte
@@ -4,12 +4,15 @@
     import { selectedAccount } from '@core/account/stores'
     import { handleError } from '@core/error/handlers'
     import { setVotingPower } from '@contexts/governance/actions'
+    import { hasPendingGovernanceTransaction } from '@contexts/governance/stores'
     import { localize } from '@core/i18n'
     import { checkActiveProfileAuth } from '@core/profile/actions'
     import { closePopup, openPopup } from '@auxiliary/popup/actions'
     import { popupState } from '@auxiliary/popup/stores'
 
     const ZERO_VOTING_POWER = '0'
+
+    $: isTransferring = $hasPendingGovernanceTransaction?.[$selectedAccount.index]
 
     function onCancelClick(): void {
         closePopup()
@@ -40,12 +43,7 @@
         <Button outline classes="w-full" onClick={onCancelClick}>
             {localize('actions.cancel')}
         </Button>
-        <Button
-            type={HTMLButtonType.Submit}
-            isBusy={$selectedAccount?.isTransferring}
-            disabled={$selectedAccount?.isTransferring}
-            classes="w-full"
-        >
+        <Button type={HTMLButtonType.Submit} isBusy={isTransferring} disabled={isTransferring} classes="w-full">
             {localize('actions.confirm')}
         </Button>
     </div>


### PR DESCRIPTION
## Summary

Correctly disable the revote button and the confirm button on manage voting power popup

...

## Changelog

```
- use hasPendingGovernanceTransaction instead of isTransferring
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
