### PR TITLE
fix: manage voting power when stronghold locked

### DIFF
--- a/packages/shared/lib/core/stronghold/actions/checkOrUnlockStronghold.ts
+++ b/packages/shared/lib/core/stronghold/actions/checkOrUnlockStronghold.ts
@@ -1,5 +1,5 @@
 import { isStrongholdUnlocked } from '@core/profile-manager'
-import { openPopup, popupState } from '@auxiliary/popup'
+import { closePopup, openPopup, popupState } from '@auxiliary/popup'
 import { get } from 'svelte/store'
 import { handleError } from '@core/error/handlers/handleError'
 
@@ -17,10 +17,10 @@ export async function checkOrUnlockStronghold(
     }
     try {
         const strongholdUnlocked = await isStrongholdUnlocked()
-
         if (strongholdUnlocked) {
             return callback()
         } else {
+            closePopup(true)
             openPopup({
                 type: 'unlockStronghold',
                 props: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7502,7 +7502,7 @@ svelte-loader@^3.0.0:
     svelte-dev-helper "^1.1.9"
     svelte-hmr "^0.14.2"
 
-svelte-markdown@^0.2.3:
+svelte-markdown@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/svelte-markdown/-/svelte-markdown-0.2.3.tgz#16c6db61605512100cf25c3e18f8e4105837895c"
   integrity sha512-2h680NzTXnAD0CXhxe3GeHl6W+ayG4iKQRl+BIDRw+R0mUE0OiNxP1Vt8Rn+aWevB/LBiBIPCAwvL+0BkG057A==


### PR DESCRIPTION
## Summary

Enforce closing a popup before opening the unlockStrongholdPopup

...

## Changelog

```
- Update yarn.lock
- Add closePopup(true)
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
