### PR TITLE
fix: set default assetId in handleDeepLink

### DIFF
--- a/packages/shared/lib/auxiliary/deep-link/handlers/wallet/operations/handleDeepLinkSendConfirmationOperation.ts
+++ b/packages/shared/lib/auxiliary/deep-link/handlers/wallet/operations/handleDeepLinkSendConfirmationOperation.ts
@@ -90,7 +90,7 @@ function parseSendConfirmationOperation(searchParams: URLSearchParams): NewTrans
 
     return {
         type: NewTransactionType.TokenTransfer,
-        ...(assetId && { assetId }),
+        ...(assetId ? { assetId } : { assetId: baseAsset.id }),
         ...(recipient && { recipient }),
         ...(rawAmount && { rawAmount }),
         ...(unit && { unit }),


### PR DESCRIPTION
## Summary

When no assetId is given in deep link params, it is not possible to determine visually which token will be sent, so this PRs sets the base token as the default when the assetId param is undefined

## Changelog

```
- Add a default value for assetId in handleDeepLinkSendConfirmationOperation.ts
- Update docs
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

- Test the deep link using the developer tools
- [ ] this deep link shows a send confirmation popup with shimmer as a token
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=10000`
- [ ] this deep link shows a send confirmation popup with a native token
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=10000&assetId=<INSERT_A_NATIVE_TOKEN_ID_HERE>`

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [x] I have made corresponding changes to the documentation
