### PR TITLE
fix: validate asset id from deeplinks

### DIFF
--- a/packages/shared/lib/auxiliary/deep-link/errors/index.ts
+++ b/packages/shared/lib/auxiliary/deep-link/errors/index.ts
@@ -1,5 +1,6 @@
 export * from './amount-not-an-integer.error'
 export * from './invalid-address.error'
+export * from './invalid-asset-id.error'
 export * from './metadata-length.error'
 export * from './no-address-specified.error'
 export * from './tag-length.error'

--- a/packages/shared/lib/auxiliary/deep-link/errors/invalid-asset-id.error.ts
+++ b/packages/shared/lib/auxiliary/deep-link/errors/invalid-asset-id.error.ts
@@ -1,0 +1,14 @@
+import { BaseError } from '@core/error'
+import { localize } from '@core/i18n'
+
+export class InvalidAssetIdError extends BaseError {
+    constructor() {
+        const message = localize('error.send.invalidAssetId')
+        super({
+            message,
+            showNotification: true,
+            saveToErrorLog: false,
+            logToConsole: true,
+        })
+    }
+}

--- a/packages/shared/lib/auxiliary/deep-link/handlers/wallet/operations/handleDeepLinkSendConfirmationOperation.ts
+++ b/packages/shared/lib/auxiliary/deep-link/handlers/wallet/operations/handleDeepLinkSendConfirmationOperation.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store'
 
 import { networkHrp } from '@core/network'
-import { isStringTrue, isValidBech32AddressAndPrefix, getByteLengthOfString } from '@core/utils'
+import { isStringTrue, isValidBech32AddressAndPrefix, getByteLengthOfString, validateAssetId } from '@core/utils'
 import {
     getAssetById,
     NewTransactionDetails,
@@ -60,6 +60,7 @@ function parseSendConfirmationOperation(searchParams: URLSearchParams): NewTrans
     const recipient: Subject = { type: 'address', address }
 
     const assetId = searchParams.get(SendOperationParameter.AssetId)
+    assetId && validateAssetId(assetId)
     const baseAsset = get(selectedAccountAssets).baseCoin
     const asset = assetId ? getAssetById(assetId) : baseAsset
     if (!asset) {

--- a/packages/shared/lib/core/utils/crypto/utils/index.ts
+++ b/packages/shared/lib/core/utils/crypto/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './validateAssetId'
 export * from './validateBech32Address'
 export * from './validateEthereumAddress'

--- a/packages/shared/lib/core/utils/crypto/utils/validateAssetId.ts
+++ b/packages/shared/lib/core/utils/crypto/utils/validateAssetId.ts
@@ -1,7 +1,11 @@
 import { InvalidAssetIdError } from '@auxiliary/deep-link'
+import { COIN_TYPE } from '@core/network'
 
 export function validateAssetId(id: string): void {
-    if (!/^(0x08)?[0-9a-f]{64}?(?:0[1-9]|[1-5][0-9]|6[0-4])?0{8}$/i.test(id)) {
+    const isHex = id.startsWith('0x')
+    if (isHex && !/^(0x08)?[0-9a-f]{64}?(?:0[1-9]|[1-5][0-9]|6[0-4])?0{8}$/i.test(id)) {
+        throw new InvalidAssetIdError()
+    } else if (!isHex && !Object.values(COIN_TYPE).includes(Number(id))) {
         throw new InvalidAssetIdError()
     }
 }

--- a/packages/shared/lib/core/utils/crypto/utils/validateAssetId.ts
+++ b/packages/shared/lib/core/utils/crypto/utils/validateAssetId.ts
@@ -1,0 +1,7 @@
+import { InvalidAssetIdError } from '@auxiliary/deep-link'
+
+export function validateAssetId(id: string): void {
+    if (!/^(0x08)?[0-9a-f]{64}?(?:0[1-9]|[1-5][0-9]|6[0-4])?0{8}$/i.test(id)) {
+        throw new InvalidAssetIdError()
+    }
+}

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -1825,6 +1825,7 @@
             "wrongAddressPrefix": "Addresses start with the prefix {prefix}.",
             "wrongAddressFormat": "The address is not correctly formatted.",
             "invalidAddress": "The address is not valid.",
+            "invalidAssetId": "The asset id is not valid.",
             "unknownAsset": "The asset is not known to this account.",
             "insufficientFunds": "This wallet has insufficient funds.",
             "insufficientFundsStorageDeposit": "Insufficient funds to cover the storage deposit",


### PR DESCRIPTION
## Summary
Deeplink's assetId already has a validation that checks for the account assets being held, but it needs a validation of format and this PR implements this solution

## Changelog
```
- Creates validateAssetId function
- Adds validateAssetId function in handleDeepLinkSendConfirmationOperation
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

- Test deeplinks using developer tools:
- [ ] Should show asset id not valid error
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=1&assetId=trololololo10`
- [ ] Should show the asset is not known to this account error
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=1&assetId=4218`
- [ ] Should show the asset is not known to this account error
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=1&assetId=0x08952e6fa7235d6a9f58b5e2e2ba2fd07bba7bc684dad5b47873d35e98fffe58a10100000000`
- [ ] Should not show any error
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=1&assetId=4219`
- [ ] Should not show any error
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=1`
- [ ] Should not show any error
`firefly-alpha://wallet/sendConfirmation?address=rms1qpwed3kpaju5rwe4nhplaj3ya6tujzvyuepypya4us95yf2rkp80u5ja230&amount=1&assetId=<A_NATIVE_TOKEN_ID_THAT_THE_ACCOUNT_IS_HOLDING`

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
