### PR TITLE
fix: only show dismiss button by default in mobile app

### DIFF
--- a/packages/mobile/App.svelte
+++ b/packages/mobile/App.svelte
@@ -112,7 +112,7 @@
     {/key}
 {/if}
 <DrawerManager />
-<ToastContainer swipe fadeDuration={100} classes="fixed top-0 p-5 z-10 w-full" />
+<ToastContainer swipe fadeDuration={100} classes="fixed top-0 p-5 z-10 w-full" showDismiss />
 
 {#if $isKeyboardOpen}
     <div class="keyboard" />

--- a/packages/shared/components/ToastContainer.svelte
+++ b/packages/shared/components/ToastContainer.svelte
@@ -8,6 +8,7 @@
     export let classes: string = ''
     export let swipe: boolean = false
     export let fadeDuration: number = 0
+    export let showDismiss = false
 
     $: toasts = $notifications.map((notification) => ({
         type: notification.type,
@@ -38,7 +39,7 @@
                                 progress={toast.progress}
                                 actions={toast.actions}
                                 id={toast.id}
-                                showDismiss
+                                {showDismiss}
                             />
                         </Swiper>
                     {:else}
@@ -50,7 +51,7 @@
                             progress={toast.progress}
                             actions={toast.actions}
                             id={toast.id}
-                            showDismiss
+                            {showDismiss}
                         />
                     {/if}
                 </li>


### PR DESCRIPTION
## Changelog

```
- Adds showDismiss prop with default false value in ToastContainer
- Sets showDismiss prop to true inside mobile App's ToastContainer
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
