### PR TITLE
fix: adds default constant of lockScreenTimeoutInMinutes as fallback

### DIFF
--- a/packages/desktop/views/dashboard/settings/views/security/AppLock.svelte
+++ b/packages/desktop/views/dashboard/settings/views/security/AppLock.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Dropdown, Text } from 'shared/components'
     import { localize } from '@core/i18n'
-    import { activeProfile, updateActiveProfileSettings } from '@core/profile'
+    import { activeProfile, DEFAULT_PERSISTED_PROFILE_OBJECT, updateActiveProfileSettings } from '@core/profile'
     import type { IDropdownChoice } from '@core/utils'
 
     function updateLockTimeout(option): void {
@@ -28,6 +28,9 @@
 <Text type="p" secondary classes="mb-5">{localize('views.settings.appLock.description')}</Text>
 <Dropdown
     onSelect={updateLockTimeout}
-    value={assignTimeoutOptionLabel($activeProfile?.settings.lockScreenTimeoutInMinutes)}
+    value={assignTimeoutOptionLabel(
+        $activeProfile?.settings?.lockScreenTimeoutInMinutes ??
+            DEFAULT_PERSISTED_PROFILE_OBJECT.settings.lockScreenTimeoutInMinutes
+    )}
     items={lockScreenTimeoutOptions()}
 />

--- a/packages/mobile/components/drawers/profile/views/settings/views/AppLockView.svelte
+++ b/packages/mobile/components/drawers/profile/views/settings/views/AppLockView.svelte
@@ -2,10 +2,12 @@
     import { Radio, Text, TextType } from '@ui'
 
     import { localize } from '@core/i18n'
-    import { activeProfile, updateActiveProfileSettings } from '@core/profile'
+    import { activeProfile, DEFAULT_PERSISTED_PROFILE_OBJECT, updateActiveProfileSettings } from '@core/profile'
     import type { IDropdownChoice } from '@core/utils'
 
-    let selectedLockTimeout: number = $activeProfile?.settings?.lockScreenTimeoutInMinutes
+    let selectedLockTimeout: number =
+        $activeProfile?.settings?.lockScreenTimeoutInMinutes ??
+        DEFAULT_PERSISTED_PROFILE_OBJECT.settings.lockScreenTimeoutInMinutes
     $: selectedLockTimeout, updateActiveProfileSettings({ lockScreenTimeoutInMinutes: selectedLockTimeout })
 
     function lockScreenTimeoutOptions(): IDropdownChoice[] {

--- a/packages/shared/components/Idle.svelte
+++ b/packages/shared/components/Idle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { onDestroy } from 'svelte'
     import { get } from 'svelte/store'
-    import { activeProfile, logout } from '@core/profile'
+    import { activeProfile, DEFAULT_PERSISTED_PROFILE_OBJECT, logout } from '@core/profile'
     import { debounce, MILLISECONDS_PER_SECOND, SECONDS_PER_MINUTE } from '@core/utils'
 
     let timeout
@@ -21,7 +21,10 @@
             const ap = get(activeProfile)
             if (ap) {
                 const timeoutDuration =
-                    MILLISECONDS_PER_SECOND * SECONDS_PER_MINUTE * ap.settings.lockScreenTimeoutInMinutes
+                    MILLISECONDS_PER_SECOND *
+                    SECONDS_PER_MINUTE *
+                    (ap?.settings?.lockScreenTimeoutInMinutes ??
+                        DEFAULT_PERSISTED_PROFILE_OBJECT.settings.lockScreenTimeoutInMinutes)
 
                 if (!isIdleTimeValid(new Date(), timeoutDuration)) lock()
 


### PR DESCRIPTION
## Summary
adds default constant of lockScreenTimeoutInMinutes as a fallback to prevent #5770 from happening again

closes #5770 

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist
-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
