### PR TITLE
Fix: create profile from menu

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -150,16 +150,16 @@
         Platform.onEvent('menu-diagnostics', () => {
             openPopup({ id: PopupId.Diagnostics })
         })
-        Platform.onEvent('menu-create-developer-profile', () => {
-            void initialiseOnboardingFlow({
+        Platform.onEvent('menu-create-developer-profile', async () => {
+            await initialiseOnboardingFlow({
                 isDeveloperProfile: true,
                 networkProtocol: NetworkProtocol.Shimmer,
             })
             $routerManager.goToAppContext(AppContext.Onboarding)
             $onboardingRouter.goTo(OnboardingRoute.NetworkSetup)
         })
-        Platform.onEvent('menu-create-normal-profile', () => {
-            void initialiseOnboardingFlow({
+        Platform.onEvent('menu-create-normal-profile', async () => {
+            await initialiseOnboardingFlow({
                 isDeveloperProfile: false,
                 networkProtocol: NetworkProtocol.Shimmer,
                 networkType: NetworkType.Mainnet,

--- a/packages/desktop/electron/lib/menu.js
+++ b/packages/desktop/electron/lib/menu.js
@@ -93,23 +93,28 @@ const buildTemplate = () => {
                 {
                     type: 'separator',
                 },
-                {
-                    label: state.strings.createDeveloperProfile,
-                    click: () => getOrInitWindow('main').webContents.send('menu-create-developer-profile'),
-                    visible: state.canCreateNewProfile,
-                },
-                {
-                    label: state.strings.createNormalProfile,
-                    click: () => getOrInitWindow('main').webContents.send('menu-create-normal-profile'),
-                    visible: state.canCreateNewProfile,
-                },
-                {
-                    label: state.strings.diagnostics,
-                    click: () => getOrInitWindow('main').webContents.send('menu-diagnostics'),
-                },
             ],
         },
     ]
+
+    if (process.env.stage === 'prod') {
+        template[0].submenu.push({
+            label: state.strings.createDeveloperProfile,
+            click: () => getOrInitWindow('main').webContents.send('menu-create-developer-profile'),
+            visible: state.canCreateNewProfile,
+        })
+    } else {
+        template[0].submenu.push({
+            label: state.strings.createNormalProfile,
+            click: () => getOrInitWindow('main').webContents.send('menu-create-normal-profile'),
+            visible: state.canCreateNewProfile,
+        })
+    }
+
+    template[0].submenu.push({
+        label: state.strings.diagnostics,
+        click: () => getOrInitWindow('main').webContents.send('menu-diagnostics'),
+    })
 
     if (!app.isPackaged || features?.electron?.developerTools?.enabled) {
         template[0].submenu.push({


### PR DESCRIPTION
## Summary

Change the issue where creating a normal profile from the top menu options automatically jumps to the enter password view.
...

## Changelog

```
- Add await in relevant functions
- Conditionally add create normal/dev profile
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
