### PR TITLE
fix: disable expiration time setting while transferring

### DIFF
--- a/packages/desktop/components/popups/send/SendConfirmationPopup.svelte
+++ b/packages/desktop/components/popups/send/SendConfirmationPopup.svelte
@@ -228,7 +228,7 @@
                         bind:this={expirationTimePicker}
                         bind:value={expirationDate}
                         initialSelected={initialExpirationDate}
-                        disabled={disableChangeExpiration}
+                        disabled={disableChangeExpiration || isTransferring}
                     />
                 </KeyValueBox>
             {/if}

--- a/packages/shared/components/molecules/ExpirationTimePicker.svelte
+++ b/packages/shared/components/molecules/ExpirationTimePicker.svelte
@@ -38,12 +38,7 @@
             darkColor="gray-500"
             classes={disabled ? '' : 'hover:text-blue-600'}
         >
-            {value
-                ? formatDate(value, {
-                      dateStyle: 'long',
-                      timeStyle: 'medium',
-                  })
-                : localize('general.none')}
+            {value ? formatDate(value, { dateStyle: 'long', timeStyle: 'medium' }) : localize('general.none')}
         </Text>
         {#if !disabled}
             <Icon icon={IconEnum.ChevronDown} width="10" classes="text-blue-500 ml-1" />

--- a/packages/shared/lib/core/wallet/utils/send/validateSendConfirmation.ts
+++ b/packages/shared/lib/core/wallet/utils/send/validateSendConfirmation.ts
@@ -13,7 +13,7 @@ export function validateSendConfirmation(outputOptions: OutputOptions, outputTyp
     const { storageDeposit, giftedStorageDeposit } = getStorageDepositFromOutput(outputTypes)
     const expirationDateTime = convertUnixTimestampToDate(outputOptions?.unlocks?.expirationUnixTime)
 
-    const isNft = !!outputOptions.assets.nftId
+    const isNft = !!outputOptions?.assets?.nftId
     if (!isNft && (balance < amount + storageDeposit || balance < amount + giftedStorageDeposit)) {
         throw new InsufficientFundsForStorageDepositError()
     } else if (expirationDateTime && !isValidExpirationDateTime(expirationDateTime)) {


### PR DESCRIPTION
## Summary

Fixes two issues:
- Fixes validate error when sending SMR due to nftId not being optionally chained.
- Disable setting expiration time while transferring

...

## Changelog

```
- Disable setting expiration time while transferring
- Optionally chain nftId
- Format
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
