### PR TITLE
fix: not visible enter password input in import from stronghold flow

### DIFF
--- a/packages/mobile/views/onboarding/views/profile-recovery/views/BackupPasswordView.svelte
+++ b/packages/mobile/views/onboarding/views/profile-recovery/views/BackupPasswordView.svelte
@@ -1,9 +1,10 @@
 <script lang="typescript">
     import { onMount } from 'svelte'
-    import { Button, PasswordInput, Text, TextType } from '@ui'
-    import { localize } from '@core/i18n'
+
     import { OnboardingLayout } from '@components'
-    import { profileRecoveryRouter } from '@/routers'
+    import { Button, PasswordInput, Text, TextType } from '@ui'
+
+    import { showAppNotification } from '@auxiliary/notification'
     import {
         CannotRestoreWithMismatchedCoinTypeError,
         createShimmerClaimingProfileManager,
@@ -15,13 +16,23 @@
         restoreBackupFromStrongholdFile,
         updateOnboardingProfile,
     } from '@contexts/onboarding'
-    import { showAppNotification } from '@auxiliary/notification'
-    import { ClientError, CLIENT_ERROR_REGEXES } from '@core/error'
+    import { CLIENT_ERROR_REGEXES, ClientError } from '@core/error'
+    import { localize } from '@core/i18n'
+
+    import { profileRecoveryRouter } from '@/routers'
+
     export let error = ''
     export let busy = false
+
     const title = `${localize('general.import')} ${localize(`general.${$onboardingProfile?.recoveryType}`)}`
+
     let strongholdPassword = ''
     $: strongholdPassword, (error = '')
+
+    onMount(() => {
+        updateOnboardingProfile({ strongholdPassword: null, lastStrongholdBackupTime: null })
+    })
+
     async function onContinueClick(): Promise<void> {
         if (strongholdPassword) {
             busy = true
@@ -55,6 +66,7 @@
             }
         }
     }
+
     function onBackClick(): void {
         // We are deliberately using "isGettingMigrationData"
         // We do not want to display the spinner if stronghold is being imported.
@@ -62,19 +74,16 @@
             $profileRecoveryRouter.previous()
         }
     }
-    onMount(() => {
-        updateOnboardingProfile({ strongholdPassword: null, lastStrongholdBackupTime: null })
-    })
 </script>
 
 <OnboardingLayout {onBackClick} {busy} {title} animation="import-from-file-password-desktop">
     <div slot="content">
-        <Text type={TextType.p} secondary fontSize="15" classes="mb-4"
-            >{localize('views.onboarding.profileRecovery.backupPassword.body1')}</Text
-        >
-        <Text type={TextType.p} secondary fontSize="15" classes="mb-8"
-            >{localize('views.onboarding.profileRecovery.backupPassword.body2')}</Text
-        >
+        <Text type={TextType.p} secondary fontSize="15" classes="mb-4">
+            {localize('views.onboarding.profileRecovery.backupPassword.body1')}
+        </Text>
+        <Text type={TextType.p} secondary fontSize="15" classes="mb-8">
+            {localize('views.onboarding.profileRecovery.backupPassword.body2')}
+        </Text>
         <PasswordInput
             classes="mb-6"
             {error}

--- a/packages/mobile/views/onboarding/views/profile-recovery/views/BackupPasswordView.svelte
+++ b/packages/mobile/views/onboarding/views/profile-recovery/views/BackupPasswordView.svelte
@@ -17,7 +17,6 @@
     } from '@contexts/onboarding'
     import { showAppNotification } from '@auxiliary/notification'
     import { ClientError, CLIENT_ERROR_REGEXES } from '@core/error'
-    import { isKeyboardOpen, keyboardHeight } from '@/auxiliary/keyboard'
     export let error = ''
     export let busy = false
     const title = `${localize('general.import')} ${localize(`general.${$onboardingProfile?.recoveryType}`)}`
@@ -86,11 +85,7 @@
             submitHandler={onContinueClick}
         />
     </div>
-    <div
-        style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}
-        slot="footer"
-        class="flex flex-row flex-wrap justify-between items-center space-x-4"
-    >
+    <div slot="footer" class="flex flex-row flex-wrap justify-between items-center space-x-4">
         <Button
             classes="flex-1"
             disabled={strongholdPassword.length === 0 || busy}


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

We had an extra `style={$isKeyboardOpen && `margin-bottom: ${$keyboardHeight}px`}` so the available space was shrinked because we already do that calculation in `OnboardingLayout`. This PR removes it and also cleans a bit the file

Close https://github.com/iotaledger/firefly/issues/6451

## Changelog

```
- Please write a list of changes
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
