### PR TITLE
fix: clear password before backup

### DIFF
--- a/packages/shared/lib/contexts/settings/actions/exportStronghold.ts
+++ b/packages/shared/lib/contexts/settings/actions/exportStronghold.ts
@@ -1,5 +1,5 @@
 import { updateActiveProfile } from '@core/profile'
-import { backup, clearStrongholdPassword } from '@core/profile-manager'
+import { backup, setStrongholdPassword } from '@core/profile-manager'
 import { Platform } from '@core/app'
 import { getDefaultStrongholdName } from '@core/stronghold'
 
@@ -12,7 +12,7 @@ export async function exportStronghold(
         if (destination) {
             try {
                 Platform.saveStrongholdBackup({ allowAccess: true })
-                await clearStrongholdPassword()
+                await setStrongholdPassword(password)
                 await backup(destination, password)
                 Platform.saveStrongholdBackup({ allowAccess: false })
                 updateActiveProfile({ lastStrongholdBackupTime: new Date() })

--- a/packages/shared/lib/contexts/settings/actions/exportStronghold.ts
+++ b/packages/shared/lib/contexts/settings/actions/exportStronghold.ts
@@ -1,5 +1,5 @@
 import { updateActiveProfile } from '@core/profile'
-import { backup } from '@core/profile-manager'
+import { backup, clearStrongholdPassword } from '@core/profile-manager'
 import { Platform } from '@core/app'
 import { getDefaultStrongholdName } from '@core/stronghold'
 
@@ -12,6 +12,7 @@ export async function exportStronghold(
         if (destination) {
             try {
                 Platform.saveStrongholdBackup({ allowAccess: true })
+                await clearStrongholdPassword()
                 await backup(destination, password)
                 Platform.saveStrongholdBackup({ allowAccess: false })
                 updateActiveProfile({ lastStrongholdBackupTime: new Date() })


### PR DESCRIPTION
## Summary
This PR clears stronghold password from memory before trying to export stronghold backup

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist
-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
