### PR TITLE
enhancement: add exit button to About Window for windowsOS

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -586,6 +586,13 @@ export const openAboutWindow = () => {
         height: 230,
         useContentSize: true,
         titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
+
+        // affects only WindowsOS
+        titleBarOverlay: {
+            color: '#192742',
+            symbolColor: '#ffffff',
+        },
+
         show: false,
         fullscreenable: false,
         resizable: false,


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

About Electron browserWindow didn't have a title bar on Windows so users could not exit it without using Alt + F4 or using the task bar. Added an option for users to exit out of the window.

![image](https://user-images.githubusercontent.com/72045705/232899339-70ae8a66-8224-41dc-82cb-4747429e62fd.png)

![image](https://user-images.githubusercontent.com/72045705/232900112-0ec791e1-bf44-4719-b3b2-07b5e971a6cf.png)



## Changelog

```
- Added a titleBarOverlay to About Electron window on Windows OS
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [x] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
