### PR TITLE
fix-mobile: disable confirm when no date selected in DateTimePickerDrawer

### DIFF
--- a/packages/mobile/components/drawers/DateTimePickerDrawer.svelte
+++ b/packages/mobile/components/drawers/DateTimePickerDrawer.svelte
@@ -38,7 +38,8 @@
         theme="datetime-picker-colors"
         bind:value={sveltyPickerDate}
     />
-    <Button onClick={onConfirmClick} classes="w-full">{localize('actions.confirm')}</Button>
+    <Button onClick={onConfirmClick} disabled={!sveltyPickerDate} classes="w-full">{localize('actions.confirm')}</Button
+    >
 </datetime-picker-drawer>
 
 <style type="text/scss">

--- a/packages/mobile/components/drawers/DateTimePickerDrawer.svelte
+++ b/packages/mobile/components/drawers/DateTimePickerDrawer.svelte
@@ -38,8 +38,9 @@
         theme="datetime-picker-colors"
         bind:value={sveltyPickerDate}
     />
-    <Button onClick={onConfirmClick} disabled={!sveltyPickerDate} classes="w-full">{localize('actions.confirm')}</Button
-    >
+    <Button onClick={onConfirmClick} disabled={!sveltyPickerDate} classes="w-full">
+        {localize('actions.confirm')}
+    </Button>
 </datetime-picker-drawer>
 
 <style type="text/scss">


### PR DESCRIPTION
## Summary
closes #6583 

## Testing

### Platforms
-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [x] iOS
    -   [x] Android

### Instructions
- Go to activity list
- Touch the filter icon
- Toggle the "Date" filter
- Touch the date input
- The confirm button should be disabled
- Select a date by touching it
- The confirm button should be enabled

## Checklist
-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [x] I have made corresponding changes to the documentation
