### PR TITLE
fix-mobile: tabNavigator component needs more padding for iPhone mini

### DIFF
--- a/packages/mobile/views/dashboard/tabs/TabNavigator.svelte
+++ b/packages/mobile/views/dashboard/tabs/TabNavigator.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <tab-navigator
-    class="w-full bg-white dark:bg-gray-900 grid grid-cols-{NAVIGATION_ITEMS.length} grid-rows-1 gap-4 pt-4 pb-7 px-5"
+    class="w-full bg-white dark:bg-gray-900 grid grid-cols-{NAVIGATION_ITEMS.length} grid-rows-1 gap-4 pt-4 pb-8 px-5"
     class:darkmode={darkModeEnabled}
 >
     {#each NAVIGATION_ITEMS as item}


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.
tabNavigator clipped the tab options in iphone12 mini: 
![image](https://user-images.githubusercontent.com/72045705/234388301-ce45683b-a560-48a7-8047-b1f062f0596b.png)


## Changelog

```
- Added additional padding to tabNaviagor
```

## Testing
![image](https://user-images.githubusercontent.com/72045705/234388201-e05c4285-f8b9-4643-b730-a48ce927b897.png)

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [x] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
