### PR TITLE
enhancement: adds ensureDirectoryExistence function and call it on copy-file handler

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -405,6 +405,7 @@ ipcMain.handle('copy-file', (_e, sourceFilePath, destinationFilePath) => {
     const src = path.resolve(sourceFilePath)
     const srcFileBuffer = fs.readFileSync(src)
     const dest = path.resolve(destinationFilePath)
+    ensureDirectoryExistence(dest)
     fs.writeFileSync(dest, srcFileBuffer)
 })
 
@@ -422,6 +423,15 @@ ipcMain.handle('check-if-file-exists', (_e, filePath) => {
 
     return fs.existsSync(`${directory}/__storage__/${filePath}`)
 })
+
+function ensureDirectoryExistence(filePath) {
+    const dirname = path.dirname(filePath)
+    if (fs.existsSync(dirname)) {
+        return true
+    }
+    ensureDirectoryExistence(dirname)
+    fs.mkdirSync(dirname)
+}
 
 // Diagnostics
 const getDiagnostics = () => {


### PR DESCRIPTION
## Summary

When trying to copy a file to a directory that does not exist an error is thrown, so the ensureDirectoryExistence function creates all the directory paths if it does not exist before copying the file

## Testing

### Platforms
-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
