### PR TITLE
fix-mobile: default native token storage deposit

### DIFF
--- a/packages/mobile/components/drawers/send/SendRouter.svelte
+++ b/packages/mobile/components/drawers/send/SendRouter.svelte
@@ -34,7 +34,7 @@
     let initialExpirationDate: ExpirationTime = getInitialExpirationDate()
 
     $: transactionDetails = get(newTransactionDetails)
-    $: expirationDate, giftStorageDeposit, refreshSendConfirmationState()
+    $: $sendRoute, expirationDate, giftStorageDeposit, refreshSendConfirmationState()
 
     onMount(() => {
         if (transactionDetails.type === NewTransactionType.TokenTransfer && transactionDetails?.assetId) {


### PR DESCRIPTION
## Summary

closes #6572 

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [x] Android

### Instructions

- Try to send a native token, the storage deposit shouldn't be 0 in the SendRoute.Review

## Checklist

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
