### PR TITLE
fix: recovery phrase autoformat issue

### DIFF
--- a/packages/shared/components/inputs/ImportTextfield.svelte
+++ b/packages/shared/components/inputs/ImportTextfield.svelte
@@ -65,7 +65,12 @@
         statusMessage = ''
         error = false
 
-        content = content.replace(/\r/g, '').replace(/\n/g, '').replace(/  +/g, ' ')
+        // Copilot describe what this is doing:
+        // 1. Remove all line breaks
+        // 2. Remove all double spaces
+        // 3. Remove all leading and trailing spaces
+
+        content = content.replace(/\r/g, ' ').replace(/\n/g, ' ').replace(/  +/g, ' ')
 
         const trimmedContent = content?.trim()
 

--- a/packages/shared/components/inputs/ImportTextfield.svelte
+++ b/packages/shared/components/inputs/ImportTextfield.svelte
@@ -65,11 +65,6 @@
         statusMessage = ''
         error = false
 
-        // Copilot describe what this is doing:
-        // 1. Remove all line breaks
-        // 2. Remove all double spaces
-        // 3. Remove all leading and trailing spaces
-
         content = content.replace(/\r/g, ' ').replace(/\n/g, ' ').replace(/  +/g, ' ')
 
         const trimmedContent = content?.trim()


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

When pasting the recovery phrase into the mnemonic recovery input field, carriage returns and newlines are replaced with an empty string. This causes an issue where the last word in a line and the first word of the following line are joined. Fixed this issue by replacing the lines with a space instead. 

## Changelog

```
- Replaced carriage returns and newlines with space instead of empty string
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [x] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
