### PR TITLE
mobile-fix: burn button appearing twice

### DIFF
--- a/packages/mobile/components/drawers/SelectedTokenDrawer.svelte
+++ b/packages/mobile/components/drawers/SelectedTokenDrawer.svelte
@@ -163,9 +163,6 @@
                         {localize('actions.burnToken')}
                     </Button>
                 {/if}
-                <Button outline classes="w-full" onClick={onBurnClick}>
-                    {localize('actions.burnToken')}
-                </Button>
                 <Button classes="w-full" onClick={onSendClick}>
                     {localize('actions.send')}
                 </Button>


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

Burn button is appearing twice on native tokens and appearing for SMR tokens as well. This was the result of a merge mistake. PR #6382 code was initially correct. 

## Changelog

```
- Removed burn button outside of conditional
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [x] iOS
    -   [x] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
