### PR TITLE
fix: set readonly attribute to false

### DIFF
--- a/packages/shared/components/inputs/NetworkInput.svelte
+++ b/packages/shared/components/inputs/NetworkInput.svelte
@@ -4,7 +4,7 @@
     import { NETWORK_ADDRESS, DestinationNetwork } from '@core/layer-2'
     import { validateBech32Address } from '@core/utils'
 
-    const readonlyAttribute = $activeProfile?.isDeveloperProfile ? {} : { readonly: true }
+    const readonlyAttribute = $activeProfile?.isDeveloperProfile ? {} : { readonly: false }
     const networkAddresses = NETWORK_ADDRESS[$activeProfile?.network?.id]
 
     const LAYER_1_NETWORK_OPTION = {


### PR DESCRIPTION
## Summary

Allow dropdown  when selecting the network for normal profiles.

...

## Changelog

```
- Seat readonly attribute to false, to show the dropdown list
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
