### PR TITLE
mobile-fix: undefined send transaction

### DIFF
--- a/packages/mobile/components/drawers/send/SendRouter.svelte
+++ b/packages/mobile/components/drawers/send/SendRouter.svelte
@@ -24,6 +24,8 @@
     import { getStorageDepositFromOutput } from '@core/wallet/utils/generateActivity/helper'
 
     import { sendRoute, SendRoute, sendRouter } from '@/routers'
+    import { drawers } from '@/auxiliary/drawer/stores'
+    import { DrawerId } from '@/auxiliary/drawer/enums'
 
     $: ({ expirationDate, giftStorageDeposit, surplus } = $newTransactionDetails)
 
@@ -57,7 +59,9 @@
                 ledgerPreparedOutput.set(preparedOutput)
             }
             await sendOutput(preparedOutput)
-            $sendRouter.next()
+            if ($drawers.some((drawer) => drawer.id === DrawerId.Send)) {
+                $sendRouter.next()
+            }
         } catch (err) {
             handleError(err)
             throw new Error(err)

--- a/packages/mobile/components/drawers/send/views/AmountView.svelte
+++ b/packages/mobile/components/drawers/send/views/AmountView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Big from 'big.js'
     import { onMount } from 'svelte'
+    import { get } from 'svelte/store'
 
     import { localize, parseCurrency } from '@core/i18n'
     import { IOTA_UNIT_MAP } from '@core/utils'
@@ -20,6 +21,9 @@
     import { getAssetById } from '@core/wallet'
     import { TokenUnitSwapper, TokenWithMax } from '@components'
     import { sendRouter } from '@/routers'
+
+    // need to store the newTransactionDetails to avoid errors
+    let transactionDetails = get(newTransactionDetails)
 
     let amount: string
     let rawAmount: string
@@ -46,11 +50,11 @@
     $: marketAmount = getMarketAmountFromAssetValue(bigAmount, asset)
 
     onMount(() => {
-        if ($newTransactionDetails?.type === NewTransactionType.TokenTransfer) {
-            const storedRawAmount = $newTransactionDetails?.rawAmount
-            asset = getAssetById($newTransactionDetails.assetId)
+        if (transactionDetails?.type === NewTransactionType.TokenTransfer) {
+            const storedRawAmount = transactionDetails?.rawAmount
+            asset = getAssetById(transactionDetails.assetId)
             tokenMetadata = asset?.metadata
-            unit = $newTransactionDetails.unit ?? tokenMetadata?.unit
+            unit = transactionDetails.unit ?? tokenMetadata?.unit
             amount = storedRawAmount
                 ? formatTokenAmountDefault(Number(storedRawAmount), asset?.metadata, unit, false)
                 : ''
@@ -111,7 +115,7 @@
 
     function onContinueClick(): void {
         updateNewTransactionDetails({
-            type: $newTransactionDetails.type,
+            type: transactionDetails.type,
             rawAmount,
             unit,
         })
@@ -148,7 +152,7 @@
         <Text color="gray-600" darkColor="gray-500" fontSize="xs">{formatCurrency(marketAmount) ?? ''}</Text>
     </div>
     <div class="flex flex-col space-y-8 w-full">
-        {#if $newTransactionDetails?.type === NewTransactionType.TokenTransfer}
+        {#if transactionDetails?.type === NewTransactionType.TokenTransfer}
             <HR overrideColor classes="border-gray-200 dark:border-gray-700" />
             <TokenWithMax {asset} onMaxClick={onClickAvailableBalance} />
         {/if}

--- a/packages/mobile/components/drawers/send/views/AmountView.svelte
+++ b/packages/mobile/components/drawers/send/views/AmountView.svelte
@@ -59,7 +59,7 @@
                 ? formatTokenAmountDefault(Number(storedRawAmount), asset?.metadata, unit, false)
                 : ''
         }
-        amountInputElement.focus()
+        amountInputElement?.focus()
     })
 
     function validate(allowZeroOrNull = false): void {
@@ -93,7 +93,7 @@
 
     function toggleUnit(newUnit: string): void {
         unit = newUnit
-        amountInputElement.focus()
+        amountInputElement?.focus()
     }
 
     function onClickAvailableBalance(): void {
@@ -129,7 +129,7 @@
             <div class="flex flex-row items-center space-x-2">
                 <amount-wrapper
                     style:--max-width={`${Math.max(amount?.length, 1) * 14}px`}
-                    on:click={() => amountInputElement.focus()}
+                    on:click={() => amountInputElement?.focus()}
                 >
                     <AmountInput
                         bind:inputElement={amountInputElement}

--- a/packages/mobile/components/drawers/send/views/ReviewView.svelte
+++ b/packages/mobile/components/drawers/send/views/ReviewView.svelte
@@ -20,6 +20,7 @@
     import { ActivityAction } from '@core/wallet/enums'
 
     import { DrawerId, openDrawer } from '@/auxiliary/drawer'
+    import { drawers } from '@/auxiliary/drawer/stores'
     import { sendRouter } from '@/routers'
 
     export let sendTransaction: () => Promise<void>
@@ -77,7 +78,9 @@
         const isUnlocked = await isStrongholdUnlocked()
         const _onConfirm = async (): Promise<void> => {
             await asyncSendTransaction()
-            $sendRouter.next()
+            if ($drawers.some((drawer) => drawer.id === DrawerId.Send)) {
+                $sendRouter.next()
+            }
         }
         if (isUnlocked) {
             _onConfirm()

--- a/packages/mobile/views/dashboard/DashboardView.svelte
+++ b/packages/mobile/views/dashboard/DashboardView.svelte
@@ -27,6 +27,8 @@
 
     $: darkModeEnabled = $appSettings.darkMode
 
+    $: isTransferring = $selectedAccount.isTransferring
+
     function onReceiveClick(): void {
         openDrawer(DrawerId.Receive)
     }
@@ -50,7 +52,13 @@
             {#if features?.dashboard?.send?.enabled || features?.dashboard?.receive?.enabled}
                 <div class="flex flex-row items-center justify-center w-full space-x-3 mt-8">
                     {#if features?.dashboard?.send?.enabled}
-                        <Button classes="w-full h-10" onClick={handleSendClick}>
+                        <Button
+                            classes="w-full h-10"
+                            onClick={handleSendClick}
+                            disabled={isTransferring}
+                            isBusy={isTransferring}
+                            busyMessage={localize('general.transferring')}
+                        >
                             {localize('actions.send')}
                         </Button>
                     {/if}

--- a/packages/shared/components/molecules/BasicActivityDetails.svelte
+++ b/packages/shared/components/molecules/BasicActivityDetails.svelte
@@ -19,7 +19,7 @@
     export let activity: TransactionActivity
 
     $: asset = getAssetFromPersistedAssets(activity.assetId)
-    $: amount = formatTokenAmountDefault(Number(activity.rawAmount), asset?.metadata, asset?.metadata?.unit)
+    $: amount = formatTokenAmountDefault(Number(activity?.rawAmount ?? 0), asset?.metadata, asset?.metadata?.unit)
     $: isTimelocked = activity.asyncData?.timelockDate > $time
     $: subject = getSubjectFromActivity(activity)
 </script>

--- a/packages/shared/lib/core/wallet/utils/getOutputOptions.ts
+++ b/packages/shared/lib/core/wallet/utils/getOutputOptions.ts
@@ -52,7 +52,7 @@ function getAmountFromTransactionDetails(transactionDetails: NewTransactionDetai
         if (nativeTokenId) {
             rawAmount = transactionDetails?.surplus ?? '0'
         } else {
-            rawAmount = BigInt(transactionDetails.rawAmount).toString()
+            rawAmount = BigInt(transactionDetails?.rawAmount ?? 0).toString()
         }
     } else if (transactionDetails.type === NewTransactionType.NftTransfer) {
         rawAmount = transactionDetails?.surplus ?? '0'
@@ -72,7 +72,7 @@ function getAssetFromTransactionDetails(transactionDetails: NewTransactionDetail
         const nativeTokenId = asset?.id === get(selectedAccountAssets)?.baseCoin?.id ? undefined : asset?.id
 
         if (nativeTokenId) {
-            const bigAmount = BigInt(transactionDetails.rawAmount)
+            const bigAmount = BigInt(transactionDetails?.rawAmount)
             assets = {
                 nativeTokens: [
                     {


### PR DESCRIPTION
## Summary

closes #6574 

## Changelog

```
- Prevents send functions to go to the next route in sendRouter if the send drawer is closed
- Use transactionDetails in a local variable on AmountView.svelte to prevent errors from getting the global store newTransactionDetails
- Uses nullish coalescing operator where necessary to prevent errors when converting a string to a Number
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [x] iOS
    -   [x] Android

### Instructions

- Login into a profile
- Unlock stronghold
- Go through the send flow until the final step
- In the final step click on "Send button" and then immediately close the drawer
- Try to quickly send again

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
