### PR TITLE
hotfix: tsconfig not error checking

### DIFF
--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,10 +5,21 @@
         "strict": true
     },
     // folders included below pass the strict check
-    "include": [
-        "./lib/core/utils/constants",
-        "./lib/core/utils/enums",
-        "./lib/core/utils/types",
-        "./lib/core/utils/stores"
+    "files": [
+        "./lib/core/utils/constants/bech32-address-length.constant.ts",
+        "./lib/core/utils/constants/date-format.constant.ts",
+        "./lib/core/utils/constants/default-application-json-request-options.constant.ts",
+        "./lib/core/utils/constants/default-exchange-rates.constant.ts",
+        "./lib/core/utils/constants/hex.constants.ts",
+        "./lib/core/utils/constants/index.ts",
+        "./lib/core/utils/constants/iota-unit-map.constant.ts",
+        "./lib/core/utils/constants/max-bytes.constant.ts",
+        "./lib/core/utils/constants/max-number-of-iotas.constant.ts",
+        "./lib/core/utils/constants/pin-length.constant.ts",
+        "./lib/core/utils/constants/time.constants.ts",
+        "./lib/core/utils/enums/exchange-rate.enum.ts",
+        "./lib/core/utils/enums/iota-unit.enum.ts",
+        "./lib/core/utils/types/exchange-rates.type.ts",
+        "./lib/core/utils/types/iota-unit-map.type.ts"
     ]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,7 +4,7 @@
     "compilerOptions": {
         "strict": true
     },
-    // folders included below pass the strict check
+    // files included below pass the strict check
     "files": [
         "./lib/core/utils/constants/bech32-address-length.constant.ts",
         "./lib/core/utils/constants/date-format.constant.ts",


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

A last second change to use `include` instead of `files` in the `packages/shared/tsconfig.json` file is causing issues in type checking outside of the included files. Switching it back to files fixes the issue.

## Changelog

```
- Switch from include to files and reestablish list of correct files
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [x] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
