### PR TITLE
fix: timelock not shown on tx summary

### DIFF
--- a/packages/desktop/views/dashboard/send-flow/views/TransactionSummaryView.svelte
+++ b/packages/desktop/views/dashboard/send-flow/views/TransactionSummaryView.svelte
@@ -46,8 +46,8 @@
     let metadataInput: OptionalInput
     let tagInput: OptionalInput
 
-    let selectedExpirationPeriod: TimePeriod
-    let selectedTimelockPeriod: TimePeriod
+    let selectedExpirationPeriod: TimePeriod | undefined = expirationDate ? TimePeriod.Custom : undefined
+    let selectedTimelockPeriod: TimePeriod | undefined = timelockDate ? TimePeriod.Custom : undefined
 
     $: transactionDetails = get(newTransactionDetails)
     $: recipient =


### PR DESCRIPTION
## Summary

When the transaction summary is accessed, the `selectedTimelockperiod` needs to be initialized if the timelock was set. With this, the item in the details will be displayed

## Changelog

```
- initialize `selectedTimelockperiod`
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
