### PR TITLE
fix: fix send flow on token information

### DIFF
--- a/packages/desktop/components/popups/TokenInformationPopup.svelte
+++ b/packages/desktop/components/popups/TokenInformationPopup.svelte
@@ -64,7 +64,7 @@
             asset: asset,
             disableAssetSelection: true,
         })
-        sendFlowRouter.set(new SendFlowRouter(undefined, SendFlowRoute.InputTokenAmount))
+        sendFlowRouter.set(new SendFlowRouter(undefined, SendFlowRoute.SelectRecipient))
         openPopup({
             id: features.wallet.newSendFlow.enabled ? PopupId.SendFlow : PopupId.SendForm,
             overflow: true,

--- a/packages/desktop/views/dashboard/send-flow/views/InputTokenAmountView.svelte
+++ b/packages/desktop/views/dashboard/send-flow/views/InputTokenAmountView.svelte
@@ -12,7 +12,6 @@
     import { get } from 'svelte/store'
     import { sendFlowRouter } from '../send-flow.router'
     import SendFlowTemplate from './SendFlowTemplate.svelte'
-    import { closePopup } from '@desktop/auxiliary/popup'
 
     const transactionDetails = get(newTransactionDetails)
     let assetAmountInput: TokenAmountInput
@@ -20,7 +19,6 @@
     let rawAmount: string
     let amount: string
     let unit: string
-    const disableAssetSelection = transactionDetails.disableAssetSelection
 
     if (transactionDetails.type === NewTransactionType.TokenTransfer) {
         asset = transactionDetails.asset
@@ -56,11 +54,7 @@
             type: NewTransactionType.TokenTransfer,
             rawAmount: undefined,
         })
-        if (disableAssetSelection) {
-            closePopup()
-        } else {
-            $sendFlowRouter.previous()
-        }
+        $sendFlowRouter.previous()
     }
 </script>
 
@@ -68,7 +62,7 @@
     title={localize('popups.transaction.selectAmount', {
         values: { tokenName: asset.metadata.name },
     })}
-    leftButton={{ text: localize(disableAssetSelection ? 'actions.cancel' : 'actions.back'), onClick: onBackClick }}
+    leftButton={{ text: localize('actions.back'), onClick: onBackClick }}
     rightButton={{ text: localize('actions.continue'), onClick: onContinueClick, disabled: !amount }}
 >
     <TokenAmountInput bind:this={assetAmountInput} bind:asset bind:rawAmount bind:inputtedAmount={amount} {unit} />

--- a/packages/desktop/views/dashboard/send-flow/views/SelectRecipientView.svelte
+++ b/packages/desktop/views/dashboard/send-flow/views/SelectRecipientView.svelte
@@ -2,28 +2,22 @@
     import { selectedAccount } from '@core/account/stores'
     import { localize } from '@core/i18n'
     import { ChainType, IIscpChainConfiguration, network } from '@core/network'
-    import {
-        NewTransactionType,
-        formatTokenAmountBestMatch,
-        newTransactionDetails,
-        updateNewTransactionDetails,
-    } from '@core/wallet'
+    import { NewTransactionType, newTransactionDetails, updateNewTransactionDetails } from '@core/wallet'
     import features from '@features/features'
     import { INetworkRecipientSelectorOption, NetworkRecipientSelector } from '@ui'
     import { onMount } from 'svelte'
     import { sendFlowRouter } from '../send-flow.router'
     import SendFlowTemplate from './SendFlowTemplate.svelte'
+    import { closePopup } from '@desktop/auxiliary/popup'
 
     let networkAddress = $newTransactionDetails?.layer2Parameters?.networkAddress
     let selectorOptions: INetworkRecipientSelectorOption[] = []
     let selectedIndex = -1
 
-    const formattedAmount =
+    const disableAssetSelection = $newTransactionDetails.disableAssetSelection
+    const assetName =
         $newTransactionDetails?.type === NewTransactionType.TokenTransfer
-            ? formatTokenAmountBestMatch(
-                  Number($newTransactionDetails?.rawAmount),
-                  $newTransactionDetails.asset?.metadata
-              )
+            ? $newTransactionDetails.asset?.metadata.name
             : undefined
 
     $: selectedOption = selectorOptions[selectedIndex]
@@ -98,15 +92,19 @@
             recipient: undefined,
             layer2Parameters: undefined,
         })
-        $sendFlowRouter.previous()
+        if (disableAssetSelection) {
+            closePopup()
+        } else {
+            $sendFlowRouter.previous()
+        }
     }
 </script>
 
 <SendFlowTemplate
     title={localize('popups.transaction.selectRecipient', {
-        values: { amount: formattedAmount },
+        values: { assetName },
     })}
-    leftButton={{ text: localize('actions.back'), onClick: onBackClick }}
+    leftButton={{ text: localize(disableAssetSelection ? 'actions.cancel' : 'actions.back'), onClick: onBackClick }}
     rightButton={{
         text: localize('actions.continue'),
         onClick: onContinueClick,

--- a/packages/shared/locales/en.json
+++ b/packages/shared/locales/en.json
@@ -908,7 +908,7 @@
             "body": "You’re about to send {amount} to",
             "selectToken": "Select a token",
             "selectAmount": "Send {tokenName}",
-            "selectRecipient": "Send {amount} to",
+            "selectRecipient": "Send {assetName} to",
             "transactionSummary": "Transaction to {recipient}",
             "surplusIncluded": "This transaction contains a surplus amount. Please double check this is the amount you want to send.",
             "sendingFromStakedAccount": "You are sending a transfer from a wallet that is currently being staked. This may unstake your tokens. Feel free to send the transfer but you may need to restake your remaining tokens afterwards.",


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

...

## Changelog

```
- `send` on token info directs now to recipient input
- `recipient input` only allows to close the popup instead of going back
- fix title of `recipient input` which still showed the token amount
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
