### PR TITLE
enhancement: show asset tile in token information popup

### DIFF
--- a/packages/desktop/components/popups/TokenInformationPopup.svelte
+++ b/packages/desktop/components/popups/TokenInformationPopup.svelte
@@ -87,7 +87,7 @@
             {/if}
         </div>
 
-        <AssetTile classes="mb-2 pointer-events-none" onClick={() => {}} {asset} />
+        <AssetTile classes="pointer-events-none" onClick={() => {}} {asset} />
 
         <div class="space-y-4 flex flex-col items-center justify-center">
             {#if !asset.verification?.verified}

--- a/packages/desktop/components/popups/TokenInformationPopup.svelte
+++ b/packages/desktop/components/popups/TokenInformationPopup.svelte
@@ -87,9 +87,7 @@
             {/if}
         </div>
 
-        <div class="space-y-3 flex flex-col items-center justify-center">
-            <AssetTile classes="mb-2 pointer-events-none" onClick={() => {}} {asset} />
-        </div>
+        <AssetTile classes="mb-2 pointer-events-none" onClick={() => {}} {asset} />
 
         <div class="space-y-4 flex flex-col items-center justify-center">
             {#if !asset.verification?.verified}

--- a/packages/desktop/components/popups/TokenInformationPopup.svelte
+++ b/packages/desktop/components/popups/TokenInformationPopup.svelte
@@ -10,15 +10,14 @@
         NotVerifiedStatus,
         VerifiedStatus,
         NewTransactionType,
-        getUnitFromTokenMetadata,
     } from '@core/wallet'
     import { openPopup, PopupId, updatePopupProps } from '@desktop/auxiliary/popup'
     import {
-        AssetIcon,
         Button,
         Text,
         TextHint,
         AssetActionsButton,
+        AssetTile,
         KeyValueBox,
         FontWeight,
         TextType,
@@ -89,10 +88,7 @@
         </div>
 
         <div class="space-y-3 flex flex-col items-center justify-center">
-            <AssetIcon {asset} chainId={asset.chainId} large />
-            <Text type={TextType.h2} fontWeight={FontWeight.bold}>
-                {getUnitFromTokenMetadata(asset.metadata)}
-            </Text>
+            <AssetTile classes="mb-2 pointer-events-none" onClick={() => {}} {asset} />
         </div>
 
         <div class="space-y-4 flex flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
 Display the Asset tile in Token Information Popup to match the Assets List
closes #6940 

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android


## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
