### PR TITLE
fix: modal visibility when pane has overflow-hidden

### DIFF
--- a/packages/desktop/components/menu-buttons/ProposalDetailsButton.svelte
+++ b/packages/desktop/components/menu-buttons/ProposalDetailsButton.svelte
@@ -88,11 +88,16 @@
 
 <div class="max-h-7 max-w-9 flex-none flex-initial overflow-visible relative">
     <MeatballMenuButton onClick={modal?.toggle} />
-    <Modal bind:this={modal} position={{ right: '0' }} classes="mt-1.5">
-        <div class="flex flex-col">
-            {#each buttons as button}
-                <MenuItem {...button} />
-            {/each}
-        </div>
-    </Modal>
+    <div class="fixed overflow-visible translate-x-9">
+        <Modal bind:this={modal} position={{ right: '0' }} classes="mt-1.5">
+            <div class="flex flex-col">
+                {#each buttons as button}
+                    <MenuItem {...button} />
+                {/each}
+            </div>
+        </Modal>
+    </div>
 </div>
+
+<style lang="scss">
+</style>


### PR DESCRIPTION
## Summary

Closes #7117 

## Changelog

before:
![image](https://github.com/iotaledger/firefly/assets/72078237/d88ad5c3-0899-4855-9439-df350abfe30b)

after:
![image](https://github.com/iotaledger/firefly/assets/72078237/3c794d6e-7ae8-41e1-894b-1f05c25268c6)


## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
