### PR TITLE
fix: phase filter locale in the Governance view

### DIFF
--- a/packages/shared/lib/contexts/governance/constants/default-proposal-filter.constant.ts
+++ b/packages/shared/lib/contexts/governance/constants/default-proposal-filter.constant.ts
@@ -7,7 +7,7 @@ export const DEFAULT_PROPOSAL_FILTER: IProposalFilter = {
         active: false,
         type: 'selection',
         labelKey: 'filters.phase.label',
-        localeKey: 'pills.proposalStatus',
+        localeKey: 'pills.governance.proposalStatus',
         selected: ProposalStatus.Commencing,
         choices: [ProposalStatus.Commencing, ProposalStatus.Upcoming, ProposalStatus.Holding, ProposalStatus.Ended],
     },


### PR DESCRIPTION
Closes #7276 

## Summary

> Fix literals in phase filter texts in the Governance view

## Changelog

```
- Modify locale text
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [X] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

- Go to the governance screen
- Click on the filters and apply `phase`
- Check that the text of the options is correct

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
