### PR TITLE
fix: dont store stronghold version on ledger profiles

### DIFF
--- a/packages/desktop/views/onboarding/views/create-profile/views/ChooseCreateProfileFlowView.svelte
+++ b/packages/desktop/views/onboarding/views/create-profile/views/ChooseCreateProfileFlowView.svelte
@@ -27,8 +27,10 @@
 
     async function onProfileTypeClick(createProfileType: CreateProfileType): Promise<void> {
         isBusy = { ...isBusy, [createProfileType]: true }
-        const type = createProfileType === CreateProfileType.Ledger ? ProfileType.Ledger : ProfileType.Software
-        updateOnboardingProfile({ createProfileType, type })
+        const isLedgerProfile = createProfileType === CreateProfileType.Ledger
+        const type = isLedgerProfile ? ProfileType.Ledger : ProfileType.Software
+        const strongholdVersion = isLedgerProfile ? undefined : $onboardingProfile.strongholdVersion
+        updateOnboardingProfile({ createProfileType, type, strongholdVersion })
         await initialiseProfileManagerFromOnboardingProfile()
         $createProfileRouter.next()
     }

--- a/packages/desktop/views/onboarding/views/create-profile/views/ChooseCreateProfileFlowView.svelte
+++ b/packages/desktop/views/onboarding/views/create-profile/views/ChooseCreateProfileFlowView.svelte
@@ -15,6 +15,7 @@
     import { destroyProfileManager } from '@core/profile-manager/actions'
     import { Icon as IconEnum } from '@auxiliary/icon'
     import { AnimationEnum } from '@auxiliary/animation'
+    import { STRONGHOLD_VERSION } from '@core/stronghold'
 
     let isBusy = {
         [CreateProfileType.Mnemonic]: false,
@@ -29,8 +30,8 @@
         isBusy = { ...isBusy, [createProfileType]: true }
         const isLedgerProfile = createProfileType === CreateProfileType.Ledger
         const type = isLedgerProfile ? ProfileType.Ledger : ProfileType.Software
-        const strongholdVersion = isLedgerProfile ? undefined : $onboardingProfile.strongholdVersion
-        updateOnboardingProfile({ createProfileType, type, strongholdVersion })
+        const strongholdVersion = isLedgerProfile ? undefined : STRONGHOLD_VERSION
+        updateOnboardingProfile({ createProfileType, type, ...(strongholdVersion && { strongholdVersion }) })
         await initialiseProfileManagerFromOnboardingProfile()
         $createProfileRouter.next()
     }

--- a/packages/shared/lib/contexts/onboarding/helpers/buildInitialOnboardingProfile.ts
+++ b/packages/shared/lib/contexts/onboarding/helpers/buildInitialOnboardingProfile.ts
@@ -1,5 +1,4 @@
 import { generateRandomId } from '@core/utils'
-import { STRONGHOLD_VERSION } from '@core/stronghold'
 import { IOnboardingProfile } from '../interfaces'
 
 /**
@@ -10,6 +9,5 @@ export function buildInitialOnboardingProfile(isDeveloperProfile: boolean): Part
     return {
         id: generateRandomId(),
         isDeveloperProfile,
-        strongholdVersion: STRONGHOLD_VERSION,
     }
 }

--- a/packages/shared/lib/core/profile/actions/active-profile/saveActiveProfile.ts
+++ b/packages/shared/lib/core/profile/actions/active-profile/saveActiveProfile.ts
@@ -16,7 +16,7 @@ export function saveActiveProfile(): void {
             isDeveloperProfile: _activeProfile.isDeveloperProfile,
             clientOptions: _activeProfile.clientOptions,
             forceAssetRefresh: _activeProfile.forceAssetRefresh,
-            strongholdVersion: _activeProfile.strongholdVersion,
+            ...(_activeProfile.strongholdVersion && { strongholdVersion: _activeProfile.strongholdVersion }),
             ...(_activeProfile.hasVisitedDashboard && { hasVisitedDashboard: _activeProfile.hasVisitedDashboard }),
             ...(_activeProfile.lastUsedAccountIndex && { lastUsedAccountIndex: _activeProfile.lastUsedAccountIndex }),
             ...(_activeProfile.accountPersistedData && { accountPersistedData: _activeProfile.accountPersistedData }),

--- a/packages/shared/lib/core/profile/actions/profiles/checkAndMigrateProfiles.ts
+++ b/packages/shared/lib/core/profile/actions/profiles/checkAndMigrateProfiles.ts
@@ -295,7 +295,7 @@ function persistedProfileMigrationToV13(
 function persistedProfileMigrationToV14(existingProfile: IPersistedProfile): void {
     const isLedgerProfile = existingProfile?.type === ProfileType.Ledger
     if (isLedgerProfile) {
-        existingProfile.strongholdVersion = undefined
+        delete existingProfile.strongholdVersion
         saveProfile(existingProfile)
     }
 }

--- a/packages/shared/lib/core/profile/actions/profiles/checkAndMigrateProfiles.ts
+++ b/packages/shared/lib/core/profile/actions/profiles/checkAndMigrateProfiles.ts
@@ -17,6 +17,7 @@ import {
 } from '../../constants'
 import { IPersistedProfile } from '../../interfaces'
 import { currentProfileVersion, profiles, saveProfile } from '../../stores'
+import { ProfileType } from '@core/profile/enums'
 
 /**
  * Migrates profile data in need of being modified to accommodate changes
@@ -60,6 +61,7 @@ const persistedProfileMigrationsMap: Record<number, (existingProfile: unknown) =
     10: persistedProfileMigrationToV11,
     11: persistedProfileMigrationToV12,
     12: persistedProfileMigrationToV13,
+    13: persistedProfileMigrationToV14,
 }
 
 function persistedProfileMigrationToV4(existingProfile: unknown): void {
@@ -288,4 +290,12 @@ function persistedProfileMigrationToV13(
     }
 
     saveProfile(newProfile as IPersistedProfile)
+}
+
+function persistedProfileMigrationToV14(existingProfile: IPersistedProfile): void {
+    const isLedgerProfile = existingProfile?.type === ProfileType.Ledger
+    if (isLedgerProfile) {
+        existingProfile.strongholdVersion = undefined
+        saveProfile(existingProfile)
+    }
 }

--- a/packages/shared/lib/core/profile/constants/profile-version.constant.ts
+++ b/packages/shared/lib/core/profile/constants/profile-version.constant.ts
@@ -1,1 +1,1 @@
-export const PROFILE_VERSION = 13
+export const PROFILE_VERSION = 14

--- a/packages/shared/lib/core/profile/interfaces/persisted-profile.interface.ts
+++ b/packages/shared/lib/core/profile/interfaces/persisted-profile.interface.ts
@@ -20,6 +20,6 @@ export interface IPersistedProfile {
     lastUsedAccountIndex?: number
     clientOptions: IClientOptions
     forceAssetRefresh: boolean
-    strongholdVersion: StrongholdVersion
+    strongholdVersion?: StrongholdVersion
     pfp?: INft
 }


### PR DESCRIPTION
Closes #7291 

## Summary

> dont store stronghold version on ledger profiles

## Changelog

```
- Remove strongholdVersion in Ledger profiles
- Dont store stronghold version when creating ledger profiles
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [X] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

- Check in the `localStorage` that the `strongholdVersion` of the Ledger profiles no longer appears
- Create a new ledger profile and check that `strongholdVersion` is not stored

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
