### PR TITLE
fix(ci): Install Python 2 manually on macOS

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -135,7 +135,6 @@ jobs:
               env:
                   SENTRY_DSN: ${{ secrets.SENTRY_DSN_PROD_BACKEND }}
                   SENTRY_ENVIRONMENT: ${{ env.STAGE }}
-                  NODE_GYP_FORCE_PYTHON: '2.7.18'
 
             - name: Install Sentry CLI
               # Yarn has issues putting binaries in the PATH on Windows

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -60,11 +60,10 @@ jobs:
               with:
                   node-version: 14.x
 
-            - name: Set up Python 2.x (macOS)
-              uses: actions/setup-python@v2
-              if: matrix.os == 'macos-11'
+            - name: Set up Python 3.10
+              uses: actions/setup-python@v4
               with:
-                  python-version: '2.x'
+                python-version: '3.10'
 
             - name: Install Rust toolchain
               uses: actions-rs/toolchain@v1
@@ -180,6 +179,18 @@ jobs:
                   SENTRY: ${{ startsWith(github.ref, 'refs/tags/desktop') }}
                   SENTRY_DSN: ${{ secrets.SENTRY_DSN_PROD_DESKTOP }}
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+            - name: Set up Python 2.x (macOS)
+              if: matrix.os == 'macos-11'
+              run: |
+                wget https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg -O ${{ runner.temp }}/python.pkg
+                sudo installer -pkg ${{ runner.temp }}/python.pkg -target / -verbose
+            
+            - name: Test Python 2.x (macOS)
+              if: matrix.os == 'macos-11'
+              run: |
+                which python
+                python --version
 
             - name: Build Electron app (macOS)
               run: yarn compile:${STAGE}:mac


### PR DESCRIPTION
## Summary

Installs Python 2 on macOS by downloading the PKG from python.org. This is necessary because `actions/setup-python` has removed support for Python 2 (https://github.com/actions/setup-python/issues/672) but we still need it for the DMG builder script in `electron-builder`. This needs to be run right before building the DMG since Python 3 is necessary for `node-gyp` when building the bindings, but the Python 2 installation script will override it.

## Testing

CI workflow passes

### Platforms

-   **Desktop**
    -   [x] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [x] I have verified that my latest changes pass CI workflows for testing and linting