### PR TITLE
fix(ci): Fix macOS build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -65,6 +65,12 @@ jobs:
               with:
                 python-version: '3.10'
 
+            - name: Select Xcode
+              uses: maxim-lobanov/setup-xcode@v1
+              if: matrix.os == 'macos-13'
+              with:
+                xcode-version: 'latest-stable'
+
             - name: Install Rust toolchain
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -89,6 +89,10 @@ jobs:
               run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
               if: matrix.os == 'windows-latest'
 
+            - name: Set deployment target (macOS)
+              run: echo "MACOSX_DEPLOYMENT_TARGET=10.13" >> $GITHUB_ENV
+              if: matrix.os == 'macos-13'
+
             - name: Update node-gyp to 9.3.1 and apply patch (Windows)
               # The node-gyp bundled with Node 14.x does not support VS 2022
               # https://github.com/nodejs/node-gyp/blob/main/docs/Updating-npm-bundled-node-gyp.md#windows
@@ -111,9 +115,16 @@ jobs:
               working-directory: packages/backend/bindings/node/native
               if: matrix.os == 'windows-latest'
 
-            - name: Set deployment target (macOS)
-              run: echo "MACOSX_DEPLOYMENT_TARGET=10.13" >> $GITHUB_ENV
-              if: matrix.os == 'macos-13'
+            # This step is required to support macOS 10.13
+            - name: Apply librocksdb-sys patch (macOS)
+              run: |
+                cargo install cargo-patch
+                cp ${{ github.workspace }}/manual-patches/rocksdb_faligned_allocation.patch .
+                git apply --ignore-space-change --ignore-whitespace ${{ github.workspace }}/manual-patches/macos_cargo_toml.patch
+                cat Cargo.toml
+                cargo patch
+              working-directory: packages/backend/bindings/node/native
+              if: ${{ startsWith(matrix.os, 'macos') }}
 
             - name: Install required packages (Linux)
               run: |

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -46,7 +46,7 @@ jobs:
         needs: [setup]
         strategy:
             matrix:
-                os: [ubuntu-20.04, macos-11, windows-latest]
+                os: [ubuntu-20.04, macos-13, windows-latest]
             fail-fast: false
         env:
             VERSION: ${{ needs.setup.outputs.version }}
@@ -107,7 +107,7 @@ jobs:
 
             - name: Set deployment target (macOS)
               run: echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
-              if: matrix.os == 'macos-11'
+              if: matrix.os == 'macos-13'
 
             - name: Install required packages (Linux)
               run: |
@@ -139,7 +139,7 @@ jobs:
             - name: Install Sentry CLI
               # Yarn has issues putting binaries in the PATH on Windows
               run: npm i -g @sentry/cli
-              if: ${{ startsWith(github.ref, 'refs/tags/desktop') && matrix.os != 'macos-11' }}
+              if: ${{ startsWith(github.ref, 'refs/tags/desktop') && matrix.os != 'macos-13' }}
 
             #    - name: Strip backend debug info and upload to Sentry (Linux)
             #      run: |
@@ -180,13 +180,13 @@ jobs:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
             - name: Set up Python 2.x (macOS)
-              if: matrix.os == 'macos-11'
+              if: matrix.os == 'macos-13'
               run: |
                 wget https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg -O ${{ runner.temp }}/python.pkg
                 sudo installer -pkg ${{ runner.temp }}/python.pkg -target / -verbose
             
             - name: Test Python 2.x (macOS)
-              if: matrix.os == 'macos-11'
+              if: matrix.os == 'macos-13'
               run: |
                 which python
                 python --version
@@ -199,7 +199,7 @@ jobs:
                   FIREFLY_APPLE_ID: ${{ secrets.APPLE_ID }}
                   FIREFLY_APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
               working-directory: packages/desktop
-              if: matrix.os == 'macos-11'
+              if: matrix.os == 'macos-13'
 
             - name: Build Electron app (Windows)
               run: yarn compile:${env:STAGE}:win
@@ -238,7 +238,7 @@ jobs:
             - name: Compute checksums (macOS)
               run: for i in `ls | grep 'firefly-desktop*'` ; do shasum -a 256 $i | awk {'print $1'} > $i.sha256 ; done
               working-directory: packages/desktop/out
-              if: matrix.os == 'macos-11'
+              if: matrix.os == 'macos-13'
 
             - name: Compute checksums (Windows)
               run: Get-ChildItem "." -Filter firefly-desktop* | Foreach-Object { $(Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash | Set-Content ($_.FullName + '.sha256') }
@@ -277,7 +277,7 @@ jobs:
             - name: Downloading artifacts
               uses: actions/download-artifact@v2
               with:
-                  name: firefly-desktop-macos-11
+                  name: firefly-desktop-macos-13
                   path: assets
 
             - name: Downloading artifacts

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,7 +112,7 @@ jobs:
               if: matrix.os == 'windows-latest'
 
             - name: Set deployment target (macOS)
-              run: echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
+              run: echo "MACOSX_DEPLOYMENT_TARGET=10.13" >> $GITHUB_ENV
               if: matrix.os == 'macos-13'
 
             - name: Install required packages (Linux)

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -135,7 +135,6 @@ jobs:
               env:
                   SENTRY_DSN: ${{ secrets.SENTRY_DSN_PROD_BACKEND }}
                   SENTRY_ENVIRONMENT: ${{ env.STAGE }}
-                  NODE_GYP_FORCE_PYTHON: '2.7.18'
 
             - name: Install Sentry CLI
               # Yarn has issues putting binaries in the PATH on Windows

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -60,11 +60,10 @@ jobs:
               with:
                   node-version: 14.x
 
-            - name: Set up Python 2.x (macOS)
-              uses: actions/setup-python@v2
-              if: matrix.os == 'macos-11'
+            - name: Set up Python 3.10
+              uses: actions/setup-python@v4
               with:
-                  python-version: '2.x'
+                python-version: '3.10'
 
             - name: Install Rust toolchain
               uses: actions-rs/toolchain@v1
@@ -180,6 +179,18 @@ jobs:
                   SENTRY: ${{ startsWith(github.ref, 'refs/tags/desktop') }}
                   SENTRY_DSN: ${{ secrets.SENTRY_DSN_PROD_DESKTOP }}
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+            - name: Set up Python 2.x (macOS)
+              if: matrix.os == 'macos-11'
+              run: |
+                wget https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg -O ${{ runner.temp }}/python.pkg
+                sudo installer -pkg ${{ runner.temp }}/python.pkg -target / -verbose
+            
+            - name: Test Python 2.x (macOS)
+              if: matrix.os == 'macos-11'
+              run: |
+                which python
+                python --version
 
             - name: Build Electron app (macOS)
               run: yarn compile:${STAGE}:mac

--- a/manual-patches/macos_cargo_toml.patch
+++ b/manual-patches/macos_cargo_toml.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/backend/bindings/node/native/Cargo.toml b/packages/backend/bindings/node/native/Cargo.toml
+index 1fd63b42c..9e8f1fc71 100644
+--- a/packages/backend/bindings/node/native/Cargo.toml
++++ b/packages/backend/bindings/node/native/Cargo.toml
+@@ -26,3 +26,12 @@ firefly-actor-system = { path = "../../.." }
+ [profile.release]
+ # Build with debug symbols included
+ debug = true
++
++[package.metadata.patch.librocksdb-sys]
++version = "0.11.0+8.3.2"
++patches = [
++    { path = "rocksdb_faligned_allocation.patch", source = "GithubPrDiff" },
++]
++
++[patch.crates-io]
++librocksdb-sys = { path = "./target/patch/librocksdb-sys-0.11.0+8.3.2"}

--- a/manual-patches/rocksdb_faligned_allocation.patch
+++ b/manual-patches/rocksdb_faligned_allocation.patch
@@ -1,0 +1,12 @@
+diff --git a/build.rs b/build.rs
+index dae9682..1545e18 100644
+--- a/build.rs
++++ b/build.rs
+@@ -150,6 +150,7 @@ fn build_rocksdb() {
+         config.define("OS_MACOSX", None);
+         config.define("ROCKSDB_PLATFORM_POSIX", None);
+         config.define("ROCKSDB_LIB_IO_POSIX", None);
++        config.flag_if_supported("-faligned-allocation");
+     } else if target.contains("android") {
+         config.define("OS_ANDROID", None);
+         config.define("ROCKSDB_PLATFORM_POSIX", None);


### PR DESCRIPTION
## Summary

- Installs Python 2 on macOS by downloading the PKG from python.org. This is necessary because `actions/setup-python` has removed support for Python 2 (https://github.com/actions/setup-python/issues/672) but we still need it for the DMG builder script in `electron-builder`. This needs to be run right before building the DMG since Python 3 is necessary for `node-gyp` when building the bindings, but the Python 2 installation script will override it.
- Remove `NODE_GYP_FORCE_PYTHON`
- Use macOS 13 runner with latest stable Xcode
- Set macOS deployment target to 10.13
- Patch `librocksdb-sys` to support macOS 10.13 (see https://github.com/iotaledger/iota-sdk/pull/195)


## Changelog

```
- Drop support for macOS 10.12 (all models that support macOS 10.12 also support macOS 10.13)
```

## Testing
CI passes

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
