### PR TITLE
fix: cannot read properties of null (reading `webContents`) using `powerMonitor` on macOS

### DIFF
--- a/packages/desktop/electron/main.js
+++ b/packages/desktop/electron/main.js
@@ -359,12 +359,12 @@ app.on('window-all-closed', () => {
 
 powerMonitor.on('suspend', () => {
     // MacOS, Windows and Linux
-    windows.main.webContents.send('power-monitor-suspend')
+    windows.main?.webContents?.send('power-monitor-suspend')
 })
 
 powerMonitor.on('lock-screen', () => {
     // MacOS and Windows
-    windows.main.webContents.send('power-monitor-lock-screen')
+    windows.main?.webContents?.send('power-monitor-lock-screen')
 })
 
 app.once('ready', () => {


### PR DESCRIPTION
Closes #7306

## Summary

> Fix error screen randomly after coming back to machine

## Changelog

```
- Add optional chaining to prevent app from crashing when suspended
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [X] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Login to a profile and `suspend` the machine


## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
