### PR TITLE
fix: misleading insufficient funds on send

### DIFF
--- a/packages/desktop/components/popups/send/SendConfirmationPopup.svelte
+++ b/packages/desktop/components/popups/send/SendConfirmationPopup.svelte
@@ -25,7 +25,7 @@
     import { DEFAULT_TRANSACTION_OPTIONS } from '@core/wallet/constants'
     import { getOutputParameters, validateSendConfirmation, getAddressFromSubject } from '@core/wallet/utils'
     import { Activity, NewTokenTransactionDetails, Output } from '@core/wallet/types'
-    import { closePopup, openPopup, PopupId } from '@auxiliary/popup'
+    import { closePopup, openPopup, PopupId, updatePopupProps } from '@auxiliary/popup'
     import { ledgerPreparedOutput } from '@core/ledger'
     import { getStorageDepositFromOutput } from '@core/wallet/utils/generateActivity/helper'
     import { handleError } from '@core/error/handlers/handleError'
@@ -41,6 +41,7 @@
 
     export let _onMount: (..._: any[]) => Promise<void> = async () => {}
     export let disableBack = false
+    export let isOutputAlreadyPrepared: boolean = false
 
     let {
         recipient,
@@ -103,8 +104,10 @@
     }
 
     function refreshSendConfirmationState(): void {
-        updateNewTransactionDetails({ type: transactionDetails.type, expirationDate, giftStorageDeposit, surplus })
-        void prepareTransactionOutput()
+        if (!isOutputAlreadyPrepared) {
+            updateNewTransactionDetails({ type: transactionDetails.type, expirationDate, giftStorageDeposit, surplus })
+            void prepareTransactionOutput()
+        }
     }
 
     function getInitialExpirationDate(): TimePeriod {
@@ -171,6 +174,8 @@
             if ($isActiveLedgerProfile) {
                 ledgerPreparedOutput.set(preparedOutput)
             }
+
+            updatePopupProps({ isOutputAlreadyPrepared: true })
             await checkActiveProfileAuth(sendOutputAndClosePopup, { stronghold: true, ledger: false })
         } catch (err) {
             handleError(err)


### PR DESCRIPTION
## Summary

> Adds a check so that the `preparedOutput` won't be recomputed after "Stronghold unlocking" step and `sendOutputAndClosePopup` callback execution.

Previously we had the case where, after ` checkActiveProfileAuth` (stronghold unlock step), the `SendConfirmationPopup` component would be re-mounted, also recomputing `preparedOutput` before executing the callback, causing the wallet to throw an error on this subsequent `prepareOutput()` because the output was already "locked" in the previous execution.

Closes https://github.com/iotaledger/firefly/issues/7373

## Changelog

```
- Fixed a misleading insufficient funds error (visible only in dev mode) cause by trying to lock the same output(s) twice 
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [x] MacOS
    -   [ ] Linux
    -   [ ] Windows
-   **Mobile**
    -   [ ] iOS
    -   [ ] Android

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

1. Log into a stronghold profile
2. While stronghold is "locked"
3. Send a simple transaction to another wallet (even for the same profile)
4. Unlock stronghold and finish sending
5. You should see an error in console and screen overlay with "insufficient funds" while also having the transaction go through

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
