### PR TITLE
Fix: Simplify validateSendConfirmation

### DIFF
--- a/packages/desktop/components/popups/send/SendConfirmationPopup.svelte
+++ b/packages/desktop/components/popups/send/SendConfirmationPopup.svelte
@@ -122,24 +122,28 @@
     }
 
     async function prepareTransactionOutput(): Promise<void> {
-        const transactionDetails = get(newTransactionDetails)
-        const outputParams = await getOutputParameters(transactionDetails)
-        preparedOutput = await prepareOutput($selectedAccount.index, outputParams, DEFAULT_TRANSACTION_OPTIONS)
+        try {
+            const transactionDetails = get(newTransactionDetails)
+            const outputParams = await getOutputParameters(transactionDetails)
+            preparedOutput = await prepareOutput($selectedAccount.index, outputParams, DEFAULT_TRANSACTION_OPTIONS)
 
-        await updateStorageDeposit()
+            await updateStorageDeposit()
 
-        // Note: we need to adjust the surplus
-        // so we make sure that the surplus is always added on top of the minimum storage deposit
-        if (Number(surplus) > 0) {
-            if (minimumStorageDeposit >= Number(surplus)) {
-                visibleSurplus = surplus = undefined
-            } else {
-                visibleSurplus = Number(surplus) - minimumStorageDeposit
-                // Note: we have to hide it because currently, in the sdk,
-                // the storage deposit return strategy is only looked at
-                // if the provided amount is < the minimum required storage deposit
-                hideGiftToggle = true
+            // Note: we need to adjust the surplus
+            // so we make sure that the surplus is always added on top of the minimum storage deposit
+            if (Number(surplus) > 0) {
+                if (minimumStorageDeposit >= Number(surplus)) {
+                    visibleSurplus = surplus = undefined
+                } else {
+                    visibleSurplus = Number(surplus) - minimumStorageDeposit
+                    // Note: we have to hide it because currently, in the sdk,
+                    // the storage deposit return strategy is only looked at
+                    // if the provided amount is < the minimum required storage deposit
+                    hideGiftToggle = true
+                }
             }
+        } catch (err) {
+            handleError(err)
         }
 
         if (transactionDetails.expirationDate === undefined) {
@@ -170,7 +174,7 @@
 
     async function onConfirmClick(): Promise<void> {
         try {
-            await validateSendConfirmation($selectedAccount, preparedOutput as CommonOutput)
+            validateSendConfirmation(preparedOutput as CommonOutput)
 
             if ($isActiveLedgerProfile) {
                 ledgerPreparedOutput.set(preparedOutput)

--- a/packages/shared/lib/core/wallet/utils/send/validateSendConfirmation.ts
+++ b/packages/shared/lib/core/wallet/utils/send/validateSendConfirmation.ts
@@ -1,26 +1,15 @@
-import { getSelectedAccount } from '@core/account'
-import { InsufficientFundsForStorageDepositError, InvalidExpirationDateTimeError } from '@contexts/wallet'
+import { InvalidExpirationDateTimeError } from '@contexts/wallet'
 import { convertUnixTimestampToDate, isValidExpirationDateTime } from '@core/utils'
-import { getStorageDepositFromOutput } from '../generateActivity/helper'
-import { IAccountState } from '@core/account/interfaces'
-import { CommonOutput, ExpirationUnlockCondition, OutputType, UnlockConditionType } from '@iota/sdk/out/types'
+import { CommonOutput, ExpirationUnlockCondition, UnlockConditionType } from '@iota/sdk/out/types'
 
-export async function validateSendConfirmation(account: IAccountState, output: CommonOutput): Promise<void> {
-    const parseNumber = (value: string) => parseInt(value, 10) ?? 0
-    const amount = parseNumber(output?.amount)
-    const balance = parseNumber(getSelectedAccount()?.balances?.baseCoin.available.toString() ?? '0')
-    const { storageDeposit, giftedStorageDeposit } = await getStorageDepositFromOutput(account, output)
-
+export function validateSendConfirmation(output: CommonOutput): void {
     const expirationUnlockCondition = output.unlockConditions.find(
         (c) => c.type === UnlockConditionType.Expiration
     ) as ExpirationUnlockCondition
     const expirationUnixTime = expirationUnlockCondition?.unixTime
     const expirationDateTime = expirationUnixTime ? convertUnixTimestampToDate(expirationUnixTime) : undefined
 
-    const isNft = output.type === OutputType.Nft
-    if (!isNft && (balance < amount + storageDeposit || balance < amount + giftedStorageDeposit)) {
-        throw new InsufficientFundsForStorageDepositError()
-    } else if (expirationDateTime && !isValidExpirationDateTime(expirationDateTime)) {
+    if (expirationDateTime && !isValidExpirationDateTime(expirationDateTime)) {
         throw new InvalidExpirationDateTimeError()
     }
 }


### PR DESCRIPTION
## Summary
- Simplified `validateSendConfirmation`  by removing available balance check because that validation is already done in the previous step in `SendFormPopup`
- add try catch to `prepareOutput` in SendConfirmationPopup

resolves #7396 

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [ ] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
