### PR TITLE
Fix: Enhanced logic for identifying burned native tokens.

### DIFF
--- a/packages/shared/lib/core/wallet/utils/outputs/preprocessOutgoingTransaction.ts
+++ b/packages/shared/lib/core/wallet/utils/outputs/preprocessOutgoingTransaction.ts
@@ -1,5 +1,5 @@
 import { IProcessedTransaction, IWrappedOutput } from '../../interfaces'
-import { Output, RegularTransactionEssence, Transaction, UTXOInput } from '@iota/sdk/out/types'
+import { Output, OutputType, RegularTransactionEssence, Transaction, UTXOInput } from '@iota/sdk/out/types'
 import { computeOutputId } from './computeOutputId'
 import { getOutputIdFromTransactionIdAndIndex } from './getOutputIdFromTransactionIdAndIndex'
 import { getDirectionFromOutgoingTransaction } from '../transactions'
@@ -57,6 +57,6 @@ function convertTransactionOutputTypeToWrappedOutput(
     return {
         outputId,
         output: outputType,
-        remainder: false,
+        remainder: index === 0 || outputType.type !== OutputType.Basic ? false : true, // when sending prepared output in the resulting transactions outputs array it will always be first output(index = 0)
     }
 }

--- a/packages/shared/lib/core/wallet/utils/transactions/getNonRemainderBasicOutputsFromTransaction.ts
+++ b/packages/shared/lib/core/wallet/utils/transactions/getNonRemainderBasicOutputsFromTransaction.ts
@@ -9,12 +9,13 @@ export function getNonRemainderBasicOutputsFromTransaction(
     accountAddressesWithOutputs: AddressWithOutputs[],
     direction: ActivityDirection
 ): IWrappedOutput[] {
+    const accountAddresses = accountAddressesWithOutputs.map((addressWithOutputs) => addressWithOutputs.address)
+
     return wrappedOutputs.filter((outputData) => {
         const recipientAddress = getRecipientAddressFromOutput(outputData.output as CommonOutput)
-        const accountAddresses = accountAddressesWithOutputs.map((addressWithOutputs) => addressWithOutputs.address)
 
         if (direction === ActivityDirection.Incoming || direction === ActivityDirection.SelfTransaction) {
-            return accountAddresses.includes(recipientAddress)
+            return !outputData.remainder && accountAddresses.includes(recipientAddress)
         } else {
             return !accountAddresses.includes(recipientAddress)
         }


### PR DESCRIPTION
## Summary

- Refactor `getBurnedNativeTokens` logic for identifying burned native tokens.
- Update logic to determine `remainder` in `convertTransactionOutputTypeToWrappedOutput`
- Update logic `getNonRemainderBasicOutputsFromTransaction` to use `remainder` property

resolves #7107 

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [ ] Windows


## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
