### PR TITLE
hotfix: remove `bits` and `sats` currencies

### DIFF
--- a/packages/shared/lib/core/market/enums/market-currency.enum.ts
+++ b/packages/shared/lib/core/market/enums/market-currency.enum.ts
@@ -58,6 +58,4 @@ export enum MarketCurrency {
     Xdr = 'xdr',
     Xag = 'xag',
     Xau = 'xau',
-    Bits = 'bits',
-    Sats = 'sats',
 }


### PR DESCRIPTION
## Summary

Profile gets corrupted when `bits` or `sats` currency are selected, so this PR removes them

## Changelog

```
- Removes `bits` currency in `market-currency.enum.ts`
- Removes `sats` currency in `market-currency.enum.ts`
```

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

### Instructions

- Try selecting `bits` or `sats` in another branch and profile should get corrupted (inaccessible)
- In `hotfix/remove-bits-and-sats-main` branch the not working currencies should not show in settings

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
