### PR TITLE
feat: add validate input on blur

### DIFF
--- a/packages/shared/components/SelectorInput.svelte
+++ b/packages/shared/components/SelectorInput.svelte
@@ -3,6 +3,7 @@
     import { Modal, TextInput, Text, TextType, FontWeight, IOption } from 'shared/components'
     import { fade } from 'svelte/transition'
     import { truncateString } from '@core/utils'
+    import { createEventDispatcher } from 'svelte'
 
     export let labelLocale: string
     export let options: IOption[]
@@ -15,6 +16,8 @@
     // HTML checks whether this value is absent to determine whether the field is readonly
     // If the attribute is set to false, HTML interprets it as a readonly field.
     export let readonly: boolean | null = null
+
+    const dispatch = createEventDispatcher()
 
     let value: string = selected?.key ?? selected?.value ?? ''
     let previousValue: string = value
@@ -73,6 +76,7 @@
         placeholder={localize(labelLocale)}
         fontSize="sm"
         {readonly}
+        on:blur={() => dispatch('blur')}
         {...$$restProps}
     >
         <div slot="right">

--- a/packages/shared/components/inputs/AmountInput.svelte
+++ b/packages/shared/components/inputs/AmountInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { NumberInput, FontWeight } from 'shared/components'
+    import { createEventDispatcher } from 'svelte'
 
     export let inputElement: HTMLInputElement | undefined = undefined
     export let fontSize = 24
@@ -7,6 +8,8 @@
     export let disabled = false
     export let hasFocus = false
     export let amount: string = ''
+
+    const dispatch = createEventDispatcher()
 
     $: amount, addLeadingZeroToDecimalSeparator()
 
@@ -26,5 +29,6 @@
     {fontSize}
     alignment="right"
     {fontWeight}
+    on:blur={() => dispatch('blur')}
     {...$$restProps}
 />

--- a/packages/shared/components/inputs/AssetAmountInput.svelte
+++ b/packages/shared/components/inputs/AssetAmountInput.svelte
@@ -119,6 +119,7 @@
             clearPadding
             clearBorder
             {disabled}
+            on:blur={() => validate()?.catch((err) => console.error(err))}
         />
         {#if getUnitFromTokenMetadata(asset?.metadata)}
             <UnitInput bind:unit bind:isFocused {disabled} tokenMetadata={asset?.metadata} />

--- a/packages/shared/components/inputs/Input.svelte
+++ b/packages/shared/components/inputs/Input.svelte
@@ -165,7 +165,10 @@
                         on:paste={onPaste}
                         on:contextmenu={handleContextMenu}
                         on:focus={() => (hasFocus = true)}
-                        on:blur={() => (hasFocus = false)}
+                        on:blur={() => {
+                            hasFocus = false
+                            dispatch('blur')
+                        }}
                         on:change={() => dispatch('change')}
                         {disabled}
                         {placeholder}

--- a/packages/shared/components/inputs/NumberInput.svelte
+++ b/packages/shared/components/inputs/NumberInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { TextInput } from 'shared/components'
     import { localize } from '@core/i18n'
+    import { createEventDispatcher } from 'svelte'
 
     export let inputElement: HTMLInputElement = undefined
 
@@ -8,6 +9,8 @@
     export let hasFocus = false
     export let value: string
     export let isInteger: boolean
+
+    const dispatch = createEventDispatcher()
 </script>
 
 <TextInput
@@ -18,6 +21,7 @@
     placeholder={localize('general.amount')}
     float={!isInteger}
     integer={isInteger}
+    on:blur={() => dispatch('blur')}
     {...$$restProps}
 >
     <slot name="right-full-h" slot="right-full-h" />

--- a/packages/shared/components/inputs/RecipientInput.svelte
+++ b/packages/shared/components/inputs/RecipientInput.svelte
@@ -74,6 +74,7 @@
     {disabled}
     options={accountOptions}
     pickerHeight="max-h-48"
+    on:blur={() => validate()?.catch((err) => console.error(err))}
     {...$$restProps}
     let:option
 >

--- a/packages/shared/components/inputs/TextInput.svelte
+++ b/packages/shared/components/inputs/TextInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { createEventDispatcher } from 'svelte'
     import Input from './Input.svelte'
     import { FontWeight, InputType, TextPropTypes, TextType } from 'shared/components'
 
@@ -15,11 +16,23 @@
     export let fontSize = 'sm'
     export let lineHeight = '140'
 
+    const dispatch = createEventDispatcher()
+
     let textProps: TextPropTypes
     $: textProps = { type: textType, fontSize, lineHeight, fontWeight }
 </script>
 
-<Input bind:inputElement bind:value bind:hasFocus bind:error type={inputType} {textProps} {alignment} {...$$restProps}>
+<Input
+    bind:inputElement
+    bind:value
+    bind:hasFocus
+    bind:error
+    type={inputType}
+    {textProps}
+    {alignment}
+    on:blur={() => dispatch('blur')}
+    {...$$restProps}
+>
     <slot name="left" slot="left" />
     <slot name="right" slot="right" />
     <slot name="right-full-h" slot="right-full-h" />


### PR DESCRIPTION
before the input validation on submit.

This PR makes it validate on input blur, I have tried the `on:change` event but after focusing on the input again the error is gone and if the input didn't change it does not trigger validate again.

## Summary

Validate input on blur instead of on submit

![image](https://github.com/iotaledger/firefly/assets/8283616/f21984b3-caa2-4a72-80f1-a4f5477d5309)

## Changelog

```
- Add validation on amount and recipient input
```

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [x] Windows

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
